### PR TITLE
Improve dataset interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - 2022-01-16
+
+### Added
+
+* When datasets are not available, a prompt is displayed to download them or use synthetic data.
+* CLI interface trigger changed from `openfisca-uk-setup` to `openfisca-uk` and default years updated.
+
 ## [0.10.4] - 2022-01-14
 
-###
+### Changed
 
 * OpenFisca-UK-Data version increased to 0.7.0.
 

--- a/README.md
+++ b/README.md
@@ -20,16 +20,9 @@ The model supports multiple different input datasets provided by the user, one o
 
 ## Fast setup instructions
 
-1. `pip install git+https://github.com/PSLmodels/openfisca-uk`
+1. Run `pip install openfisca-uk`
 
-For microdata instructions, follow (from [openfisca-uk-data](https://github.com/nikhilwoodruff/openfisca-uk-data)):
-2. Download the [synthetic FRS file](https://github.com/nikhilwoodruff/openfisca-uk-data/releases/download/synth-frs/synth_frs_2018.h5)
-3. Run `openfisca-uk-data synth_frs save synth_frs_2018`
-
-Or with the actual microdata:
-2. Have the `8633~~~.zip` file ready
-3. Run `openfisca-uk-data raw_frs generate 2018 8633~~~.zip`
-4. Run `openfisca-uk-data frs generate 2018`
+2. Run `openfisca-uk` and go through the prompt to setup microdata.
 
 ## Contact
 

--- a/openfisca_uk/initial_setup.py
+++ b/openfisca_uk/initial_setup.py
@@ -55,7 +55,7 @@ def main():
             if 2019 not in FRSEnhanced.years:
                 print("Couldn't find the enhanced 2019 dataset, downloading.")
                 FRSEnhanced.download(2019)
-            set_default(SynthFRS)
+            set_default(FRSEnhanced)
         elif setup_mode == CUSTOM:
             dataset_question = inquirer.List(
                 "default_dataset",

--- a/openfisca_uk/tools/simulation.py
+++ b/openfisca_uk/tools/simulation.py
@@ -44,7 +44,7 @@ class Microsimulation(GeneralMicrosimulation):
         else:
             dataset = dataset
         if year is None:
-            year = self.default_year or max(self.dataset.years)
+            year = self.default_year or max(dataset.years)
         else:
             year = year
 

--- a/openfisca_uk/tools/simulation.py
+++ b/openfisca_uk/tools/simulation.py
@@ -1,3 +1,4 @@
+import logging
 from openfisca_uk import CountryTaxBenefitSystem
 from openfisca_uk.entities import entities
 import numpy as np
@@ -5,8 +6,10 @@ import warnings
 from openfisca_uk.entities import *
 import numpy as np
 import warnings
+from openfisca_uk.initial_setup import set_default
 from openfisca_uk.tools.parameters import backdate_parameters
-from openfisca_uk_data import DATASETS
+from openfisca_tools import ReformType
+from openfisca_uk_data import DATASETS, SynthFRS
 from openfisca_tools.microsimulation import (
     Microsimulation as GeneralMicrosimulation,
 )
@@ -32,6 +35,37 @@ class Microsimulation(GeneralMicrosimulation):
     entities = entities
     default_dataset = DEFAULT_DATASET
     post_reform = backdate_parameters()
+
+    def __init__(
+        self, reform: ReformType = (), dataset: type = None, year: int = None
+    ):
+        if dataset is None:
+            dataset = self.default_dataset
+        else:
+            dataset = dataset
+        if year is None:
+            year = self.default_year or max(self.dataset.years)
+        else:
+            year = year
+
+        # Check if dataset is available
+
+        if year not in dataset.years:
+            download = input(
+                f"\nYear {year} not available in dataset {dataset.name}: \n\t* Download the dataset [y]\n\t* Use the synthetic FRS (and set default) [n]\n\nChoice: "
+            )
+            if download == "y":
+                dataset.download(year)
+            else:
+                set_default(SynthFRS)
+                dataset = SynthFRS
+                if year not in dataset.years:
+                    logging.info(
+                        f"Year {year} synthetic FRS not stored, downloading..."
+                    )
+                    dataset.download(year)
+
+        super().__init__(reform=reform, dataset=dataset, year=year)
 
 
 class IndividualSim(GeneralIndividualSim):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "pytest>=5.4.3",
         "OpenFisca-Core>=35.4.1",
         "microdf_python>=0.3.0",
-        "OpenFisca-UK-Data>=0.7.0",
+        "OpenFisca-UK-Data>=0.7.1",
         "OpenFisca-Tools>=0.1.7,<0.2.0",
         "tqdm>=4.59.0",
         "plotly>=4.14.3",
@@ -49,9 +49,7 @@ setup(
         ]
     },
     entry_points={
-        "console_scripts": [
-            "openfisca-uk-setup=openfisca_uk.initial_setup:main"
-        ],
+        "console_scripts": ["openfisca-uk=openfisca_uk.initial_setup:main"],
     },
     packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK",
-    version="0.10.4",
+    version="0.10.5",
     author="PolicyEngine",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
This PR aims to make handling datasets much easier:

* The default dataset is the enhanced FRS, but when Microsimulation is instantiated, it'll run a prompt if datasets fail to load.
* Run `openfisca-uk` to generate a prompt - if you do this after install, dataset configuration should be complete.