### PR TITLE
Add tax credit minimum benefit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2021-12-29
+
+### Added
+
+* Minimum tax credit benefit amount.
+
 ## [0.8.0] - 2021-12-27
 
 ### Added

--- a/openfisca_uk/parameters/benefit/tax_credits/min_benefit.yaml
+++ b/openfisca_uk/parameters/benefit/tax_credits/min_benefit.yaml
@@ -5,7 +5,7 @@ metadata:
   label: Tax credits minimum benefit
   name: tax_credits_minimum_benefit
   unit: currency-USD
-  period: week
+  period: year
   reference:
     - name: The Tax Credits (Income Thresholds and Determination of Rates) Regulations 2002
       href: https://www.legislation.gov.uk/uksi/2002/2008/regulation/9

--- a/openfisca_uk/parameters/benefit/tax_credits/min_benefit.yaml
+++ b/openfisca_uk/parameters/benefit/tax_credits/min_benefit.yaml
@@ -1,0 +1,11 @@
+description: Tax credit amount below which tax credits are not paid
+values:
+  2002-08-01: 26
+metadata:
+  label: Tax credits minimum benefit
+  name: tax_credits_minimum_benefit
+  unit: currency-USD
+  period: week
+  reference:
+    name: The Tax Credits (Income Thresholds and Determination of Rates) Regulations 2002
+    href: https://www.legislation.gov.uk/uksi/2002/2008/regulation/9

--- a/openfisca_uk/parameters/benefit/tax_credits/min_benefit.yaml
+++ b/openfisca_uk/parameters/benefit/tax_credits/min_benefit.yaml
@@ -7,5 +7,5 @@ metadata:
   unit: currency-USD
   period: week
   reference:
-    name: The Tax Credits (Income Thresholds and Determination of Rates) Regulations 2002
-    href: https://www.legislation.gov.uk/uksi/2002/2008/regulation/9
+    - name: The Tax Credits (Income Thresholds and Determination of Rates) Regulations 2002
+      href: https://www.legislation.gov.uk/uksi/2002/2008/regulation/9

--- a/openfisca_uk/tests/policy/baseline/finance/benefit/family/tax_credits.yaml
+++ b/openfisca_uk/tests/policy/baseline/finance/benefit/family/tax_credits.yaml
@@ -130,14 +130,14 @@
   period: 2022
   absolute_error_margin: 0
   input:
-    child_tax_credit: 20
-    working_tax_credit: 5.99
+    child_tax_credit_pre_minimum: 20
+    working_tax_credit_pre_minimum: 5.99
   output:
     tax_credits: 0
 - name: Tax credits equal to £26 are paid
   period: 2022
   absolute_error_margin: 0
   input:
-    child_tax_credit: 26
+    child_tax_credit_pre_minimum: 26
   output:
     tax_credits: 26

--- a/openfisca_uk/tests/policy/baseline/finance/benefit/family/tax_credits.yaml
+++ b/openfisca_uk/tests/policy/baseline/finance/benefit/family/tax_credits.yaml
@@ -126,3 +126,18 @@
     weekly_hours: 30
   output:
     WTC_worker_element: 830
+- name: Tax credits under £26.00 are not paid
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    child_tax_credit: 20
+    working_tax_credit: 5.99
+  output:
+    tax_credits: 0
+- name: Tax credits equal to £26 are paid
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    child_tax_credit: 26
+  output:
+    tax_credits: 26

--- a/openfisca_uk/variables/finance/benefit/benefit.py
+++ b/openfisca_uk/variables/finance/benefit/benefit.py
@@ -22,8 +22,7 @@ class family_benefits(Variable):
             "pension_credit",
             "universal_credit",
             "council_tax_benefit",
-            "working_tax_credit",
-            "child_tax_credit",
+            "tax_credits",
         ]
         benefits = add(person.benunit, period, FAMILY_BENEFITS)
         return benefits * person("is_benunit_head", period)
@@ -45,8 +44,7 @@ class family_benefits_reported(Variable):
             "JSA_income",
             "pension_credit",
             "universal_credit",
-            "working_tax_credit",
-            "child_tax_credit",
+            "tax_credits",
         ]
         return add(person, period, [i + "_reported" for i in FAMILY_BENEFITS])
 

--- a/openfisca_uk/variables/finance/benefit/benefit.py
+++ b/openfisca_uk/variables/finance/benefit/benefit.py
@@ -22,7 +22,8 @@ class family_benefits(Variable):
             "pension_credit",
             "universal_credit",
             "council_tax_benefit",
-            "tax_credits",
+            "child_tax_credit",
+            "working_tax_credit",
         ]
         benefits = add(person.benunit, period, FAMILY_BENEFITS)
         return benefits * person("is_benunit_head", period)

--- a/openfisca_uk/variables/finance/benefit/benefit.py
+++ b/openfisca_uk/variables/finance/benefit/benefit.py
@@ -44,7 +44,8 @@ class family_benefits_reported(Variable):
             "JSA_income",
             "pension_credit",
             "universal_credit",
-            "tax_credits",
+            "working_tax_credit",
+            "child_tax_credit",
         ]
         return add(person, period, [i + "_reported" for i in FAMILY_BENEFITS])
 

--- a/openfisca_uk/variables/finance/benefit/family/pension_credit.py
+++ b/openfisca_uk/variables/finance/benefit/family/pension_credit.py
@@ -92,8 +92,7 @@ class guarantee_credit_applicable_income(Variable):
         tax = aggr(benunit, period, ["tax"])
         BENEFIT_COMPONENTS = [
             "child_benefit",
-            "child_tax_credit",
-            "working_tax_credit",
+            "tax_credits",
             "housing_benefit",
         ]
         benefits = add(benunit, period, BENEFIT_COMPONENTS)

