### PR TITLE
Remove enhanced FRS hard-coded requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.9] - 2022-01-22
+
+### Fixed
+
+* Baseline HBAI-excluded income variable now uses the Synthetic FRS when the enhanced FRS is not available.
+
 ## [0.10.8] - 2022-01-18
 
 ### Added

--- a/openfisca_uk/variables/income/poverty.py
+++ b/openfisca_uk/variables/income/poverty.py
@@ -1,6 +1,4 @@
-from openfisca_uk_data.datasets.frs.frs_enhanced.frs_enhanced import (
-    FRSEnhanced,
-)
+from openfisca_uk_data.datasets import FRSEnhanced, SynthFRS
 from openfisca_uk.model_api import *
 
 
@@ -18,8 +16,9 @@ class baseline_hbai_excluded_income(Variable):
             from openfisca_uk import Microsimulation
 
             # Simulate baseline policy
+            dataset = FRSEnhanced if 2019 in FRSEnhanced.years else SynthFRS
             result = Microsimulation(
-                dataset=FRSEnhanced, year=2019
+                dataset=dataset, year=2019
             ).simulation.calculate("hbai_excluded_income", period)
             # Check that the dataset/year combination is valid
             # (i.e. that the arrays are the same size)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK",
-    version="0.10.8",
+    version="0.10.9",
     author="PolicyEngine",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
### Fixed

* Baseline HBAI-excluded income variable now uses the Synthetic FRS when the enhanced FRS is not available.

Should enable @tolaouk 's local debugging with the synthetic FRS.