--- a/openfisca_uk/variables/finance/benefit/family/pension_credit.py
+++ b/openfisca_uk/variables/finance/benefit/family/pension_credit.py
@@ -136,6 +136,7 @@ class savings_credit_applicable_income(Variable):
         exempted_personal_benefits = aggr(
             benunit, period, EXEMPTED_PERSONAL_BENEFITS
         )
+        # This makes me think we need to push the minimum benefit back to CTC+WTC
         EXEMPTED_FAMILY_BENEFITS = ["working_tax_credit"]
         exempted_family_benefits = add(
             benunit,

--- a/openfisca_uk/variables/finance/benefit/family/pension_credit.py
+++ b/openfisca_uk/variables/finance/benefit/family/pension_credit.py
@@ -136,7 +136,6 @@ class savings_credit_applicable_income(Variable):
         exempted_personal_benefits = aggr(
             benunit, period, EXEMPTED_PERSONAL_BENEFITS
         )
-        # This makes me think we need to push the minimum benefit back to CTC+WTC
         EXEMPTED_FAMILY_BENEFITS = ["working_tax_credit"]
         exempted_family_benefits = add(
             benunit,

--- a/openfisca_uk/variables/finance/benefit/family/pension_credit.py
+++ b/openfisca_uk/variables/finance/benefit/family/pension_credit.py
@@ -92,7 +92,8 @@ class guarantee_credit_applicable_income(Variable):
         tax = aggr(benunit, period, ["tax"])
         BENEFIT_COMPONENTS = [
             "child_benefit",
-            "tax_credits",
+            "child_tax_credit",
+            "working_tax_credit",
             "housing_benefit",
         ]
         benefits = add(benunit, period, BENEFIT_COMPONENTS)

--- a/openfisca_uk/variables/finance/benefit/family/tax_credits.py
+++ b/openfisca_uk/variables/finance/benefit/family/tax_credits.py
@@ -530,4 +530,8 @@ class tax_credits(Variable):
     unit = "currency-GBP"
 
     def formula(person, period, parameters):
-        return add(person, period, ["working_tax_credit", "child_tax_credit"])
+        amount = add(
+            person, period, ["working_tax_credit", "child_tax_credit"]
+        )
+        min_benefit = parameters(period).benefit.tax_credits.min_benefit
+        return where(amount < min_benefit, 0, amount)

--- a/openfisca_uk/variables/finance/benefit/family/tax_credits.py
+++ b/openfisca_uk/variables/finance/benefit/family/tax_credits.py
@@ -488,10 +488,13 @@ class tax_credits_reduction(Variable):
         return overage * means_test.income_reduction_rate
 
 
-class working_tax_credit(Variable):
+class working_tax_credit_pre_minimum(Variable):
     value_type = float
     entity = BenUnit
-    label = u"Working Tax Credit"
+    label = u"Working Tax Credit pre-minimum"
+    documentation = (
+        "Working Tax Credit amount before the minimum tax credit is applied"
+    )
     definition_period = YEAR
     unit = "currency-GBP"
 
@@ -503,10 +506,13 @@ class working_tax_credit(Variable):
         )
 
 
-class child_tax_credit(Variable):
+class child_tax_credit_pre_minimum(Variable):
     value_type = float
     entity = BenUnit
-    label = u"Child Tax Credit"
+    label = u"Child Tax Credit pre-minimum"
+    documentation = (
+        "Child Tax Credit amount before the minimum tax credit is applied"
+    )
     definition_period = YEAR
     unit = "currency-GBP"
 
@@ -531,7 +537,39 @@ class tax_credits(Variable):
 
     def formula(person, period, parameters):
         amount = add(
-            person, period, ["working_tax_credit", "child_tax_credit"]
+            person,
+            period,
+            ["working_tax_credit_pre_minimum", "child_tax_credit_pre_minimum"],
         )
         min_benefit = parameters(period).benefit.tax_credits.min_benefit
         return where(amount < min_benefit, 0, amount)
+
+
+class child_tax_credit(Variable):
+    value_type = float
+    entity = BenUnit
+    label = u"Child Tax Credit"
+    definition_period = YEAR
+    unit = "currency-GBP"
+
+    def formula(benunit, period, parameters):
+        return where(
+            benunit("tax_credits", period) > 0,
+            benunit("child_tax_credit_pre_minimum", period),
+            0,
+        )
+
+
+class working_tax_credit(Variable):
+    value_type = float
+    entity = BenUnit
+    label = u"Working Tax Credit"
+    definition_period = YEAR
+    unit = "currency-GBP"
+
+    def formula(benunit, period, parameters):
+        return where(
+            benunit("tax_credits", period) > 0,
+            benunit("working_tax_credit_pre_minimum", period),
+            0,
+        )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK",
-    version="0.9.1",
+    version="0.9.0",
     author="PolicyEngine",
     author_email="nikhil@policyengine.org",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK",
-    version="0.8.0",
+    version="0.9.0",
     author="PolicyEngine",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
* Tax and benefit system evolution.
* Impacted periods: all.
* Impacted areas: `tax_credits`
* Details:
  - Sets a minimum tax credit benefit of 26

- - - -

These changes:

- Add a new feature (`benefit.tax_credits.min_benefit` parameter)
- Fix or improve an already existing calculation (`tax_credits`)

Question: Should this also affect the CTC and WTC variables? This would require adding another layer of intermediate variables.