### PR TITLE
Generate takeup-informing variables before calibration, not after

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -447,3 +447,7 @@
     changed:
     - Reorganize documentation and variables.
   date: 2022-05-21 16:01:32
+- bump: patch
+  changes:
+    fixed:
+    - Baseline variables are now generated before calibration (fixes a bug causing overestimation of benefit caseloads).

--- a/docs/summary/VARIABLE_STATS.md
+++ b/docs/summary/VARIABLE_STATS.md
@@ -7,10 +7,10 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Type: float
   - Entity: household
   - Description: In original FRS
-  - Mean: 0.9
+  - Mean: 0.8
   - Median: 1.0
-  - Stddev: 0.5
-  - Non-zero count: 25,262,401.67829895
+  - Stddev: 0.4000000059604645
+  - Non-zero count: 24,763,509.927612305
 
 
 - spi_imputed:
@@ -20,7 +20,7 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.1
   - Median: 0.0
   - Stddev: 0.4000000059604645
-  - Non-zero count: 2,196,798.202069193
+  - Non-zero count: 4,707,626.401316881
 
 
 - uc_migrated:
@@ -29,45 +29,65 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: UC migrated
   - Mean: 0.1
   - Median: 0.0
-  - Stddev: 0.5
-  - Non-zero count: 2,117,363.9047864974
+  - Stddev: 0.4000000059604645
+  - Non-zero count: 4,369,705.177594423
+
+
+- benefits:
+  - Type: float
+  - Entity: person
+  - Description: Total benefits
+  - Mean: 3,722.3
+  - Median: 0.0
+  - Stddev: 5,598.7001953125
+  - Non-zero count: 27,928,694.315009356
 
 
 - baseline_expected_lbtt:
   - Type: float
-  - Entity: household
-  - Description: LBTT (expected, baseline)
-  - Mean: 0.0
+  - Entity: person
+  - Description: Difference between reported and simulated benefits for this person
+  - Mean: 633.8
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 3,198.10009765625
+  - Non-zero count: 15,073,205.77068615
 
 
 - change_in_expected_lbtt:
   - Type: float
-  - Entity: household
-  - Description: Change in LBTT (expected)
-  - Mean: 50.3
+  - Entity: benunit
+  - Description: Value of premiums for disability and carer status
+  - Mean: 416.1
   - Median: 0.0
-  - Stddev: 573.0999755859375
-  - Non-zero count: 1,254,949.1195148826
+  - Stddev: 1,560.5
+  - Non-zero count: 3,591,886.4767143726
 
 
 - expected_lbtt:
   - Type: float
-  - Entity: household
-  - Description: Land and Buildings Transaction Tax (expected)
-  - Mean: 50.3
+  - Entity: person
+  - Description: Total simulated
+  - Mean: 3,088.6
   - Median: 0.0
-  - Stddev: 573.0999755859375
-  - Non-zero count: 1,254,949.1195148826
+  - Stddev: 5,121.7001953125
+  - Non-zero count: 24,275,120.584332943
 
 
 - land_and_buildings_transaction_tax:
   - Type: float
-  - Entity: household
-  - Description: Land and Buildings Transaction Tax
-  - Mean: 1,147.0
+  - Entity: benunit
+  - Description: Average weekly hours worked by adults in the benefit unit
+  - Mean: 29.8
+  - Median: 30.0
+  - Stddev: 31.399999618530273
+  - Non-zero count: 22,349,250.81072688
+
+
+- claims_all_entitled_benefits:
+  - Type: bool
+  - Entity: benunit
+  - Description: Claims all eligible benefits
+  - Mean: 0.0
   - Median: 0.0
   - Stddev: 13,059.599609375
   - Non-zero count: 1,254,949.1195148826
@@ -80,73 +100,133 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.1
   - Median: 0.0
   - Stddev: 0.3
-  - Non-zero count: 2,575,192.036562979
+  - Non-zero count: 4,598,995.6716918945
 
 
 - lbtt_on_non_residential_property_rent:
   - Type: float
-  - Entity: household
-  - Description: LBTT on non-residential property
-  - Mean: 0.0
+  - Entity: person
+  - Description: Total simulated family benefits for this person
+  - Mean: 1,391.1
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 3,181.10009765625
+  - Non-zero count: 15,007,955.020757437
 
 
 - lbtt_on_non_residential_property_transactions:
   - Type: float
-  - Entity: household
-  - Description: LBTT on non-residential property transactions
-  - Mean: 221.2
+  - Entity: person
+  - Description: Total reported family benefits for this person
+  - Mean: 1,036.1
   - Median: 0.0
-  - Stddev: 3,784.5
-  - Non-zero count: 548,731.394356072
+  - Stddev: 2,889.199951171875
+  - Non-zero count: 11,745,870.193576813
 
 
 - lbtt_on_rent:
   - Type: float
   - Entity: household
-  - Description: LBTT on property rental
-  - Mean: 0.0
+  - Description: Benefits
+  - Mean: 7,990.6
+  - Median: 6,931.8
+  - Stddev: 8,531.5
+  - Non-zero count: 22,427,803.405115128
+
+
+- is_QYP:
+  - Type: bool
+  - Entity: person
+  - Description: Whether this person is a qualifying young person for benefits purposes
+  - Mean: 0.1
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.4
+  - Non-zero count: 9,140,602.697384596
+
+
+- is_child_or_QYP:
+  - Type: bool
+  - Entity: person
+  - Description: Whether this person is a child or qualifying young person for most benefits
+  - Mean: 0.2
+  - Median: 0.0
+  - Stddev: 0.4
+  - Non-zero count: 12,633,341.866535902
+
+
+- is_couple:
+  - Type: bool
+  - Entity: benunit
+  - Description: Whether this benefit unit contains a joint couple claimant for benefits
+  - Mean: 0.5
+  - Median: 0.0
+  - Stddev: 0.5
+  - Non-zero count: 17,212,563.572172165
+
+
+- is_lone_parent:
+  - Type: bool
+  - Entity: benunit
+  - Description: Whether the family is a lone parent family
+  - Mean: 0.1
+  - Median: 0.0
+  - Stddev: 0.3
+  - Non-zero count: 2,537,684.0024318695
+
+
+- is_single:
+  - Type: bool
+  - Entity: benunit
+  - Description: Whether this benefit unit contains a single claimant for benefits
+  - Mean: 0.5
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 19,743,249.29787445
+
+
+- is_single_person:
+  - Type: bool
+  - Entity: benunit
+  - Description: Whether the family is a single person
+  - Mean: 0.5
+  - Median: 0.0
+  - Stddev: 0.5
+  - Non-zero count: 18,138,695.755357742
 
 
 - lbtt_on_residential_property_rent:
   - Type: float
-  - Entity: household
-  - Description: LBTT on residential property rent
-  - Mean: 0.0
+  - Entity: person
+  - Description: Income from benefits not modelled or detailed in the model
+  - Mean: -633.8
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 3,198.10009765625
+  - Non-zero count: 6,451,417.397338867
 
 
 - lbtt_on_residential_property_transactions:
   - Type: float
-  - Entity: household
-  - Description: LBTT on residential property
-  - Mean: 12,245.0
-  - Median: 300.0
-  - Stddev: 33,344.30078125
-  - Non-zero count: 14,862,568.132002562
+  - Entity: person
+  - Description: Value of personal, non-means-tested benefits
+  - Mean: 2,331.2
+  - Median: 0.0
+  - Stddev: 4,415.5
+  - Non-zero count: 18,512,171.783225536
 
 
 - lbtt_on_transactions:
   - Type: float
-  - Entity: household
-  - Description: LBTT on property transactions
-  - Mean: 12,466.2
-  - Median: 300.0
-  - Stddev: 34,147.8984375
-  - Non-zero count: 14,906,155.090069443
+  - Entity: person
+  - Description: Value of personal, non-means-tested benefits
+  - Mean: 2,052.5
+  - Median: 0.0
+  - Stddev: 4,162.10009765625
+  - Non-zero count: 16,701,723.912513256
 
 
 - baseline_expected_ltt:
   - Type: float
   - Entity: household
-  - Description: Land Transaction Tax (baseline, expected)
+  - Description: HBAI-excluded income (baseline)
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
@@ -156,11 +236,11 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - change_in_expected_ltt:
   - Type: float
   - Entity: household
-  - Description: Change in LTT (expected)
-  - Mean: 19.2
+  - Description: HBAI-excluded income
+  - Mean: 0.0
   - Median: 0.0
-  - Stddev: 264.3999938964844
-  - Non-zero count: 655,934.5569355488
+  - Stddev: 0.0
+  - Non-zero count: 0.0
 
 
 - expected_ltt:
@@ -179,8 +259,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Land Transaction Tax
   - Mean: 436.4
   - Median: 0.0
-  - Stddev: 6,024.10009765625
-  - Non-zero count: 655,934.5569355488
+  - Stddev: 0.2
+  - Non-zero count: 2,370,322.9178142548
 
 
 - ltt_liable:
@@ -189,8 +269,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Liable for Land Transaction Tax
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 1,388,364.2175705433
+  - Stddev: 0.1
+  - Non-zero count: 961,128.8059749603
 
 
 - ltt_on_non_residential_property_rent:
@@ -199,8 +279,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: LTT on non-residential property rent
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.4
+  - Non-zero count: 6,044,786.577191353
 
 
 - ltt_on_non_residential_property_transactions:
@@ -209,48 +289,48 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: LTT on non-residential property transactions
   - Mean: 22.2
   - Median: 0.0
-  - Stddev: 1,357.9000244140625
-  - Non-zero count: 29,033.703684806824
+  - Stddev: 0.3
+  - Non-zero count: 5,338,018.083772659
 
 
 - ltt_on_rent:
   - Type: float
   - Entity: household
-  - Description: LTT on property rental
-  - Mean: 0.0
+  - Description: Positive financial gap between net household income and the poverty line, after housing costs
+  - Mean: 1,154.6
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 2,839.800048828125
+  - Non-zero count: 6,044,786.577191353
 
 
 - ltt_on_residential_property_rent:
   - Type: float
   - Entity: household
-  - Description: LTT on residential property rent
-  - Mean: 0.0
+  - Description: Positive financial gap between net household income and the poverty line
+  - Mean: 790.9
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 2,224.60009765625
+  - Non-zero count: 5,338,018.083772659
 
 
 - ltt_on_residential_property_transactions:
   - Type: float
   - Entity: household
-  - Description: LTT on residential property
-  - Mean: 10,032.4
-  - Median: 0.0
-  - Stddev: 27,757.80078125
-  - Non-zero count: 13,490,246.9395096
+  - Description: The poverty line for the household, after housing costs
+  - Mean: 14,166.3
+  - Median: 14,455.1
+  - Stddev: 5,899.2998046875
+  - Non-zero count: 31,566,821.236507416
 
 
 - ltt_on_transactions:
   - Type: float
   - Entity: household
-  - Description: LTT on property transactions
-  - Mean: 10,054.5
-  - Median: 0.0
-  - Stddev: 27,859.599609375
-  - Non-zero count: 13,491,020.421443194
+  - Description: The poverty line for the household, before housing costs
+  - Mean: 16,848.8
+  - Median: 16,871.0
+  - Stddev: 5,728.7001953125
+  - Non-zero count: 31,566,821.236507416
 
 
 - baseline_has_income_support:
@@ -260,7 +340,7 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Non-zero count: 31,566,821.236507416
 
 
 - baseline_income_support:
@@ -275,128 +355,138 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - income_support:
   - Type: float
-  - Entity: benunit
-  - Description: Income Support
-  - Mean: 22.2
+  - Entity: person
+  - Description: Income from savings or dividends
+  - Mean: 1,060.5
   - Median: 0.0
-  - Stddev: 379.79998779296875
-  - Non-zero count: 154,730.59803771973
+  - Stddev: 53,843.0
+  - Non-zero count: 17,058,491.03086996
 
 
 - income_support_applicable_amount:
   - Type: float
-  - Entity: benunit
-  - Description: Applicable amount of Income Support
-  - Mean: 33.1
-  - Median: 0.0
-  - Stddev: 520.0999755859375
-  - Non-zero count: 163,938.0549545288
+  - Entity: person
+  - Description: Total earned income
+  - Mean: 16,026.0
+  - Median: 6,798.0
+  - Stddev: 26,003.400390625
+  - Non-zero count: 42,255,209.07241821
+
+
+- employment_status:
+  - Type: Categorical
+  - Entity: person
+  - Description: Employment status of the person
 
 
 - income_support_applicable_income:
   - Type: float
-  - Entity: benunit
-  - Description: Relevant income for Income Support means test
-  - Mean: 25,555.2
-  - Median: 19,126.1
-  - Stddev: 31,634.5
-  - Non-zero count: 31,762,710.055456758
+  - Entity: household
+  - Description: Equivalised household net income (HBAI)
+  - Mean: 34,543.2
+  - Median: 28,168.8
+  - Stddev: 46,856.80078125
+  - Non-zero count: 31,431,782.814266205
 
 
-- income_support_eligible:
-  - Type: bool
-  - Entity: benunit
-  - Description: Whether eligible for Income Support
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 163,938.0549545288
+- equiv_hbai_household_net_income_ahc:
+  - Type: float
+  - Entity: household
+  - Description: Equivalised household net income, after housing costs (HBAI)
+  - Mean: 31,210.0
+  - Median: 25,414.1
+  - Stddev: 48,111.30078125
+  - Non-zero count: 30,892,455.721431732
 
 
 - income_support_reported:
   - Type: float
+  - Entity: household
+  - Description: Equivalised household net income
+  - Mean: 34,543.2
+  - Median: 28,168.8
+  - Stddev: 46,856.80078125
+  - Non-zero count: 31,431,782.814266205
+
+
+- gross_income:
+  - Type: float
   - Entity: person
-  - Description: Income Support (reported amount)
-  - Mean: 18.8
-  - Median: 0.0
-  - Stddev: 278.5
-  - Non-zero count: 304,441.181892395
-
-
-- would_claim_IS:
-  - Type: bool
-  - Entity: benunit
-  - Description: Would claim Income Support
-  - Mean: 1.0
-  - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 36,144,140.87005857
+  - Description: Gross income, including benefits
+  - Mean: 21,333.2
+  - Median: 15,000.3
+  - Stddev: 60,365.1015625
+  - Non-zero count: 51,967,386.42338061
 
 
 - AA_reported:
   - Type: float
-  - Entity: person
-  - Description: Attendance Allowance (reported)
-  - Mean: 50.9
-  - Median: 0.0
-  - Stddev: 497.29998779296875
-  - Non-zero count: 868,770.7076538801
+  - Entity: household
+  - Description: Household net income (HBAI definition)
+  - Mean: 35,701.0
+  - Median: 26,899.6
+  - Stddev: 60,690.5
+  - Non-zero count: 31,431,782.814266205
 
 
-- aa_category:
-  - Type: Categorical
-  - Entity: person
-  - Description: Attendance Allowance category
+- hbai_household_net_income_ahc:
+  - Type: float
+  - Entity: household
+  - Description: Household net income, after housing costs
+  - Mean: 31,472.8
+  - Median: 23,025.1
+  - Stddev: 60,308.19921875
+  - Non-zero count: 30,892,455.721431732
 
 
 - attendance_allowance:
   - Type: float
   - Entity: person
-  - Description: Attendance Allowance
-  - Mean: 52.0
+  - Description: Total amount of hours worked by this person
+  - Mean: 852.9
   - Median: 0.0
-  - Stddev: 508.29998779296875
-  - Non-zero count: 868,770.7076538801
+  - Stddev: 1,033.9000244140625
+  - Non-zero count: 31,491,391.659608364
 
 
 - ESA_income:
   - Type: float
-  - Entity: benunit
-  - Description: ESA (income-based)
-  - Mean: 79.2
-  - Median: 0.0
-  - Stddev: 650.0999755859375
-  - Non-zero count: 402,875.4299545288
+  - Entity: household
+  - Description: Household gross income
+  - Mean: 45,428.8
+  - Median: 30,999.8
+  - Stddev: 95,009.8984375
+  - Non-zero count: 31,504,974.957393646
 
 
-- ESA_income_eligible:
-  - Type: bool
-  - Entity: benunit
-  - Description: ESA (income) eligible
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 402,875.4299545288
+- household_market_income:
+  - Type: float
+  - Entity: household
+  - Description: Household market income
+  - Mean: 37,438.3
+  - Median: 21,553.2
+  - Stddev: 96,179.3984375
+  - Non-zero count: 27,594,714.97113228
 
 
 - ESA_income_reported:
   - Type: float
-  - Entity: person
-  - Description: ESA (income-based) (reported amount)
-  - Mean: 42.6
-  - Median: 0.0
-  - Stddev: 482.79998779296875
-  - Non-zero count: 411,770.25453948975
+  - Entity: household
+  - Description: Household net income
+  - Mean: 35,701.0
+  - Median: 26,899.6
+  - Stddev: 60,690.5
+  - Non-zero count: 31,431,782.814266205
 
 
 - claims_ESA_income:
   - Type: bool
-  - Entity: benunit
-  - Description: Claims ESA (income)
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 402,875.4299545288
+  - Entity: person
+  - Description: Worked some hours
+  - Mean: 0.5
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 36,800,484.87847948
 
 
 - would_claim_ESA_income:
@@ -412,41 +502,41 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - IIDB:
   - Type: float
   - Entity: person
-  - Description: Industrial Injuries Disablement Benefit
-  - Mean: 7.2
-  - Median: 0.0
-  - Stddev: 197.5
-  - Non-zero count: 148,610.40618515015
+  - Description: Lump sum income
+  - Mean: 58.3
+  - Median: -1.0
+  - Stddev: 1,882.5
+  - Non-zero count: 191,086.9439239502
 
 
 - IIDB_reported:
   - Type: float
   - Entity: person
-  - Description: Industrial Injuries Disablement Benefit (reported)
-  - Mean: 7.2
+  - Description: Maintenance payments
+  - Mean: 33.8
   - Median: 0.0
-  - Stddev: 197.5
-  - Non-zero count: 148,610.40618515015
+  - Stddev: 493.3999938964844
+  - Non-zero count: 722,952.5704650879
 
 
 - JSA_contrib:
   - Type: float
   - Entity: person
-  - Description: JSA (contribution-based)
-  - Mean: 1.9
-  - Median: 0.0
-  - Stddev: 84.4000015258789
-  - Non-zero count: 34,267.92400932312
+  - Description: Market income
+  - Mean: 17,610.8
+  - Median: 7,540.0
+  - Stddev: 60,605.19921875
+  - Non-zero count: 45,137,423.94413638
 
 
 - JSA_contrib_reported:
   - Type: float
   - Entity: person
-  - Description: Job Seeker's Allowance (contribution-based) (reported)
-  - Mean: 1.9
-  - Median: 0.0
-  - Stddev: 84.4000015258789
-  - Non-zero count: 34,267.92400932312
+  - Description: Minimum wage
+  - Mean: 7.9
+  - Median: 8.9
+  - Stddev: 1.7999999523162842
+  - Non-zero count: 67,106,864.33584666
 
 
 - maternity_allowance:
@@ -462,41 +552,41 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - maternity_allowance_reported:
   - Type: float
   - Entity: person
-  - Description: Maternity allowance
-  - Mean: 1.3
+  - Description: Income from other sources
+  - Mean: 42.8
   - Median: 0.0
-  - Stddev: 87.80000305175781
-  - Non-zero count: 12,630.140808105469
+  - Stddev: 824.0
+  - Non-zero count: 815,056.0373458862
 
 
 - ssmg:
   - Type: float
   - Entity: person
-  - Description: Sure Start Maternity Grant
-  - Mean: 10.4
-  - Median: 0.0
-  - Stddev: 485.5
-  - Non-zero count: 27,311.686332702637
+  - Description: Net income
+  - Mean: 17,413.8
+  - Median: 14,495.2
+  - Stddev: 38,382.69921875
+  - Non-zero count: 51,967,386.42338061
 
 
 - ssmg_reported:
   - Type: float
   - Entity: person
-  - Description: Sure Start Maternity Grant (reported)
-  - Mean: 10.4
+  - Description: Private transfers
+  - Mean: 128.3
   - Median: 0.0
-  - Stddev: 485.5
-  - Non-zero count: 27,311.686332702637
+  - Stddev: 1,324.4000244140625
+  - Non-zero count: 1,040,762.6389875412
 
 
 - council_tax_benefit:
   - Type: float
-  - Entity: benunit
-  - Description: Council Tax Benefit
-  - Mean: 98.9
-  - Median: 0.0
-  - Stddev: 285.0
-  - Non-zero count: 4,328,427.430448413
+  - Entity: household
+  - Description: Real household net income
+  - Mean: 30,903.5
+  - Median: 23,284.8
+  - Stddev: 52,534.8984375
+  - Non-zero count: 31,431,782.814266205
 
 
 - council_tax_benefit_reported:
@@ -511,12 +601,12 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - CTC_child_element:
   - Type: float
-  - Entity: benunit
-  - Description: Child Tax Credit child element
-  - Mean: 1,142.2
+  - Entity: person
+  - Description: Weekly hours
+  - Mean: 16.4
   - Median: 0.0
-  - Stddev: 2,221.800048828125
-  - Non-zero count: 7,604,576.012337238
+  - Stddev: 19.899999618530273
+  - Non-zero count: 31,491,391.659608364
 
 
 - CTC_disabled_child_element:
@@ -525,18 +615,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: CTC entitlement from disabled child elements
   - Mean: 0.5
   - Median: 0.0
-  - Stddev: 48.29999923706055
-  - Non-zero count: 5,611.2418212890625
+  - Stddev: 0.0
+  - Non-zero count: 0.0
 
 
 - CTC_family_element:
   - Type: float
-  - Entity: benunit
-  - Description: CTC entitlement in the Family Element
-  - Mean: 22.6
-  - Median: 0.0
-  - Stddev: 93.30000305175781
-  - Non-zero count: 1,497,773.115433097
+  - Entity: household
+  - Description: Corporate wealth
+  - Mean: 160,369.3
+  - Median: 2,381.2
+  - Stddev: 809,632.3125
+  - Non-zero count: 17,346,084.671941757
 
 
 - CTC_maximum_rate:
@@ -545,98 +635,148 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Maximum Child Tax Credit
   - Mean: 1,165.4
   - Median: 0.0
-  - Stddev: 2,263.199951171875
-  - Non-zero count: 7,604,576.012337238
+  - Stddev: 0.0
+  - Non-zero count: 17,346,084.671941757
 
 
 - CTC_severely_disabled_child_element:
   - Type: float
-  - Entity: benunit
-  - Description: CTC entitlement from severely disabled child elements
-  - Mean: 0.1
-  - Median: 0.0
-  - Stddev: 12.0
-  - Non-zero count: 3,192.1424560546875
+  - Entity: household
+  - Description: Total wealth
+  - Mean: 364,792.2
+  - Median: 176,975.6
+  - Stddev: 933,010.875
+  - Non-zero count: 23,406,714.61865902
 
 
 - WTC_basic_element:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit basic element
-  - Mean: 58.9
-  - Median: 0.0
-  - Stddev: 260.20001220703125
-  - Non-zero count: 1,062,242.0773214102
+  - Entity: household
+  - Description: Gross financial wealth
+  - Mean: 70,567.6
+  - Median: 4,354.1
+  - Stddev: 506,343.1875
+  - Non-zero count: 27,674,050.111123085
 
 
 - WTC_childcare_element:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit childcare element
-  - Mean: 12.8
-  - Median: 0.0
-  - Stddev: 221.10000610351562
-  - Non-zero count: 193,223.30617177486
+  - Entity: household
+  - Description: Net financial wealth
+  - Mean: 61,692.9
+  - Median: 740.0
+  - Stddev: 487,785.8125
+  - Non-zero count: 18,213,997.835633993
 
 
 - WTC_couple_element:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit couple element
-  - Mean: 26.1
-  - Median: 0.0
-  - Stddev: 173.10000610351562
-  - Non-zero count: 457,341.3122638464
+  - Entity: household
+  - Description: Main residence value
+  - Mean: 179,842.4
+  - Median: 80,000.0
+  - Stddev: 293,477.5
+  - Non-zero count: 17,085,569.23855877
 
 
 - WTC_disabled_element:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit disabled element
-  - Mean: 6.7
+  - Entity: household
+  - Description: Non-residential property value
+  - Mean: 2,473.1
   - Median: 0.0
-  - Stddev: 113.9000015258789
-  - Non-zero count: 74,863.90287780762
+  - Stddev: 41,620.1015625
+  - Non-zero count: 371,197.28702545166
 
 
 - WTC_lone_parent_element:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit lone parent element
-  - Mean: 29.0
+  - Entity: household
+  - Description: Other residence value
+  - Mean: 9,048.0
   - Median: 0.0
-  - Stddev: 189.60000610351562
-  - Non-zero count: 509,276.93778800964
+  - Stddev: 82,011.203125
+  - Non-zero count: 1,178,612.8300800323
 
 
 - WTC_maximum_rate:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit maximum rate
-  - Mean: 149.2
-  - Median: 0.0
-  - Stddev: 715.4000244140625
-  - Non-zero count: 1,062,242.0773214102
+  - Entity: household
+  - Description: Property wealth
+  - Mean: 204,422.9
+  - Median: 90,000.0
+  - Stddev: 353,378.5
+  - Non-zero count: 17,894,663.603240013
 
 
 - WTC_severely_disabled_element:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit severely disabled element
-  - Mean: 1.8
+  - Entity: household
+  - Description: Residential property value
+  - Mean: 188,890.5
+  - Median: 86,000.0
+  - Stddev: 321,287.40625
+  - Non-zero count: 17,308,841.745516777
+
+
+- corporate_land_value:
+  - Type: float
+  - Entity: household
+  - Description: Land value
+  - Mean: 51,528.8
+  - Median: 765.1
+  - Stddev: 260,145.703125
+  - Non-zero count: 17,346,084.671941757
+
+
+- household_land_value:
+  - Type: float
+  - Entity: household
+  - Description: Land value
+  - Mean: 137,896.4
+  - Median: 62,748.2
+  - Stddev: 256,960.703125
+  - Non-zero count: 17,992,656.427214622
+
+
+- land_value:
+  - Type: float
+  - Entity: household
+  - Description: Land value
+  - Mean: 189,425.3
+  - Median: 99,117.1
+  - Stddev: 391,255.90625
+  - Non-zero count: 23,450,655.364691734
+
+
+- owned_land:
+  - Type: float
+  - Entity: household
+  - Description: Owned land
+  - Mean: 2,306.8
   - Median: 0.0
-  - Stddev: 42.400001525878906
-  - Non-zero count: 45,215.787006378174
+  - Stddev: 80,017.3984375
+  - Non-zero count: 369,696.04431915283
+
+
+- carbon_consumption:
+  - Type: float
+  - Entity: household
+  - Description: Carbon consumption
+  - Mean: 17.0
+  - Median: 12.4
+  - Stddev: 16.399999618530273
+  - Non-zero count: 31,566,821.236507416
 
 
 - WTC_worker_element:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit worker element
-  - Mean: 13.9
+  - Entity: household
+  - Description: Diesel volume
+  - Mean: 370.1
   - Median: 0.0
-  - Stddev: 81.5
-  - Non-zero count: 603,643.1160196066
+  - Stddev: 786.4000244140625
+  - Non-zero count: 9,366,372.24467969
 
 
 - baseline_child_tax_credit:
@@ -646,17 +786,17 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Non-zero count: 31,566,821.236507416
 
 
-- baseline_has_child_tax_credit:
-  - Type: bool
-  - Entity: benunit
-  - Description: Receives Child Tax Credit (baseline)
-  - Mean: 1.0
-  - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 36,144,140.87005857
+- petrol_litres:
+  - Type: float
+  - Entity: household
+  - Description: Petrol volume
+  - Mean: 557.7
+  - Median: 2.6
+  - Stddev: 802.2999877929688
+  - Non-zero count: 15,787,098.954917908
 
 
 - baseline_has_working_tax_credit:
@@ -666,17 +806,17 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 1.0
   - Median: 1.0
   - Stddev: 0.0
-  - Non-zero count: 36,144,140.87005857
+  - Non-zero count: 31,566,821.236507416
 
 
 - baseline_working_tax_credit:
   - Type: float
-  - Entity: benunit
-  - Description: Baseline Working Tax Credit
-  - Mean: 0.0
+  - Entity: household
+  - Description: Residential property bought (additional)
+  - Mean: 9,048.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 82,011.203125
+  - Non-zero count: 1,178,612.8300800323
 
 
 - child_tax_credit:
@@ -701,32 +841,32 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - child_tax_credit_reported:
   - Type: float
-  - Entity: person
-  - Description: Working Tax Credit
-  - Mean: 128.8
-  - Median: 0.0
-  - Stddev: 843.5
-  - Non-zero count: 1,627,944.0341590643
+  - Entity: household
+  - Description: Residential property bought (main)
+  - Mean: 179,842.4
+  - Median: 80,000.0
+  - Stddev: 293,477.5
+  - Non-zero count: 17,085,569.23855877
 
 
 - is_CTC_child_limit_exempt:
   - Type: bool
-  - Entity: person
-  - Description: Exemption from Child Tax Credit child limit
-  - Mean: 0.9
-  - Median: 1.0
-  - Stddev: 0.2
-  - Non-zero count: 62,266,757.37181795
-
-
-- is_CTC_eligible:
-  - Type: bool
-  - Entity: benunit
-  - Description: Child Tax Credit eligibility
-  - Mean: 0.0
+  - Entity: household
+  - Description: Residential property bought is first home
+  - Mean: 0.2
   - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 1,497,773.115433097
+  - Stddev: 0.4
+  - Non-zero count: 6,086,766.453796387
+
+
+- non_residential_property_purchased:
+  - Type: float
+  - Entity: household
+  - Description: Non-residential property bought
+  - Mean: 2,473.1
+  - Median: 0.0
+  - Stddev: 41,620.1015625
+  - Non-zero count: 371,197.28702545166
 
 
 - is_WTC_eligible:
@@ -741,12 +881,12 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - is_child_for_CTC:
   - Type: bool
-  - Entity: person
-  - Description: Child eligible for Child Tax Credit
-  - Mean: 0.2
-  - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 13,587,051.760222733
+  - Entity: household
+  - Description: All property bought this year
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 31,566,821.236507416
 
 
 - tax_credits:
@@ -761,162 +901,208 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - tax_credits_applicable_income:
   - Type: float
-  - Entity: benunit
-  - Description: Applicable income for Tax Credits
-  - Mean: 35,680.8
-  - Median: 22,464.0
-  - Stddev: 93,276.296875
-  - Non-zero count: 31,806,944.136042148
+  - Entity: household
+  - Description: Rent
+  - Mean: 2,769.3
+  - Median: -52.0
+  - Stddev: 4,238.10009765625
+  - Non-zero count: 11,848,860.556090355
 
 
 - tax_credits_reduction:
   - Type: float
-  - Entity: benunit
-  - Description: Reduction in Tax Credits from means-tested income
-  - Mean: 11,711.1
-  - Median: 6,142.7
-  - Stddev: 37,830.5
-  - Non-zero count: 29,472,435.673414737
+  - Entity: household
+  - Description: Alcohol and tobacco
+  - Mean: 841.8
+  - Median: 312.0
+  - Stddev: 1,513.4000244140625
+  - Non-zero count: 20,649,978.500116587
 
 
 - working_tax_credit:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit
-  - Mean: 70.7
-  - Median: 0.0
-  - Stddev: 406.6000061035156
-  - Non-zero count: 876,496.4974822998
+  - Entity: household
+  - Description: Clothing and footwear
+  - Mean: 1,530.2
+  - Median: 518.9
+  - Stddev: 2,981.39990234375
+  - Non-zero count: 21,641,362.354569674
 
 
 - working_tax_credit_pre_minimum:
   - Type: float
-  - Entity: benunit
-  - Description: Working Tax Credit pre-minimum
-  - Mean: 70.7
-  - Median: 0.0
-  - Stddev: 406.6000061035156
-  - Non-zero count: 876,496.4974822998
+  - Entity: household
+  - Description: Communication
+  - Mean: 688.9
+  - Median: 384.3
+  - Stddev: 1,695.800048828125
+  - Non-zero count: 25,133,703.45969534
 
 
 - working_tax_credit_reported:
   - Type: float
-  - Entity: person
-  - Description: Working Tax Credit
-  - Mean: 42.4
+  - Entity: household
+  - Description: Diesel spending
+  - Mean: 551.8
   - Median: 0.0
-  - Stddev: 351.1000061035156
-  - Non-zero count: 1,190,157.5173085928
+  - Stddev: 1,172.5
+  - Non-zero count: 9,366,372.24467969
 
 
-- would_claim_CTC:
-  - Type: bool
-  - Entity: benunit
-  - Description: Would claim Child Tax Credit
-  - Mean: 0.0
+- education_consumption:
+  - Type: float
+  - Entity: household
+  - Description: Education
+  - Mean: 345.4
   - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 1,627,944.0341590643
+  - Stddev: 3,558.60009765625
+  - Non-zero count: 1,733,660.3778572083
 
 
-- would_claim_WTC:
-  - Type: bool
-  - Entity: benunit
-  - Description: Would claim Working Tax Credit
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 1,190,157.5173085928
+- food_and_non_alcoholic_beverages_consumption:
+  - Type: float
+  - Entity: household
+  - Description: Food and alcoholic beverages
+  - Mean: 4,157.2
+  - Median: 3,642.0
+  - Stddev: 2,316.699951171875
+  - Non-zero count: 31,536,771.133785248
 
 
 - JSA:
   - Type: float
-  - Entity: benunit
-  - Description: Amount of Jobseeker's Allowance for this family
-  - Mean: 9.9
-  - Median: 0.0
-  - Stddev: 174.3000030517578
-  - Non-zero count: 88,472.46475028992
+  - Entity: household
+  - Description: Health
+  - Mean: 567.2
+  - Median: 51.8
+  - Stddev: 1,955.800048828125
+  - Non-zero count: 19,360,939.249423504
 
 
 - JSA_income:
   - Type: float
-  - Entity: benunit
-  - Description: JSA (income-based)
-  - Mean: 6.3
-  - Median: 0.0
-  - Stddev: 133.10000610351562
-  - Non-zero count: 54,204.5407409668
+  - Entity: household
+  - Description: Household furnishings
+  - Mean: 2,324.8
+  - Median: 683.4
+  - Stddev: 5,368.10009765625
+  - Non-zero count: 30,109,011.32818985
 
 
 - JSA_income_applicable_amount:
   - Type: float
-  - Entity: benunit
-  - Description: Maximum amount of JSA (income-based)
-  - Mean: 6.9
-  - Median: 0.0
-  - Stddev: 150.39999389648438
-  - Non-zero count: 56,614.978088378906
+  - Entity: household
+  - Description: Housing, water and electricity
+  - Mean: 5,426.2
+  - Median: 3,081.8
+  - Stddev: 6,394.0
+  - Non-zero count: 31,534,885.703243256
 
 
 - JSA_income_applicable_income:
   - Type: float
-  - Entity: benunit
-  - Description: Relevant income for JSA (income-based) means test
-  - Mean: 25,555.2
-  - Median: 19,126.1
-  - Stddev: 31,634.5
-  - Non-zero count: 31,762,710.055456758
+  - Entity: household
+  - Description: Miscellaneous
+  - Mean: 3,110.9
+  - Median: 1,470.4
+  - Stddev: 6,133.5
+  - Non-zero count: 30,964,704.84858322
 
 
-- JSA_income_eligible:
-  - Type: bool
-  - Entity: benunit
-  - Description: Eligibility for income-based JSA
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 56,614.978088378906
+- petrol_spending:
+  - Type: float
+  - Entity: household
+  - Description: Petrol spending
+  - Mean: 831.5
+  - Median: 3.9
+  - Stddev: 1,196.199951171875
+  - Non-zero count: 15,787,098.954917908
 
 
 - JSA_income_reported:
   - Type: float
-  - Entity: person
-  - Description: JSA (income-based) (reported amount)
-  - Mean: 11.2
-  - Median: 0.0
-  - Stddev: 187.6999969482422
-  - Non-zero count: 188,841.2974395752
+  - Entity: household
+  - Description: Recreation
+  - Mean: 4,881.7
+  - Median: 1,977.3
+  - Stddev: 8,985.2001953125
+  - Non-zero count: 31,282,870.76014328
+
+
+- restaurants_and_hotels_consumption:
+  - Type: float
+  - Entity: household
+  - Description: Restaurants and hotels
+  - Mean: 3,413.3
+  - Median: 1,939.4
+  - Stddev: 4,427.39990234375
+  - Non-zero count: 27,910,186.468240738
+
+
+- transport_consumption:
+  - Type: float
+  - Entity: household
+  - Description: Transport
+  - Mean: 5,126.8
+  - Median: 2,325.4
+  - Stddev: 9,828.7998046875
+  - Non-zero count: 26,973,654.195077896
 
 
 - would_claim_JSA:
   - Type: bool
   - Entity: benunit
-  - Description: Would claim income-based JSA
-  - Mean: 0.0
+  - Description: Rent
+  - Mean: 2,417.9
   - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 188,841.2974395752
+  - Stddev: 3,787.39990234375
+  - Non-zero count: 12,678,011.265280724
 
 
 - BSP:
   - Type: float
   - Entity: person
-  - Description: Bereavement Support Payment
-  - Mean: 11.0
+  - Description: Cost of childcare
+  - Mean: 110.4
   - Median: 0.0
-  - Stddev: 413.29998779296875
-  - Non-zero count: 152,353.50714492798
+  - Stddev: 862.7000122070312
+  - Non-zero count: 2,418,063.511290312
+
+
+- council_tax:
+  - Type: float
+  - Entity: household
+  - Description: Council Tax
+  - Mean: 1,377.3
+  - Median: 1,324.2
+  - Stddev: 687.7000122070312
+  - Non-zero count: 30,546,296.968494415
+
+
+- council_tax_band:
+  - Type: Categorical
+  - Entity: household
+  - Description: Council Tax Band
+
+
+- council_tax_less_benefit:
+  - Type: float
+  - Entity: household
+  - Description: Council Tax (less CTB)
+  - Mean: 1,262.9
+  - Median: 1,280.0
+  - Stddev: 783.7999877929688
+  - Non-zero count: 28,641,752.4251194
 
 
 - BSP_reported:
   - Type: float
-  - Entity: person
-  - Description: Bereavement Support Payment (reported)
-  - Mean: 11.0
+  - Entity: household
+  - Description: Domestic rates
+  - Mean: 18.6
   - Median: 0.0
-  - Stddev: 413.29998779296875
-  - Non-zero count: 152,353.50714492798
+  - Stddev: 297.20001220703125
+  - Non-zero count: 514,347.40855407715
 
 
 - incapacity_benefit:
@@ -929,34 +1115,44 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 0.0
 
 
-- incapacity_benefit_reported:
+- family_rent:
   - Type: float
-  - Entity: person
-  - Description: Incapacity Benefit (reported)
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Entity: benunit
+  - Description: Gross rent for the family
+  - Mean: 2,365.5
+  - Median: -52.0
+  - Stddev: 3,999.0
+  - Non-zero count: 11,848,860.556090355
+
+
+- housing_costs:
+  - Type: float
+  - Entity: household
+  - Description: Total housing costs
+  - Mean: 4,228.3
+  - Median: 3,172.0
+  - Stddev: 4,312.60009765625
+  - Non-zero count: 31,368,395.17809677
 
 
 - SDA_reported:
   - Type: float
-  - Entity: person
-  - Description: Severe Disablement Allowance (reported)
-  - Mean: 0.8
+  - Entity: household
+  - Description: Housing service charges
+  - Mean: 66.7
   - Median: 0.0
-  - Stddev: 57.400001525878906
-  - Non-zero count: 12,816.54459285736
+  - Stddev: 370.5
+  - Non-zero count: 2,744,611.81558609
 
 
 - sda:
   - Type: float
   - Entity: person
-  - Description: Severe Disablement Allowance
-  - Mean: 0.9
+  - Description: Maintenance expenses
+  - Mean: 45.1
   - Median: 0.0
-  - Stddev: 65.30000305175781
-  - Non-zero count: 12,816.54459285736
+  - Stddev: 609.5999755859375
+  - Non-zero count: 779,240.2688064575
 
 
 - benefit_cap:
@@ -969,64 +1165,64 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 36,144,140.87005857
 
 
-- is_benefit_cap_exempt:
-  - Type: bool
-  - Entity: benunit
-  - Description: Whether exempt from the benefits cap
-  - Mean: 0.1
+- mortgage_capital_repayment:
+  - Type: float
+  - Entity: household
+  - Description: Mortgage payments
+  - Mean: 2,107.1
   - Median: 0.0
-  - Stddev: 0.3
-  - Non-zero count: 2,930,509.2179174423
+  - Stddev: 5,418.2001953125
+  - Non-zero count: 8,307,149.308640242
 
 
 - carers_allowance:
   - Type: float
-  - Entity: person
-  - Description: Carer's Allowance
-  - Mean: 30.8
-  - Median: 0.0
-  - Stddev: 361.29998779296875
-  - Non-zero count: 588,273.4450473785
+  - Entity: household
+  - Description: Total mortgage payments
+  - Mean: 822.5
+  - Median: -52.0
+  - Stddev: 2,120.300048828125
+  - Non-zero count: 8,283,283.951859236
 
 
 - carers_allowance_reported:
   - Type: float
   - Entity: person
-  - Description: Carer's Allowance (reported)
-  - Mean: 30.1
+  - Description: Occupational pension contributions
+  - Mean: 475.6
   - Median: 0.0
-  - Stddev: 353.0
-  - Non-zero count: 588,273.4450473785
+  - Stddev: 1,303.0999755859375
+  - Non-zero count: 17,676,380.21706009
 
 
 - receives_carers_allowance:
   - Type: bool
   - Entity: person
-  - Description: Receives Carer's Allowance
-  - Mean: 0.0
+  - Description: Rent liable
+  - Mean: 1,302.7
   - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 588,273.4450473785
+  - Stddev: 3,070.60009765625
+  - Non-zero count: 11,848,860.556090355
 
 
 - HB_individual_non_dep_deduction:
   - Type: float
   - Entity: person
-  - Description: Non-dependent deduction (individual)
-  - Mean: 604.7
-  - Median: 191.4
-  - Stddev: 611.4000244140625
-  - Non-zero count: 35,191,733.28302753
+  - Description: Private pension contributions
+  - Mean: 27.8
+  - Median: 0.0
+  - Stddev: 172.0
+  - Non-zero count: 1,974,908.7239151
 
 
 - HB_non_dep_deductions:
   - Type: float
-  - Entity: benunit
-  - Description: Non-dependent deductions
-  - Mean: 470.3
-  - Median: 0.0
-  - Stddev: 918.9000244140625
-  - Non-zero count: 8,873,591.115546346
+  - Entity: household
+  - Description: Water and sewerage charges
+  - Mean: 363.3
+  - Median: 342.2
+  - Stddev: 246.60000610351562
+  - Non-zero count: 30,109,154.453250885
 
 
 - baseline_has_housing_benefit:
@@ -1035,8 +1231,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Receives Housing Benefit (baseline)
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 16.600000381469727
+  - Non-zero count: 2,418,063.511290312
 
 
 - baseline_housing_benefit:
@@ -1085,18 +1281,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Whether eligible for Housing Benefit
   - Mean: 0.1
   - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 2,970,627.8606214523
+  - Stddev: 0.8
+  - Non-zero count: 7,626,600.520817518
 
 
 - housing_benefit_reported:
   - Type: float
   - Entity: person
-  - Description: Housing Benefit (reported amount)
-  - Mean: 253.6
-  - Median: 0.0
-  - Stddev: 914.0999755859375
-  - Non-zero count: 3,550,468.789457321
+  - Description: Age
+  - Mean: 40.3
+  - Median: 40.0
+  - Stddev: 24.0
+  - Non-zero count: 66,383,947.325356245
 
 
 - would_claim_HB:
@@ -1105,8 +1301,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Would claim Housing Benefit
   - Mean: 1.0
   - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 36,144,140.87005857
+  - Stddev: 0.5
+  - Non-zero count: 40,298,441.5902257
 
 
 - UC_LCWRA_element:
@@ -1115,8 +1311,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Universal Credit limited capability for work-related-activity element
   - Mean: 345.3
   - Median: 0.0
-  - Stddev: 1,268.4000244140625
-  - Non-zero count: 2,858,800.7575235367
+  - Stddev: 0.4
+  - Non-zero count: 12,817,742.397387981
 
 
 - UC_MIF_applies:
@@ -1125,28 +1321,28 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Minimum Income Floor applies
   - Mean: 0.1
   - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 4,175,640.6977385283
+  - Stddev: 0.4
+  - Non-zero count: 13,990,680.348232985
 
 
 - UC_MIF_capped_earned_income:
   - Type: float
   - Entity: person
-  - Description: Universal Credit gross earned income (incl. MIF)
-  - Mean: 14,938.7
-  - Median: 1,522.9
-  - Stddev: 37,212.80078125
-  - Non-zero count: 34,370,945.66784504
+  - Description: The birth year of the person
+  - Mean: 1,981.7
+  - Median: 1,982.0
+  - Stddev: 24.0
+  - Non-zero count: 67,106,864.33584666
 
 
-- UC_carer_element:
-  - Type: float
-  - Entity: benunit
-  - Description: Universal Credit carer element
-  - Mean: 31.8
-  - Median: 0.0
-  - Stddev: 266.5
-  - Non-zero count: 584,523.5082798004
+- child_index:
+  - Type: int
+  - Entity: person
+  - Description: Child reference number
+  - Mean: 79.5
+  - Median: 100.0
+  - Stddev: 40.5
+  - Non-zero count: 67,106,864.33584666
 
 
 - UC_child_element:
@@ -1231,28 +1427,28 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Universal Credit child element
   - Mean: 633.1
   - Median: 0.0
-  - Stddev: 1,209.5
-  - Non-zero count: 13,749,974.600902617
+  - Stddev: 0.4
+  - Non-zero count: 11,848,416.583055496
 
 
 - UC_individual_disabled_child_element:
   - Type: float
   - Entity: person
-  - Description: Universal Credit disabled child element
-  - Mean: 1.3
-  - Median: 0.0
-  - Stddev: 49.900001525878906
-  - Non-zero count: 54,692.99230957031
+  - Description: Whether is a working-age adult
+  - Mean: 0.6
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 41,125,564.52147722
 
 
 - UC_individual_non_dep_deduction:
   - Type: float
   - Entity: person
-  - Description: Universal Credit non-dependent deduction (individual)
-  - Mean: 440.0
-  - Median: 0.0
-  - Stddev: 453.1000061035156
-  - Non-zero count: 32,644,123.848999023
+  - Description: Whether this person is an adult
+  - Mean: 0.8
+  - Median: 1.0
+  - Stddev: 0.4
+  - Non-zero count: 53,116,183.98761368
 
 
 - UC_individual_severely_disabled_child_element:
@@ -1261,18 +1457,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Universal Credit severely disabled child element
   - Mean: 2.4
   - Median: 0.0
-  - Stddev: 118.0
-  - Non-zero count: 33,613.67724609375
+  - Stddev: 0.3
+  - Non-zero count: 8,119,458.425839186
 
 
-- UC_maximum_amount:
-  - Type: float
-  - Entity: benunit
-  - Description: Maximum Universal Credit amount
-  - Mean: 7,566.7
-  - Median: 6,118.9
-  - Stddev: 4,939.89990234375
-  - Non-zero count: 35,993,268.46081784
+- is_benunit_head:
+  - Type: bool
+  - Entity: person
+  - Description: Whether this person is the head-of-family
+  - Mean: 0.6
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 36,955,812.870046616
 
 
 - UC_maximum_childcare:
@@ -1288,11 +1484,11 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - UC_minimum_income_floor:
   - Type: float
   - Entity: person
-  - Description: Minimum Income Floor
-  - Mean: 14,305.0
-  - Median: 16,216.2
-  - Stddev: 3,145.39990234375
-  - Non-zero count: 67,239,322.06306267
+  - Description: Is a child
+  - Mean: 0.2
+  - Median: 0.0
+  - Stddev: 0.4
+  - Non-zero count: 13,990,680.348232985
 
 
 - UC_non_dep_deduction_exempt:
@@ -1302,37 +1498,37 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.1
   - Median: 0.0
   - Stddev: 0.3
-  - Non-zero count: 5,052,811.1743706465
+  - Non-zero count: 8,585,806.073300123
 
 
-- UC_non_dep_deductions:
-  - Type: float
-  - Entity: benunit
-  - Description: Universal Credit non-dependent deductions
-  - Mean: 360.3
+- is_female:
+  - Type: bool
+  - Entity: person
+  - Description: Whether the person is female
+  - Mean: 0.5
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 33,883,712.40115619
+
+
+- is_household_head:
+  - Type: bool
+  - Entity: person
+  - Description: Whether this person is the head-of-household
+  - Mean: 0.5
   - Median: 0.0
-  - Stddev: 690.4000244140625
-  - Non-zero count: 8,390,336.870431066
+  - Stddev: 0.5
+  - Non-zero count: 31,566,821.236507416
 
 
-- UC_standard_allowance:
-  - Type: float
-  - Entity: benunit
-  - Description: Universal Credit standard allowance
-  - Mean: 4,829.6
-  - Median: 3,898.1
-  - Stddev: 1,196.0999755859375
-  - Non-zero count: 36,144,140.87005857
-
-
-- UC_unearned_income:
-  - Type: float
-  - Entity: benunit
-  - Description: Universal Credit unearned income
-  - Mean: 4,496.8
-  - Median: 3.0
-  - Stddev: 73,240.1015625
-  - Non-zero count: 19,309,802.02488488
+- is_male:
+  - Type: bool
+  - Entity: person
+  - Description: Whether the person is male
+  - Mean: 0.5
+  - Median: 0.0
+  - Stddev: 0.5
+  - Non-zero count: 33,223,151.934690475
 
 
 - UC_work_allowance:
@@ -1341,8 +1537,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Universal Credit work allowance
   - Mean: 1,770.1
   - Median: 0.0
-  - Stddev: 2,677.39990234375
-  - Non-zero count: 10,780,733.571810275
+  - Stddev: 0.2
+  - Non-zero count: 3,397,452.105201721
 
 
 - baseline_has_universal_credit:
@@ -1351,8 +1547,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Receives Universal Credit (baseline)
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.4
+  - Non-zero count: 10,593,228.243031263
 
 
 - baseline_universal_credit:
@@ -1372,37 +1568,37 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.8
   - Median: 1.0
   - Stddev: 0.4
-  - Non-zero count: 27,901,158.69912669
+  - Non-zero count: 55,140,208.68200302
 
 
-- is_UC_work_allowance_eligible:
-  - Type: bool
-  - Entity: benunit
-  - Description: Family receives a Universal Credit Work Allowance
-  - Mean: 0.3
-  - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 10,780,733.571810275
+- people:
+  - Type: float
+  - Entity: person
+  - Description: Variable holding people
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - is_child_born_before_child_limit:
   - Type: bool
   - Entity: person
-  - Description: Born before child limit (exempt)
-  - Mean: 0.1
-  - Median: 0.0
-  - Stddev: 0.3
-  - Non-zero count: 9,785,532.902304351
+  - Description: ID for the person
+  - Mean: 96,537,120.2
+  - Median: 96,261,110.7
+  - Stddev: 55,404,854.6
+  - Non-zero count: 67,106,864.33584666
 
 
 - is_in_startup_period:
   - Type: bool
   - Entity: person
-  - Description: In a start-up period
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Description: Weight
+  - Mean: 2,950.3
+  - Median: 2,178.4
+  - Stddev: 1,475.199951171875
+  - Non-zero count: 67,106,864.33584666
 
 
 - legacy_benefits:
@@ -1418,12 +1614,11 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - limited_capability_for_WRA:
   - Type: bool
   - Entity: person
-  - Description: Assessed to have limited capability for work-related activity
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 3,026,306.8587350845
-
+  - Description: Weight factor
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 67,106,864.33584666
 
 - num_UC_eligible_children:
   - Type: int
@@ -1437,22 +1632,22 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - universal_credit:
   - Type: float
-  - Entity: benunit
-  - Description: Universal Credit
-  - Mean: 1,102.6
-  - Median: 0.0
-  - Stddev: 3,525.39990234375
-  - Non-zero count: 5,006,486.605466843
+  - Entity: household
+  - Description: Original FRS weight
+  - Mean: 1,500.5
+  - Median: 1,452.0
+  - Stddev: 1,006.7999877929688
+  - Non-zero count: 24,763,509.927612305
 
 
 - universal_credit_reported:
   - Type: float
   - Entity: person
-  - Description: Universal Credit (reported)
-  - Mean: 235.0
-  - Median: 0.0
-  - Stddev: 2,291.39990234375
-  - Non-zero count: 1,554,400.9394574165
+  - Description: Person's benefit unit ID
+  - Mean: 96,536,928.8
+  - Median: 96,261,008.0
+  - Stddev: 55,404,856.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - would_claim_UC:
@@ -1468,11 +1663,11 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - ESA_contrib:
   - Type: float
   - Entity: person
-  - Description: ESA (contribution-based)
-  - Mean: 31.4
-  - Median: 0.0
-  - Stddev: 521.7000122070312
-  - Non-zero count: 331,941.6319360733
+  - Description: Person's household ID
+  - Mean: 96,535,811.6
+  - Median: 96,260,008.0
+  - Stddev: 55,404,852.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - ESA_contrib_reported:
@@ -1517,62 +1712,72 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - baseline_pension_credit:
   - Type: float
-  - Entity: benunit
-  - Description: Pension Credit (baseline)
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Entity: household
+  - Description: Equivalisation factor to account for household composition, after housing costs
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.4000000059604645
+  - Non-zero count: 31,566,821.236507416
 
 
 - guarantee_credit_applicable_income:
   - Type: float
-  - Entity: benunit
-  - Description: Applicable income for Pension Credit
-  - Mean: 29,216.2
-  - Median: 21,138.9
-  - Stddev: 58,653.69921875
-  - Non-zero count: 33,706,624.29152158
+  - Entity: household
+  - Description: Equivalisation factor to account for household composition, before housing costs
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.30000001192092896
+  - Non-zero count: 31,566,821.236507416
 
 
-- pension_credit:
-  - Type: float
-  - Entity: benunit
-  - Description: Pension Credit
-  - Mean: 80.9
-  - Median: 0.0
-  - Stddev: 594.9000244140625
-  - Non-zero count: 1,338,011.1094360352
+- household_id:
+  - Type: int
+  - Entity: household
+  - Description: ID for the household
+  - Mean: 96,280,255.7
+  - Median: 95,976,826.4
+  - Stddev: 55,341,671.1
+  - Non-zero count: 31,566,821.236507416
 
 
-- pension_credit_GC:
-  - Type: float
-  - Entity: benunit
-  - Description: Pension Credit (Guarantee Credit) amount
-  - Mean: 62.7
-  - Median: 0.0
-  - Stddev: 547.5
-  - Non-zero count: 848,252.2827301025
+- household_num_benunits:
+  - Type: int
+  - Entity: household
+  - Description: Number of benefit units
+  - Mean: 1.2
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 31,566,821.236507416
+
+
+- household_num_people:
+  - Type: int
+  - Entity: household
+  - Description: Number of people
+  - Mean: 2.1
+  - Median: 2.0
+  - Stddev: 1.2
+  - Non-zero count: 31,566,821.236507416
 
 
 - pension_credit_MG:
   - Type: float
-  - Entity: benunit
-  - Description: Pension Credit (Minimum Guarantee) amount per week
-  - Mean: 2,355.4
-  - Median: 0.0
-  - Stddev: 4,984.2001953125
-  - Non-zero count: 7,655,977.704196036
+  - Entity: household
+  - Description: Weight factor for the household
+  - Mean: 3,152.0
+  - Median: 2,365.8
+  - Stddev: 1,574.5999755859375
+  - Non-zero count: 31,566,821.236507416
 
 
 - pension_credit_SC:
   - Type: float
-  - Entity: benunit
-  - Description: Pension Credit (Savings Credit) amount per week
-  - Mean: 18.2
-  - Median: 0.0
-  - Stddev: 166.39999389648438
-  - Non-zero count: 849,915.0264129639
+  - Entity: household
+  - Description: Variable holding households
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 31,566,821.236507416
 
 
 - pension_credit_eligible:
@@ -1582,7 +1787,7 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.2
   - Median: 0.0
   - Stddev: 0.4
-  - Non-zero count: 7,655,977.704196036
+  - Non-zero count: 8,882,277.498753548
 
 
 - pension_credit_reported:
@@ -1595,14 +1800,14 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 1,231,041.3284056187
 
 
-- savings_credit_applicable_income:
-  - Type: float
-  - Entity: benunit
-  - Description: Applicable income for Savings Credit
-  - Mean: 29,054.5
-  - Median: 20,791.1
-  - Stddev: 58,653.8984375
-  - Non-zero count: 33,533,872.699450046
+- num_bedrooms:
+  - Type: int
+  - Entity: household
+  - Description: The number of bedrooms in the house
+  - Mean: 2.7
+  - Median: 3.0
+  - Stddev: 1.0
+  - Non-zero count: 31,566,821.236507416
 
 
 - would_claim_PC:
@@ -1635,14 +1840,14 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 59,349.19867706299
 
 
-- child_ema:
-  - Type: float
-  - Entity: person
-  - Description: Child EMA
-  - Mean: 0.9
-  - Median: 0.0
-  - Stddev: 43.599998474121094
-  - Non-zero count: 45,767.17613220215
+- benunit_id:
+  - Type: int
+  - Entity: benunit
+  - Description: ID for the family
+  - Mean: 96,379,830.4
+  - Median: 96,511,381.1
+  - Stddev: 55,221,821.1
+  - Non-zero count: 36,955,812.870046616
 
 
 - education_grants:
@@ -1667,42 +1872,42 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - student_payments:
   - Type: float
-  - Entity: person
-  - Description: Student payments
-  - Mean: 51.8
-  - Median: 0.0
-  - Stddev: 870.5
-  - Non-zero count: 588,913.9909410477
+  - Entity: benunit
+  - Description: Weight factor for the benefit unit
+  - Mean: 3,135.2
+  - Median: 2,394.6
+  - Stddev: 1,566.699951171875
+  - Non-zero count: 36,955,812.870046616
 
 
 - BRMA_LHA_rate:
   - Type: float
   - Entity: benunit
-  - Description: LHA rate
-  - Mean: 9,549.5
-  - Median: 9,753.1
-  - Stddev: 2,457.800048828125
-  - Non-zero count: 36,144,140.87005857
+  - Description: Eldest adult age
+  - Mean: 49.4
+  - Median: 50.0
+  - Stddev: 19.299999237060547
+  - Non-zero count: 36,955,812.870046616
 
 
 - LHA_allowed_bedrooms:
   - Type: float
   - Entity: benunit
-  - Description: The number of bedrooms covered by LHA for the benefit unit
-  - Mean: 2.0
-  - Median: 2.0
-  - Stddev: 1.100000023841858
-  - Non-zero count: 36,144,140.87005857
+  - Description: Eldest adult age
+  - Mean: nan
+  - Median: -inf
+  - Stddev: nan
+  - Non-zero count: 7,763,899.624294996
 
 
 - LHA_cap:
   - Type: float
   - Entity: benunit
-  - Description: Applicable amount for LHA
-  - Mean: 1,843.4
-  - Median: 0.0
-  - Stddev: 2,931.89990234375
-  - Non-zero count: 11,198,118.913994372
+  - Description: Variable holding families
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 36,955,812.870046616
 
 
 - LHA_category:
@@ -1721,34 +1926,60 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 0.0
 
 
-- is_SP_age:
-  - Type: bool
-  - Entity: person
-  - Description: Whether the person is State Pension Age
-  - Mean: 0.2
+- num_adults:
+  - Type: int
+  - Entity: benunit
+  - Description: The number of adults in the family
+  - Mean: 1.4
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 36,294,038.56520653
+
+
+- num_children:
+  - Type: int
+  - Entity: benunit
+  - Description: The number of children in the family
+  - Mean: 0.4
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 11,493,751.700008094
+  - Stddev: 0.8
+  - Non-zero count: 8,585,806.073300123
+
+
+- relation_type:
+  - Type: Categorical
+  - Entity: benunit
+  - Description: Whether single or a couple
 
 
 - state_pension:
   - Type: float
-  - Entity: person
-  - Description: State Pension
-  - Mean: 1,608.9
-  - Median: 0.0
-  - Stddev: 3,745.10009765625
-  - Non-zero count: 12,824,677.907904088
+  - Entity: benunit
+  - Description: Eldest adult age
+  - Mean: 47.7
+  - Median: 47.0
+  - Stddev: 19.299999237060547
+  - Non-zero count: 36,955,812.870046616
 
 
 - state_pension_age:
   - Type: float
+  - Entity: benunit
+  - Description: Eldest adult age
+  - Mean: nan
+  - Median: inf
+  - Stddev: nan
+  - Non-zero count: 36,236,220.39800835
+
+
+- person_state_id:
+  - Type: int
   - Entity: person
   - Description: State Pension age for this person
   - Mean: 66.0
   - Median: 66.0
   - Stddev: 0.0
-  - Non-zero count: 67,239,322.06306267
+  - Non-zero count: 67,106,864.33584666
 
 
 - state_pension_reported:
@@ -1777,18 +2008,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Winter Fuel Allowance
   - Mean: 77.6
   - Median: 0.0
-  - Stddev: 114.9000015258789
-  - Non-zero count: 9,540,825.560111344
+  - Stddev: 0.1
+  - Non-zero count: 666,621.905736208
 
 
 - winter_fuel_allowance_reported:
   - Type: float
-  - Entity: person
-  - Description: Winter fuel allowance
-  - Mean: 33.0
+  - Entity: benunit
+  - Description: Carer premium
+  - Mean: 35.4
   - Median: 0.0
-  - Stddev: 79.69999694824219
-  - Non-zero count: 12,826,006.58387798
+  - Stddev: 250.39999389648438
+  - Non-zero count: 666,621.905736208
 
 
 - DLA_M_reported:
@@ -1797,8 +2028,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: DLA (mobility) (reported)
   - Mean: 30.3
   - Median: 0.0
-  - Stddev: 325.8999938964844
-  - Non-zero count: 794,603.9834299088
+  - Stddev: 0.1
+  - Non-zero count: 670,706.3129017353
 
 
 - dla_m:
@@ -1807,8 +2038,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: DLA (mobility)
   - Mean: 29.8
   - Median: 0.0
-  - Stddev: 319.1000061035156
-  - Non-zero count: 794,603.9834299088
+  - Stddev: 0.1
+  - Non-zero count: 666,621.905736208
 
 
 - dla_m_category:
@@ -1819,28 +2050,32 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - DLA_SC_reported:
   - Type: float
-  - Entity: person
-  - Description: DLA (self-care) (reported)
-  - Mean: 46.4
+  - Entity: benunit
+  - Description: Disability premium
+  - Mean: 186.2
   - Median: 0.0
-  - Stddev: 454.6000061035156
-  - Non-zero count: 981,401.0508308411
+  - Stddev: 595.9000244140625
+  - Non-zero count: 3,204,263.3590221405
 
 
 - dla_sc:
   - Type: float
-  - Entity: person
-  - Description: DLA (self-care)
-  - Mean: 47.1
+  - Entity: benunit
+  - Description: Enhanced disability premium
+  - Mean: 10.5
   - Median: 0.0
-  - Stddev: 456.8999938964844
-  - Non-zero count: 981,401.0508308411
+  - Stddev: 116.80000305175781
+  - Non-zero count: 364,466.1809616089
 
 
 - dla_sc_category:
   - Type: Categorical
   - Entity: person
-  - Description: DLA (Self-care) category
+  - Description: Has a disability
+  - Mean: 0.1
+  - Median: 0.0
+  - Stddev: 0.2
+  - Non-zero count: 3,778,370.4700603485
 
 
 - dla_sc_middle_plus:
@@ -1850,7 +2085,7 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.1
-  - Non-zero count: 748,702.0986862183
+  - Non-zero count: 424,565.89055633545
 
 
 - dla:
@@ -1859,8 +2094,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Disability Living Allowance
   - Mean: 77.0
   - Median: 0.0
-  - Stddev: 710.2000122070312
-  - Non-zero count: 1,114,483.50055027
+  - Stddev: 0.1
+  - Non-zero count: 1,539,465.9202384949
 
 
 - PIP_M_reported:
@@ -1869,8 +2104,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Disability Living Allowance (mobility) (reported)
   - Mean: 47.1
   - Median: 0.0
-  - Stddev: 386.70001220703125
-  - Non-zero count: 1,376,311.2113780975
+  - Stddev: 0.3
+  - Non-zero count: 3,204,263.3590221405
 
 
 - pip_m:
@@ -1879,8 +2114,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: PIP (mobility)
   - Mean: 46.6
   - Median: 0.0
-  - Stddev: 380.70001220703125
-  - Non-zero count: 1,376,311.2113780975
+  - Stddev: 0.0
+  - Non-zero count: 13,362.926254272461
 
 
 - pip_m_category:
@@ -1895,8 +2130,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: PIP (self-care) (reported)
   - Mean: 100.3
   - Median: 0.0
-  - Stddev: 660.4000244140625
-  - Non-zero count: 1,808,884.3287525177
+  - Stddev: 0.1
+  - Non-zero count: 364,466.1809616089
 
 
 - pip_dl:
@@ -1921,8 +2156,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Personal Independence Payment
   - Mean: 149.2
   - Median: 0.0
-  - Stddev: 998.2999877929688
-  - Non-zero count: 1,917,229.389678955
+  - Stddev: 0.2
+  - Non-zero count: 1,325,348.9816093445
 
 
 - benunit_tax:
@@ -1972,17 +2207,17 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Non-zero count: 5,647.0709228515625
 
 
 - baseline_corporate_sdlt:
   - Type: float
-  - Entity: household
-  - Description: Stamp Duty (corporations, baseline)
-  - Mean: 109.6
-  - Median: 38.3
-  - Stddev: 419.1000061035156
-  - Non-zero count: 22,987,657.523749888
+  - Entity: benunit
+  - Description: Severe disability premium
+  - Mean: 184.0
+  - Median: 0.0
+  - Stddev: 976.0
+  - Non-zero count: 1,325,348.9816093445
 
 
 - baseline_expected_sdlt:
@@ -2025,7 +2260,27 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 0.0
 
 
-- expected_sdlt:
+- bi_household_phaseout:
+  - Type: float
+  - Entity: person
+  - Description: Basic income phase-out (household)
+  - Mean: 0.0
+  - Median: 0.0
+  - Stddev: 0.0
+  - Non-zero count: 0.0
+
+
+- bi_individual_phaseout:
+  - Type: float
+  - Entity: person
+  - Description: Basic income phase-out (individual)
+  - Mean: 0.0
+  - Median: 0.0
+  - Stddev: 0.0
+  - Non-zero count: 0.0
+
+
+- bi_phaseout:
   - Type: float
   - Entity: household
   - Description: Stamp Duty (expected)
@@ -2087,22 +2342,22 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - sdlt_on_residential_property_transactions:
   - Type: float
-  - Entity: household
-  - Description: Stamp Duty on residential property
-  - Mean: 8,190.0
-  - Median: 160.0
-  - Stddev: 22,961.599609375
-  - Non-zero count: 14,537,718.922358125
+  - Entity: benunit
+  - Description: Child Tax Credit child element
+  - Mean: 1,081.4
+  - Median: 0.0
+  - Stddev: 2,347.10009765625
+  - Non-zero count: 7,626,600.520817518
 
 
 - sdlt_on_transactions:
   - Type: float
-  - Entity: household
-  - Description: SDLT on property transactions
-  - Mean: 8,425.8
-  - Median: 200.0
-  - Stddev: 23,907.5
-  - Non-zero count: 14,591,522.270894617
+  - Entity: benunit
+  - Description: CTC entitlement from disabled child elements
+  - Mean: 0.4
+  - Median: 0.0
+  - Stddev: 44.0
+  - Non-zero count: 4,632.5372314453125
 
 
 - stamp_duty_land_tax:
@@ -2111,18 +2366,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Stamp Duty Land Tax
   - Mean: 7,299.1
   - Median: 0.0
-  - Stddev: 22,155.30078125
-  - Non-zero count: 12,618,049.461886793
+  - Stddev: 115.30000305175781
+  - Non-zero count: 1,439,554.5789794922
 
 
 - baseline_child_benefit:
   - Type: float
   - Entity: benunit
-  - Description: Child Benefit (baseline)
-  - Mean: 0.0
+  - Description: Maximum Child Tax Credit
+  - Mean: 1,103.2
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 2,403.60009765625
+  - Non-zero count: 7,626,600.520817518
 
 
 - baseline_has_child_benefit:
@@ -2131,8 +2386,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Receives Child Benefit (baseline)
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 12.600000381469727
+  - Non-zero count: 2,557.3665771484375
 
 
 - child_benefit:
@@ -2141,78 +2396,78 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Child Benefit
   - Mean: 326.5
   - Median: 0.0
-  - Stddev: 696.2000122070312
-  - Non-zero count: 7,132,352.404498607
+  - Stddev: 308.8999938964844
+  - Non-zero count: 984,163.1622924805
 
 
 - child_benefit_less_tax_charge:
   - Type: float
   - Entity: benunit
-  - Description: Child Benefit (less tax charge)
-  - Mean: 270.0
+  - Description: Working Tax Credit childcare element
+  - Mean: 8.1
   - Median: 0.0
-  - Stddev: 640.0999755859375
-  - Non-zero count: 6,113,730.2608162165
+  - Stddev: 248.3000030517578
+  - Non-zero count: 161,936.1049194336
 
 
 - child_benefit_reported:
   - Type: float
-  - Entity: person
-  - Description: Child Benefit (reported amount)
-  - Mean: 150.4
+  - Entity: benunit
+  - Description: Working Tax Credit couple element
+  - Mean: 24.5
   - Median: 0.0
-  - Stddev: 507.5
-  - Non-zero count: 6,126,531.264963627
+  - Stddev: 210.3000030517578
+  - Non-zero count: 438,914.86532592773
 
 
 - child_benefit_respective_amount:
   - Type: float
-  - Entity: person
-  - Description: Child Benefit (respective amount)
-  - Mean: 186.7
+  - Entity: benunit
+  - Description: Working Tax Credit disabled element
+  - Mean: 4.1
   - Median: 0.0
-  - Stddev: 365.29998779296875
-  - Non-zero count: 13,587,051.760222733
+  - Stddev: 119.0999984741211
+  - Non-zero count: 46,565.70706176758
 
 
 - would_claim_child_benefit:
   - Type: bool
   - Entity: benunit
-  - Description: Would claim Child Benefit
-  - Mean: 0.8
-  - Median: 1.0
-  - Stddev: 0.4
-  - Non-zero count: 29,008,855.95105079
+  - Description: Working Tax Credit lone parent element
+  - Mean: 22.5
+  - Median: 0.0
+  - Stddev: 225.8000030517578
+  - Non-zero count: 404,089.41592407227
 
 
 - baseline_business_rates:
   - Type: float
-  - Entity: household
-  - Description: Baseline business rates incidence
-  - Mean: 1,111.3
-  - Median: 388.3
-  - Stddev: 4,249.2001953125
-  - Non-zero count: 22,987,657.523749888
+  - Entity: benunit
+  - Description: Working Tax Credit maximum rate
+  - Mean: 128.2
+  - Median: 0.0
+  - Stddev: 838.7000122070312
+  - Non-zero count: 984,163.1622924805
 
 
 - business_rates:
   - Type: float
-  - Entity: household
-  - Description: Business rates incidence
-  - Mean: 1,111.3
-  - Median: 388.3
-  - Stddev: 4,249.2001953125
-  - Non-zero count: 22,987,657.523749888
+  - Entity: benunit
+  - Description: Working Tax Credit severely disabled element
+  - Mean: 1.3
+  - Median: 0.0
+  - Stddev: 45.70000076293945
+  - Non-zero count: 33,122.97134399414
 
 
 - business_rates_change_incidence:
   - Type: float
-  - Entity: household
-  - Description: Business rates changes
-  - Mean: 0.0
+  - Entity: benunit
+  - Description: Working Tax Credit worker element
+  - Mean: 14.4
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 98.4000015258789
+  - Non-zero count: 639,159.8714904785
 
 
 - change_in_business_rates:
@@ -2225,7 +2480,27 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 0.0
 
 
-- baseline_fuel_duty:
+- baseline_has_child_tax_credit:
+  - Type: bool
+  - Entity: benunit
+  - Description: Receives Child Tax Credit (baseline)
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 36,955,812.870046616
+
+
+- baseline_has_working_tax_credit:
+  - Type: bool
+  - Entity: benunit
+  - Description: Receives Working Tax Credit (baseline)
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 36,955,812.870046616
+
+
+- baseline_working_tax_credit:
   - Type: float
   - Entity: household
   - Description: Baseline fuel duty (cars only)
@@ -2237,52 +2512,42 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - change_in_fuel_duty:
   - Type: float
-  - Entity: household
-  - Description: Change in fuel duty
-  - Mean: 567.2
-  - Median: 404.2
-  - Stddev: 654.9000244140625
-  - Non-zero count: 19,272,700.238146722
+  - Entity: benunit
+  - Description: Child Tax Credit
+  - Mean: 160.2
+  - Median: 0.0
+  - Stddev: 1,187.5
+  - Non-zero count: 1,227,160.5479888916
 
 
 - fuel_duty:
   - Type: float
-  - Entity: household
-  - Description: Fuel duty (cars only)
-  - Mean: 567.2
-  - Median: 404.2
-  - Stddev: 654.9000244140625
-  - Non-zero count: 19,272,700.238146722
-
-
-- NI_class_2:
-  - Type: float
-  - Entity: person
-  - Description: Class 2 Contributions for National Insurance for the year
-  - Mean: 7.1
+  - Entity: benunit
+  - Description: Child Tax Credit pre-minimum
+  - Mean: 375.0
   - Median: 0.0
-  - Stddev: 29.200000762939453
-  - Non-zero count: 2,997,701.830866337
+  - Stddev: 1,547.5999755859375
+  - Non-zero count: 3,014,456.051595688
 
 
 - weekly_NI_class_2:
   - Type: float
   - Entity: person
-  - Description: Class 2 Contributions for National Insurance
-  - Mean: 7.1
+  - Description: Working Tax Credit
+  - Mean: 117.2
   - Median: 0.0
-  - Stddev: 29.200000762939453
-  - Non-zero count: 2,997,701.830866337
+  - Stddev: 1,027.9000244140625
+  - Non-zero count: 1,643,502.8787841797
 
 
 - NI_exempt:
   - Type: bool
   - Entity: person
-  - Description: Exempt from National Insurance
-  - Mean: 0.4
-  - Median: 0.0
-  - Stddev: 0.5
-  - Non-zero count: 24,400,148.003022194
+  - Description: Exemption from Child Tax Credit child limit
+  - Mean: 0.9
+  - Median: 1.0
+  - Stddev: 0.3
+  - Non-zero count: 62,356,787.767611265
 
 
 - employee_NI_class_1:
@@ -2291,8 +2556,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Employee Class 1 Contributions for National Insurance
   - Mean: 896.0
   - Median: 0.0
-  - Stddev: 1,655.0
-  - Non-zero count: 24,420,517.142964244
+  - Stddev: 0.2
+  - Non-zero count: 1,439,554.5789794922
 
 
 - employer_NI:
@@ -2301,8 +2566,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Employer contributions to National Insurance
   - Mean: 1,289.3
   - Median: 0.0
-  - Stddev: 2,854.5
-  - Non-zero count: 25,006,511.983914256
+  - Stddev: 0.2
+  - Non-zero count: 984,163.1622924805
 
 
 - employer_NI_class_1:
@@ -2311,38 +2576,38 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Employer Class 1 Contributions for National Insurance
   - Mean: 1,289.3
   - Median: 0.0
-  - Stddev: 2,854.5
-  - Non-zero count: 25,006,511.983914256
+  - Stddev: 0.4
+  - Non-zero count: 12,633,341.866535902
 
 
 - total_NI:
   - Type: float
-  - Entity: person
-  - Description: National Insurance (total)
-  - Mean: 2,241.6
+  - Entity: benunit
+  - Description: Tax Credits
+  - Mean: 417.6
   - Median: 0.0
-  - Stddev: 4,430.89990234375
-  - Non-zero count: 27,696,584.16005552
+  - Stddev: 1,771.199951171875
+  - Non-zero count: 3,218,260.4193019867
 
 
 - NI_class_4:
   - Type: float
-  - Entity: person
-  - Description: Class 4 Contributions for National Insurance for the year
-  - Mean: 65.0
-  - Median: 0.0
-  - Stddev: 692.0999755859375
-  - Non-zero count: 2,549,543.7053189278
+  - Entity: benunit
+  - Description: Applicable income for Tax Credits
+  - Mean: 34,734.1
+  - Median: 21,424.0
+  - Stddev: 88,142.8984375
+  - Non-zero count: 32,522,702.000450134
 
 
 - employee_NI:
   - Type: float
-  - Entity: person
-  - Description: Employee-side National Insurance
-  - Mean: 896.0
-  - Median: 0.0
-  - Stddev: 1,655.0
-  - Non-zero count: 24,420,517.142964244
+  - Entity: benunit
+  - Description: Reduction in Tax Credits from means-tested income
+  - Mean: 11,328.3
+  - Median: 5,711.8
+  - Stddev: 35,676.30078125
+  - Non-zero count: 29,816,893.76969719
 
 
 - national_insurance:
@@ -2351,8 +2616,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: National Insurance
   - Mean: 952.2
   - Median: 0.0
-  - Stddev: 1,768.0
-  - Non-zero count: 26,622,246.41255462
+  - Stddev: 451.3999938964844
+  - Non-zero count: 735,159.7142944336
 
 
 - self_employed_NI:
@@ -2361,18 +2626,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Self-employed National Insurance
   - Mean: 72.1
   - Median: 0.0
-  - Stddev: 703.7999877929688
-  - Non-zero count: 2,997,701.830866337
+  - Stddev: 451.3999938964844
+  - Non-zero count: 735,159.7142944336
 
 
 - add_rate_earned_income:
   - Type: float
   - Entity: person
-  - Description: Earned income (non-savings, non-dividend) at the additional rate
-  - Mean: 776.2
+  - Description: Working Tax Credit
+  - Mean: 35.3
   - Median: 0.0
-  - Stddev: 29,155.599609375
-  - Non-zero count: 353,355.9631690979
+  - Stddev: 378.8999938964844
+  - Non-zero count: 1,117,794.2751464844
 
 
 - add_rate_earned_income_tax:
@@ -2381,8 +2646,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Income tax on earned income at the additional rate
   - Mean: 349.3
   - Median: 0.0
-  - Stddev: 13,120.0
-  - Non-zero count: 353,355.9631690979
+  - Stddev: 0.2
+  - Non-zero count: 1,643,502.8787841797
 
 
 - add_rate_savings_income:
@@ -2391,28 +2656,28 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Savings income at the higher rate
   - Mean: 4.3
   - Median: 0.0
-  - Stddev: 276.3999938964844
-  - Non-zero count: 18,277.750274658203
+  - Stddev: 0.2
+  - Non-zero count: 1,117,794.2751464844
 
 
 - basic_rate_earned_income:
   - Type: float
   - Entity: person
-  - Description: Earned income (non-savings, non-dividend) at the basic rate
-  - Mean: 7,309.1
+  - Description: Bereavement Support Payment
+  - Mean: 12.4
   - Median: 0.0
-  - Stddev: 12,142.099609375
-  - Non-zero count: 30,891,080.23272544
+  - Stddev: 409.70001220703125
+  - Non-zero count: 178,054.86631774902
 
 
 - basic_rate_earned_income_tax:
   - Type: float
   - Entity: person
-  - Description: Income tax on earned income at the basic rate
-  - Mean: 1,461.8
+  - Description: Bereavement Support Payment (reported)
+  - Mean: 12.4
   - Median: 0.0
-  - Stddev: 2,428.39990234375
-  - Non-zero count: 30,891,080.23272544
+  - Stddev: 409.70001220703125
+  - Non-zero count: 178,054.86631774902
 
 
 - basic_rate_savings_income:
@@ -2421,8 +2686,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Savings income at the basic rate
   - Mean: 13.7
   - Median: 0.0
-  - Stddev: 389.3999938964844
-  - Non-zero count: 113,972.9571428299
+  - Stddev: 97.19999694824219
+  - Non-zero count: 14,927.764465332031
 
 
 - basic_rate_savings_income_pre_starter:
@@ -2431,38 +2696,38 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Savings income which would otherwise be taxed at the basic rate, without the starter rate
   - Mean: 19.9
   - Median: 0.0
-  - Stddev: 409.0
-  - Non-zero count: 605,345.2122935355
+  - Stddev: 97.19999694824219
+  - Non-zero count: 14,927.764465332031
 
 
 - dividend_income_tax:
   - Type: float
   - Entity: person
-  - Description: Income tax on dividend income
-  - Mean: 369.9
+  - Description: Sure Start Maternity Grant
+  - Mean: 14.5
   - Median: 0.0
-  - Stddev: 18,766.400390625
-  - Non-zero count: 1,154,228.3843764365
+  - Stddev: 495.79998779296875
+  - Non-zero count: 37,849.4697265625
 
 
 - earned_income_tax:
   - Type: float
   - Entity: person
-  - Description: Income tax on earned income
-  - Mean: 2,611.6
+  - Description: Sure Start Maternity Grant (reported)
+  - Mean: 14.5
   - Median: 0.0
-  - Stddev: 15,414.7001953125
-  - Non-zero count: 30,891,080.23272544
+  - Stddev: 495.79998779296875
+  - Non-zero count: 37,849.4697265625
 
 
 - earned_taxable_income:
   - Type: float
-  - Entity: person
-  - Description: Non-savings, non-dividend income for Income Tax
-  - Mean: 10,065.3
-  - Median: 0.0
-  - Stddev: 37,099.69921875
-  - Non-zero count: 30,891,080.23272544
+  - Entity: benunit
+  - Description: Benefit cap for the family
+  - Mean: nan
+  - Median: 13,399.9
+  - Stddev: nan
+  - Non-zero count: 36,955,812.870046616
 
 
 - higher_rate_earned_income:
@@ -2471,8 +2736,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Earned income (non-savings, non-dividend) at the higher rate
   - Mean: 1,980.1
   - Median: 0.0
-  - Stddev: 10,582.599609375
-  - Non-zero count: 4,096,062.9593215287
+  - Stddev: 0.3
+  - Non-zero count: 2,985,648.248229265
 
 
 - higher_rate_earned_income_tax:
@@ -2481,38 +2746,38 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Income tax on earned income at the higher rate
   - Mean: 792.0
   - Median: 0.0
-  - Stddev: 4,233.0
-  - Non-zero count: 4,096,062.9593215287
+  - Stddev: 0.4
+  - Non-zero count: 11,990,619.466136456
 
 
 - higher_rate_savings_income:
   - Type: float
   - Entity: person
-  - Description: Savings income at the higher rate
-  - Mean: 17.2
+  - Description: State Pension
+  - Mean: 1,631.7
   - Median: 0.0
-  - Stddev: 718.7999877929688
-  - Non-zero count: 55,933.899629592896
+  - Stddev: 3,749.39990234375
+  - Non-zero count: 12,955,366.143363476
 
 
 - income_tax:
   - Type: float
   - Entity: person
-  - Description: Income Tax
-  - Mean: 3,023.5
-  - Median: 0.0
-  - Stddev: 24,490.0
-  - Non-zero count: 31,208,727.077200264
+  - Description: State Pension age for this person
+  - Mean: 66.0
+  - Median: 66.0
+  - Stddev: 0.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - income_tax_pre_charges:
   - Type: float
   - Entity: person
-  - Description: Income Tax before any tax charges
-  - Mean: 2,993.1
+  - Description: Reported income from the State Pension
+  - Mean: 1,631.7
   - Median: 0.0
-  - Stddev: 24,412.80078125
-  - Non-zero count: 31,208,727.077200264
+  - Stddev: 3,749.39990234375
+  - Non-zero count: 12,955,366.143363476
 
 
 - is_higher_earner:
@@ -2521,18 +2786,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Whether this person is the highest earner in a family
   - Mean: 0.5
   - Median: 1.0
-  - Stddev: 0.5
-  - Non-zero count: 36,144,140.87005857
+  - Stddev: 0.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - pays_scottish_income_tax:
   - Type: float
   - Entity: person
-  - Description: Whether the individual pays Scottish Income Tax rates
-  - Mean: 0.1
+  - Description: Attendance Allowance (reported)
+  - Mean: 36.7
   - Median: 0.0
-  - Stddev: 0.30000001192092896
-  - Non-zero count: 5,544,417.5458628535
+  - Stddev: 450.5
+  - Non-zero count: 631,634.3214645386
 
 
 - savings_income_tax:
@@ -2548,37 +2813,41 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - savings_starter_rate_income:
   - Type: float
   - Entity: person
-  - Description: Savings income which is tax-free under the starter rate
-  - Mean: 4,987.7
-  - Median: 5,000.0
-  - Stddev: 214.1999969482422
-  - Non-zero count: 67,174,519.0311718
+  - Description: Attendance Allowance
+  - Mean: 37.5
+  - Median: 0.0
+  - Stddev: 460.5
+  - Non-zero count: 631,634.3214645386
 
 
-- tax_band:
-  - Type: Categorical
-  - Entity: person
-  - Description: Tax band of the individual
+- BRMA_LHA_rate:
+  - Type: float
+  - Entity: benunit
+  - Description: LHA rate
+  - Mean: 9,002.4
+  - Median: 7,778.7
+  - Stddev: 2,274.39990234375
+  - Non-zero count: 36,955,812.870046616
 
 
 - taxed_dividend_income:
   - Type: float
-  - Entity: person
-  - Description: Dividend income which is taxed
-  - Mean: 1,115.6
-  - Median: 0.0
-  - Stddev: 51,176.5
-  - Non-zero count: 1,154,228.3843764365
+  - Entity: benunit
+  - Description: The number of bedrooms covered by LHA for the benefit unit
+  - Mean: 1.7
+  - Median: 1.0
+  - Stddev: 1.100000023841858
+  - Non-zero count: 36,955,812.870046616
 
 
 - taxed_income:
   - Type: float
-  - Entity: person
-  - Description: Income which is taxed
-  - Mean: 11,216.1
+  - Entity: benunit
+  - Description: Applicable amount for LHA
+  - Mean: 2,042.2
   - Median: 0.0
-  - Stddev: 63,623.6015625
-  - Non-zero count: 31,208,727.077200264
+  - Stddev: 2,845.10009765625
+  - Non-zero count: 12,678,011.265280724
 
 
 - taxed_savings_income:
@@ -2604,21 +2873,21 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - SMP:
   - Type: float
   - Entity: person
-  - Description: Statutory Maternity Pay
-  - Mean: 19.2
+  - Description: ESA (contribution-based)
+  - Mean: 38.5
   - Median: 0.0
-  - Stddev: 334.3999938964844
-  - Non-zero count: 175,309.49304771423
+  - Stddev: 466.70001220703125
+  - Non-zero count: 395,211.5219268799
 
 
 - SSP:
   - Type: float
   - Entity: person
-  - Description: Statutory Sick Pay
-  - Mean: 5.9
+  - Description: Employment and Support Allowance (contribution-based) (reported)
+  - Mean: 38.5
   - Median: 0.0
-  - Stddev: 168.6999969482422
-  - Non-zero count: 105,672.27379798889
+  - Stddev: 466.70001220703125
+  - Non-zero count: 395,211.5219268799
 
 
 - adjusted_net_income:
@@ -2644,21 +2913,21 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - deficiency_relief:
   - Type: float
   - Entity: person
-  - Description: Deficiency relief
-  - Mean: 0.0
+  - Description: Carer's Allowance
+  - Mean: 35.1
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 331.5
+  - Non-zero count: 670,706.3129017353
 
 
 - employment_benefits:
   - Type: float
   - Entity: person
-  - Description: Employment benefits
-  - Mean: 25.1
+  - Description: Carer's Allowance (reported)
+  - Mean: 34.4
   - Median: 0.0
-  - Stddev: 375.70001220703125
-  - Non-zero count: 280,127.93017578125
+  - Stddev: 324.3999938964844
+  - Non-zero count: 670,706.3129017353
 
 
 - employment_deductions:
@@ -2667,248 +2936,288 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Deductions from employment income
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 670,706.3129017353
 
 
 - employment_expenses:
   - Type: float
   - Entity: person
-  - Description: Cost of expenses necessarily incurred and reimbursed by employment
-  - Mean: 0.0
+  - Description: Industrial Injuries Disablement Benefit
+  - Mean: 6.9
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 176.89999389648438
+  - Non-zero count: 162,031.14375305176
 
 
 - loss_relief:
   - Type: float
   - Entity: person
-  - Description: Tax relief from trading losses
-  - Mean: 0.0
+  - Description: Industrial Injuries Disablement Benefit (reported)
+  - Mean: 6.9
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 176.89999389648438
+  - Non-zero count: 162,031.14375305176
 
 
 - pension_contributions:
   - Type: float
-  - Entity: person
-  - Description: Amount contributed to registered pension schemes paid by the individual (not the employer)
-  - Mean: 479.6
+  - Entity: benunit
+  - Description: Council Tax Benefit
+  - Mean: 97.7
   - Median: 0.0
-  - Stddev: 1,289.199951171875
-  - Non-zero count: 19,344,420.679252625
+  - Stddev: 255.0
+  - Non-zero count: 4,562,880.866437912
 
 
 - pension_contributions_relief:
   - Type: float
   - Entity: person
-  - Description: Reduction in taxable income from pension contributions
-  - Mean: 1,809.7
+  - Description: Council Tax Benefit (reported)
+  - Mean: 53.8
   - Median: 0.0
-  - Stddev: 2,067.10009765625
-  - Non-zero count: 33,082,469.85757926
+  - Stddev: 190.1999969482422
+  - Non-zero count: 4,562,880.866437912
 
 
 - tax_free_savings_income:
   - Type: float
   - Entity: person
-  - Description: Income from savings in tax-free accounts
-  - Mean: 39.2
+  - Description: Non-dependent deduction (individual)
+  - Mean: 595.4
+  - Median: 191.4
+  - Stddev: 611.0999755859375
+  - Non-zero count: 34,296,161.06988621
+
+
+- HB_non_dep_deductions:
+  - Type: float
+  - Entity: benunit
+  - Description: Non-dependent deductions
+  - Mean: 295.4
   - Median: 0.0
-  - Stddev: 380.70001220703125
-  - Non-zero count: 9,316,864.649248093
+  - Stddev: 781.4000244140625
+  - Non-zero count: 5,962,723.509792328
+
+
+- baseline_has_housing_benefit:
+  - Type: bool
+  - Entity: benunit
+  - Description: Receives Housing Benefit (baseline)
+  - Mean: 0.1
+  - Median: 0.0
+  - Stddev: 0.2
+  - Non-zero count: 2,830,541.0888061523
 
 
 - taxable_dividend_income:
   - Type: float
-  - Entity: person
-  - Description: Amount of dividend income that is taxable
-  - Mean: 1,166.8
+  - Entity: benunit
+  - Description: Housing Benefit (baseline)
+  - Mean: 434.0
   - Median: 0.0
-  - Stddev: 51,290.0
-  - Non-zero count: 4,138,236.9688646197
+  - Stddev: 1,005.7000122070312
+  - Non-zero count: 2,830,541.0888061523
 
 
 - taxable_employment_income:
   - Type: float
-  - Entity: person
-  - Description: Net taxable earnings
-  - Mean: 12,628.0
+  - Entity: benunit
+  - Description: Housing Benefit
+  - Mean: 433.9
   - Median: 0.0
-  - Stddev: 22,515.0
-  - Non-zero count: 30,286,992.402183324
+  - Stddev: 1,005.2999877929688
+  - Non-zero count: 2,830,541.0888061523
 
 
 - taxable_miscellaneous_income:
   - Type: float
-  - Entity: person
-  - Description: Amount of miscellaneous income that is taxable
-  - Mean: 59.5
+  - Entity: benunit
+  - Description: Applicable amount for Housing Benefit
+  - Mean: 775.2
   - Median: 0.0
-  - Stddev: 1,002.9000244140625
-  - Non-zero count: 771,787.4630403519
+  - Stddev: 2,245.39990234375
+  - Non-zero count: 3,283,475.612388611
 
 
 - taxable_pension_income:
   - Type: float
-  - Entity: person
-  - Description: Amount of pension income that is taxable
-  - Mean: 1,102.0
+  - Entity: benunit
+  - Description: Relevant income for Housing Benefit means test
+  - Mean: 26,151.0
+  - Median: 19,542.4
+  - Stddev: 24,174.19921875
+  - Non-zero count: 35,095,522.01021004
+
+
+- housing_benefit_eligible:
+  - Type: bool
+  - Entity: benunit
+  - Description: Whether eligible for Housing Benefit
+  - Mean: 0.1
   - Median: 0.0
-  - Stddev: 4,881.5
-  - Non-zero count: 9,301,682.557232678
+  - Stddev: 0.2
+  - Non-zero count: 3,283,475.612388611
 
 
 - taxable_property_income:
   - Type: float
   - Entity: person
-  - Description: Amount of property income that is taxable
-  - Mean: 488.3
+  - Description: Housing Benefit (reported amount)
+  - Mean: 288.6
   - Median: 0.0
-  - Stddev: 6,364.89990234375
-  - Non-zero count: 2,060,066.305748254
+  - Stddev: 945.5
+  - Non-zero count: 3,736,540.6955184937
+
+
+- would_claim_HB:
+  - Type: bool
+  - Entity: benunit
+  - Description: Would claim Housing Benefit
+  - Mean: 1.0
+  - Median: 1.0
+  - Stddev: 0.0
+  - Non-zero count: 36,955,812.870046616
 
 
 - taxable_savings_interest_income:
   - Type: float
   - Entity: person
-  - Description: Amount of savings interest which is taxable
-  - Mean: 81.4
+  - Description: Access Fund
+  - Mean: 2.4
   - Median: 0.0
-  - Stddev: 1,070.4000244140625
-  - Non-zero count: 19,025,031.979306996
+  - Stddev: 180.5
+  - Non-zero count: 41,549.21798706055
 
 
 - taxable_self_employment_income:
   - Type: float
   - Entity: person
-  - Description: Amount of trading income that is taxable
-  - Mean: 1,504.8
+  - Description: Adult EMA
+  - Mean: 3.1
   - Median: 0.0
-  - Stddev: 29,242.900390625
-  - Non-zero count: 3,961,577.255010605
+  - Stddev: 132.6999969482422
+  - Non-zero count: 42,582.32238769531
 
 
 - taxable_social_security_income:
   - Type: float
   - Entity: person
-  - Description: Amount of social security income that is taxable
-  - Mean: 1,672.9
+  - Description: Child EMA
+  - Mean: 1.4
   - Median: 0.0
-  - Stddev: 3,762.5
-  - Non-zero count: 13,748,469.413428724
+  - Stddev: 44.79999923706055
+  - Non-zero count: 67,589.15292358398
 
 
 - total_income:
   - Type: float
   - Entity: person
-  - Description: Taxable income after tax reliefs and before allowances
-  - Mean: 19,260.9
-  - Median: 11,350.9
-  - Stddev: 64,376.0
-  - Non-zero count: 47,333,046.1043514
+  - Description: Education grants
+  - Mean: 41.2
+  - Median: 0.0
+  - Stddev: 669.0
+  - Non-zero count: 548,046.9269714355
 
 
 - trading_loss:
   - Type: float
   - Entity: person
-  - Description: Loss from trading in the current year.
-  - Mean: 0.0
+  - Description: Student loans
+  - Mean: 186.9
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 1,384.9000244140625
+  - Non-zero count: 1,195,401.8905029297
 
 
 - dividend_income:
   - Type: float
   - Entity: person
-  - Description: Income from dividends
-  - Mean: 1,166.8
+  - Description: Student payments
+  - Mean: 48.1
   - Median: 0.0
-  - Stddev: 51,290.0
-  - Non-zero count: 4,138,236.9688646197
+  - Stddev: 718.5999755859375
+  - Non-zero count: 661,800.7219238281
 
 
 - employment_income:
   - Type: float
   - Entity: person
-  - Description: Employment income
-  - Mean: 13,069.4
+  - Description: Severe Disablement Allowance (reported)
+  - Mean: 0.2
   - Median: 0.0
-  - Stddev: 23,191.599609375
-  - Non-zero count: 30,225,843.990287572
+  - Stddev: 50.5
+  - Non-zero count: 2,307.4921264648438
 
 
 - pension_income:
   - Type: float
   - Entity: person
-  - Description: Pension income
-  - Mean: 1,102.0
+  - Description: Severe Disablement Allowance
+  - Mean: 0.2
   - Median: 0.0
-  - Stddev: 4,881.5
-  - Non-zero count: 9,301,682.557232678
+  - Stddev: 55.70000076293945
+  - Non-zero count: 2,307.4921264648438
 
 
 - property_income:
   - Type: float
   - Entity: person
-  - Description: Rental income
-  - Mean: 522.1
+  - Description: Armed Forces Compensation Scheme
+  - Mean: 3.8
   - Median: 0.0
-  - Stddev: 6,451.5
-  - Non-zero count: 2,547,360.87280491
+  - Stddev: 188.0
+  - Non-zero count: 62,037.4892578125
 
 
 - savings_interest_income:
   - Type: float
   - Entity: person
-  - Description: Savings interest income
-  - Mean: 115.8
+  - Description: Armed Forces Compensation Scheme (reported)
+  - Mean: 3.8
   - Median: 0.0
-  - Stddev: 1,136.0
-  - Non-zero count: 22,247,425.56127006
+  - Stddev: 188.0
+  - Non-zero count: 62,037.4892578125
 
 
 - self_employment_income:
   - Type: float
-  - Entity: person
-  - Description: Self-employment income
-  - Mean: 1,552.4
+  - Entity: benunit
+  - Description: Amount of Jobseeker's Allowance for this family
+  - Mean: 8.3
   - Median: 0.0
-  - Stddev: 29,289.69921875
-  - Non-zero count: 4,175,640.6977385283
+  - Stddev: 213.3000030517578
+  - Non-zero count: 74,404.14653015137
 
 
 - social_security_income:
   - Type: float
-  - Entity: person
-  - Description: Income from social security for tax purposes
-  - Mean: 1,672.9
+  - Entity: benunit
+  - Description: JSA (income-based)
+  - Mean: 5.8
   - Median: 0.0
-  - Stddev: 3,762.5
-  - Non-zero count: 13,748,469.413428724
+  - Stddev: 187.5
+  - Non-zero count: 50,326.67984008789
 
 
 - total_pension_income:
   - Type: float
-  - Entity: person
-  - Description: Total pension income
-  - Mean: 2,710.9
+  - Entity: benunit
+  - Description: Maximum amount of JSA (income-based)
+  - Mean: 6.0
   - Median: 0.0
-  - Stddev: 7,293.5
-  - Non-zero count: 14,335,566.632000625
+  - Stddev: 194.8000030517578
+  - Non-zero count: 50,326.67984008789
 
 
 - allowances:
   - Type: float
-  - Entity: person
-  - Description: Allowances applicable to adjusted net income
-  - Mean: 12,409.1
-  - Median: 12,570.0
-  - Stddev: 1,426.5999755859375
-  - Non-zero count: 66,562,754.78077945
+  - Entity: benunit
+  - Description: Relevant income for JSA (income-based) means test
+  - Mean: 25,328.1
+  - Median: 18,520.9
+  - Stddev: 25,272.30078125
+  - Non-zero count: 32,481,456.446077347
 
 
 - blind_persons_allowance:
@@ -2918,57 +3227,77 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Non-zero count: 50,326.67984008789
 
 
 - charitable_investment_gifts:
   - Type: float
   - Entity: person
-  - Description: Gifts of qualifying investment or property to charities
+  - Description: JSA (income-based) (reported amount)
+  - Mean: 10.7
+  - Median: 0.0
+  - Stddev: 201.39999389648438
+  - Non-zero count: 184,292.96328735352
+
+
+- would_claim_JSA:
+  - Type: bool
+  - Entity: benunit
+  - Description: Would claim income-based JSA
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 184,292.96328735352
 
 
 - covenanted_payments:
   - Type: float
   - Entity: person
-  - Description: Covenanted payments to charities
-  - Mean: 0.0
+  - Description: JSA (contribution-based)
+  - Mean: 1.4
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 74.5
+  - Non-zero count: 24,077.466690063477
 
 
 - dividend_allowance:
   - Type: float
   - Entity: person
-  - Description: Dividend allowance for the person
-  - Mean: 2,000.0
-  - Median: 2,000.0
-  - Stddev: 0.0
-  - Non-zero count: 67,239,322.06306267
+  - Description: Job Seeker's Allowance (contribution-based) (reported)
+  - Mean: 1.4
+  - Median: 0.0
+  - Stddev: 74.5
+  - Non-zero count: 24,077.466690063477
 
 
 - gift_aid:
   - Type: float
-  - Entity: person
-  - Description: Expenditure under Gift Aid
+  - Entity: benunit
+  - Description: ESA (income-based)
+  - Mean: 143.9
+  - Median: 0.0
+  - Stddev: 652.7000122070312
+  - Non-zero count: 485,548.13566589355
+
+
+- ESA_income_eligible:
+  - Type: bool
+  - Entity: benunit
+  - Description: ESA (income) eligible
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 485,548.13566589355
 
 
 - married_couples_allowance:
   - Type: float
   - Entity: person
-  - Description: Married Couples' allowance for the year
-  - Mean: 0.0
+  - Description: ESA (income-based) (reported amount)
+  - Mean: 79.2
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 471.3999938964844
+  - Non-zero count: 582,417.4403533936
 
 
 - married_couples_allowance_deduction:
@@ -2977,8 +3306,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Deduction from Married Couples' allowance for the year
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 485,548.13566589355
 
 
 - other_deductions:
@@ -2987,28 +3316,28 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: All other tax deductions
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 485,548.13566589355
 
 
 - pension_annual_allowance:
   - Type: float
-  - Entity: person
-  - Description: Annual Allowance for pension contributions
-  - Mean: 39,899.1
-  - Median: 40,000.0
-  - Stddev: 2,150.800048828125
-  - Non-zero count: 67,239,322.06306267
+  - Entity: household
+  - Description: Winter Fuel Allowance
+  - Mean: 77.4
+  - Median: 0.0
+  - Stddev: 116.0999984741211
+  - Non-zero count: 10,435,144.914662361
 
 
 - personal_allowance:
   - Type: float
   - Entity: person
-  - Description: Personal Allowance for the year
-  - Mean: 12,409.1
-  - Median: 12,570.0
-  - Stddev: 1,426.5999755859375
-  - Non-zero count: 66,562,754.78077945
+  - Description: Winter fuel allowance
+  - Mean: 36.4
+  - Median: 0.0
+  - Stddev: 81.69999694824219
+  - Non-zero count: 13,187,231.866094828
 
 
 - property_allowance:
@@ -3023,52 +3352,62 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - property_allowance_deduction:
   - Type: float
+  - Entity: benunit
+  - Description: Universal Credit limited capability for work-related-activity element
+  - Mean: 421.6
+  - Median: 0.0
+  - Stddev: 1,232.4000244140625
+  - Non-zero count: 3,355,690.3569927216
+
+
+- UC_MIF_applies:
+  - Type: bool
   - Entity: person
   - Description: Deduction applied by the property allowance
   - Mean: 33.7
   - Median: 0.0
-  - Stddev: 206.89999389648438
-  - Non-zero count: 2,547,360.87280491
+  - Stddev: 0.3
+  - Non-zero count: 4,633,176.941186905
 
 
 - savings_allowance:
   - Type: float
   - Entity: person
-  - Description: Savings Allowance for the year
-  - Mean: 962.8
-  - Median: 1,000.0
-  - Stddev: 151.3000030517578
-  - Non-zero count: 66,780,442.63740644
+  - Description: Universal Credit gross earned income (incl. MIF)
+  - Mean: 14,704.5
+  - Median: 1,742.1
+  - Stddev: 25,114.80078125
+  - Non-zero count: 36,720,211.65680742
 
 
 - trading_allowance:
   - Type: float
-  - Entity: person
-  - Description: Trading Allowance for the year
-  - Mean: 1,000.0
-  - Median: 1,000.0
-  - Stddev: 0.0
-  - Non-zero count: 67,239,322.06306267
+  - Entity: benunit
+  - Description: Universal Credit carer element
+  - Mean: 35.4
+  - Median: 0.0
+  - Stddev: 251.0
+  - Non-zero count: 666,621.905736208
 
 
 - trading_allowance_deduction:
   - Type: float
-  - Entity: person
-  - Description: Deduction applied by the trading allowance
-  - Mean: 47.6
+  - Entity: benunit
+  - Description: Universal Credit child element
+  - Mean: 1,112.5
   - Median: 0.0
-  - Stddev: 618.4000244140625
-  - Non-zero count: 4,175,640.6977385283
+  - Stddev: 2,331.10009765625
+  - Non-zero count: 8,585,806.073300123
 
 
 - marriage_allowance:
   - Type: float
-  - Entity: person
-  - Description: Marriage Allowance for the year (a tax-reducer, rather than an allowance or tax relief)
-  - Mean: 159.9
+  - Entity: benunit
+  - Description: Universal Credit childcare element
+  - Mean: 144.8
   - Median: 0.0
-  - Stddev: 401.5
-  - Non-zero count: 8,945,638.722113729
+  - Stddev: 1,005.4000244140625
+  - Non-zero count: 1,543,645.602141142
 
 
 - meets_marriage_allowance_income_conditions:
@@ -3077,198 +3416,224 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Meets Marriage Allowance income conditions
   - Mean: 0.9
   - Median: 1.0
-  - Stddev: 0.3
-  - Non-zero count: 62,690,906.34895021
+  - Stddev: 0.5
+  - Non-zero count: 23,253,274.75121045
+
+
+- UC_claimant_type:
+  - Type: Categorical
+  - Entity: benunit
+  - Description: UC claimant type
 
 
 - partners_unused_personal_allowance:
   - Type: float
-  - Entity: person
-  - Description: Partner's unused personal allowance
-  - Mean: 198.6
+  - Entity: benunit
+  - Description: Universal Credit disability elements
+  - Mean: 447.4
   - Median: 0.0
-  - Stddev: 5,374.60009765625
-  - Non-zero count: 14,315,381.732912183
+  - Stddev: 1,278.699951171875
+  - Non-zero count: 3,355,690.3569927216
 
 
 - unused_personal_allowance:
   - Type: float
-  - Entity: person
-  - Description: Unused personal allowance
-  - Mean: 5,067.0
-  - Median: 1,521.8
-  - Stddev: 5,453.7001953125
-  - Non-zero count: 35,709,986.01497379
+  - Entity: benunit
+  - Description: Universal Credit earned income (after disregards and tax)
+  - Mean: 18,369.8
+  - Median: 11,215.4
+  - Stddev: 23,646.0
+  - Non-zero count: 25,029,350.629741907
 
 
 - CB_HITC:
   - Type: float
-  - Entity: person
-  - Description: Child Benefit High-Income Tax Charge
-  - Mean: 30.4
+  - Entity: benunit
+  - Description: Universal Credit housing costs element
+  - Mean: 1,294.9
   - Median: 0.0
-  - Stddev: 221.8000030517578
-  - Non-zero count: 1,456,776.7904271185
+  - Stddev: 2,800.5
+  - Non-zero count: 9,119,510.319523811
 
 
 - ebr_energy_bills_credit:
   - Type: float
-  - Entity: household
-  - Description: Energy bills credit (EBR)
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Entity: benunit
+  - Description: Reduction from income for Universal Credit
+  - Mean: 15,195.0
+  - Median: 9,598.8
+  - Stddev: 76,870.1015625
+  - Non-zero count: 31,372,666.654190063
 
 
 - ebr_council_tax_rebate:
   - Type: float
-  - Entity: household
-  - Description: Council Tax Rebate (EBR)
-  - Mean: 0.0
+  - Entity: person
+  - Description: Universal Credit child element
+  - Mean: 612.7
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 1,247.5
+  - Non-zero count: 13,246,311.297644377
 
 
 - energy_bills_rebate:
   - Type: float
-  - Entity: household
-  - Description: Energy Bills Rebate
-  - Mean: 0.0
+  - Entity: person
+  - Description: Universal Credit disabled child element
+  - Mean: 5.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 46.900001525878906
+  - Non-zero count: 214,940.81065368652
 
 
 - bi_phaseout:
   - Type: float
   - Entity: person
-  - Description: Basic income phase-out
-  - Mean: 0.0
+  - Description: Universal Credit non-dependent deduction (individual)
+  - Mean: 437.5
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 453.1000061035156
+  - Non-zero count: 32,391,352.044723272
 
 
 - basic_income:
   - Type: float
   - Entity: person
-  - Description: Basic income
-  - Mean: 0.0
+  - Description: Universal Credit severely disabled child element
+  - Mean: 9.3
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 115.19999694824219
+  - Non-zero count: 128,995.05627441406
 
 
 - bi_maximum:
   - Type: float
-  - Entity: person
-  - Description: Basic income before phase-outs
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Entity: benunit
+  - Description: Maximum Universal Credit amount
+  - Mean: 7,844.9
+  - Median: 6,118.9
+  - Stddev: 4,866.10009765625
+  - Non-zero count: 36,885,914.79991722
 
 
 - main_residence_value:
   - Type: float
-  - Entity: household
-  - Description: Main residence value
-  - Mean: 225,958.1
-  - Median: 149,000.0
-  - Stddev: 310,853.8125
-  - Non-zero count: 18,107,816.797572345
+  - Entity: benunit
+  - Description: Maximum Universal Credit childcare element
+  - Mean: 8,381.6
+  - Median: 7,756.2
+  - Stddev: 1,829.699951171875
+  - Non-zero count: 36,955,812.870046616
 
 
 - non_residential_property_value:
   - Type: float
-  - Entity: household
-  - Description: Non-residential property value
-  - Mean: 10,070.0
+  - Entity: person
+  - Description: Minimum Income Floor
+  - Mean: 14,415.5
+  - Median: 16,216.2
+  - Stddev: 3,218.800048828125
+  - Non-zero count: 67,106,864.33584666
+
+
+- UC_non_dep_deduction_exempt:
+  - Type: bool
+  - Entity: person
+  - Description: Not expected to contribute to housing costs for Universal Credit
+  - Mean: 0.1
   - Median: 0.0
-  - Stddev: 93,943.0
-  - Non-zero count: 1,144,783.5358160138
+  - Stddev: 0.3
+  - Non-zero count: 5,797,730.904467821
 
 
 - other_residential_property_value:
   - Type: float
-  - Entity: household
-  - Description: Other residence value
-  - Mean: 31,969.3
+  - Entity: benunit
+  - Description: Universal Credit non-dependent deductions
+  - Mean: 231.1
   - Median: 0.0
-  - Stddev: 137,675.296875
-  - Non-zero count: 3,602,005.252691269
+  - Stddev: 602.4000244140625
+  - Non-zero count: 5,700,014.287899017
 
 
 - property_wealth:
   - Type: float
-  - Entity: household
-  - Description: Property wealth
-  - Mean: 294,618.1
-  - Median: 172,866.9
-  - Stddev: 440,782.0
-  - Non-zero count: 19,104,571.99468538
+  - Entity: benunit
+  - Description: Universal Credit standard allowance
+  - Mean: 4,809.7
+  - Median: 3,898.1
+  - Stddev: 1,188.300048828125
+  - Non-zero count: 36,955,812.870046616
 
 
 - residential_property_value:
   - Type: float
-  - Entity: household
-  - Description: Residential property value
-  - Mean: 257,927.4
-  - Median: 156,000.0
-  - Stddev: 369,108.8125
-  - Non-zero count: 18,562,516.159478635
+  - Entity: benunit
+  - Description: Universal Credit unearned income
+  - Mean: 5,091.6
+  - Median: 0.0
+  - Stddev: 76,706.6015625
+  - Non-zero count: 17,882,429.907406807
 
 
 - corporate_tax_incidence:
   - Type: float
-  - Entity: household
-  - Description: Corporate tax incidence
+  - Entity: benunit
+  - Description: Universal Credit work allowance
+  - Mean: 1,783.2
+  - Median: 0.0
+  - Stddev: 2,760.699951171875
+  - Non-zero count: 11,358,075.536501646
+
+
+- baseline_has_universal_credit:
+  - Type: bool
+  - Entity: benunit
+  - Description: Receives Universal Credit (baseline)
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.2
+  - Non-zero count: 1,760,112.264848709
 
 
 - corporate_wealth:
   - Type: float
-  - Entity: household
-  - Description: Corporate wealth
-  - Mean: 358,571.1
-  - Median: 125,284.9
-  - Stddev: 1,371,022.375
-  - Non-zero count: 22,987,657.523749888
-
-
-- shareholding:
-  - Type: float
-  - Entity: household
-  - Description: Share in the corporate sector
-  - Mean: 0.0
+  - Entity: benunit
+  - Description: Universal Credit (baseline)
+  - Mean: 589.6
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 22,987,657.523749888
+  - Stddev: 2,448.0
+  - Non-zero count: 1,760,112.264848709
 
 
-- total_wealth:
-  - Type: float
-  - Entity: household
-  - Description: Total wealth
-  - Mean: 653,189.3
-  - Median: 347,640.9
-  - Stddev: 1,527,302.625
-  - Non-zero count: 25,060,300.119156778
+- is_UC_eligible:
+  - Type: bool
+  - Entity: benunit
+  - Description: Universal Credit eligible
+  - Mean: 0.7
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 27,565,529.92134452
 
 
-- gross_financial_wealth:
-  - Type: float
-  - Entity: household
-  - Description: Gross financial wealth
-  - Mean: 189,541.6
-  - Median: 30,026.9
-  - Stddev: 1,068,570.375
-  - Non-zero count: 27,657,035.614601314
+- is_UC_work_allowance_eligible:
+  - Type: bool
+  - Entity: benunit
+  - Description: Family receives a Universal Credit Work Allowance
+  - Mean: 0.3
+  - Median: 0.0
+  - Stddev: 0.5
+  - Non-zero count: 11,358,075.536501646
+
+
+- is_child_born_before_child_limit:
+  - Type: bool
+  - Entity: person
+  - Description: Born before child limit (exempt)
+  - Mean: 0.1
+  - Median: 0.0
+  - Stddev: 0.4
+  - Non-zero count: 9,240,603.779997587
 
 
 - net_financial_wealth:
@@ -3283,62 +3648,62 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - corporate_land_value:
   - Type: float
-  - Entity: household
-  - Description: Land value
-  - Mean: 61,560.6
-  - Median: 21,509.3
-  - Stddev: 235,381.40625
-  - Non-zero count: 22,987,657.523749888
+  - Entity: benunit
+  - Description: Legacy benefits
+  - Mean: 806.8
+  - Median: 0.0
+  - Stddev: 2,072.89990234375
+  - Non-zero count: 4,598,995.6716918945
 
 
-- household_land_value:
-  - Type: float
-  - Entity: household
-  - Description: Land value
-  - Mean: 162,861.4
-  - Median: 89,639.2
-  - Stddev: 304,490.0
-  - Non-zero count: 19,276,742.931046695
+- limited_capability_for_WRA:
+  - Type: bool
+  - Entity: person
+  - Description: Assessed to have limited capability for work-related activity
+  - Mean: 0.1
+  - Median: 0.0
+  - Stddev: 0.2
+  - Non-zero count: 3,778,370.4700603485
 
 
-- land_value:
-  - Type: float
-  - Entity: household
-  - Description: Land value
-  - Mean: 224,422.0
-  - Median: 123,770.0
-  - Stddev: 415,958.40625
-  - Non-zero count: 25,128,531.11282438
+- num_UC_eligible_children:
+  - Type: int
+  - Entity: benunit
+  - Description: Children eligible for Universal Credit
+  - Mean: 0.4
+  - Median: 0.0
+  - Stddev: 0.8
+  - Non-zero count: 8,585,806.073300123
 
 
 - owned_land:
   - Type: float
-  - Entity: household
-  - Description: Owned land
-  - Mean: 11,950.9
+  - Entity: benunit
+  - Description: Universal Credit
+  - Mean: 1,182.4
   - Median: 0.0
-  - Stddev: 151,052.59375
-  - Non-zero count: 1,170,859.0618499517
+  - Stddev: 3,056.10009765625
+  - Non-zero count: 5,230,973.332187414
 
 
 - age:
   - Type: int
   - Entity: person
-  - Description: Age
-  - Mean: 39.1
-  - Median: 39.0
-  - Stddev: 23.5
-  - Non-zero count: 66,488,837.18433237
+  - Description: Universal Credit (reported)
+  - Mean: 285.3
+  - Median: 0.0
+  - Stddev: 1,700.5999755859375
+  - Non-zero count: 2,094,830.138332367
 
 
 - age_18_64:
   - Type: bool
-  - Entity: person
-  - Description: Whether the person is age 18 to 64
-  - Mean: 0.6
+  - Entity: benunit
+  - Description: Would claim Universal Credit
+  - Mean: 0.8
   - Median: 1.0
-  - Stddev: 0.5
-  - Non-zero count: 40,036,183.23662686
+  - Stddev: 0.4
+  - Non-zero count: 27,759,867.298994303
 
 
 - age_over_64:
@@ -3347,56 +3712,68 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Whether the person is over age 64
   - Mean: 0.2
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 12,445,041.232886732
+  - Stddev: 0.1
+  - Non-zero count: 173,636.80599975586
 
 
-- age_under_18:
-  - Type: bool
-  - Entity: person
-  - Description: Whether the person is under age 18
-  - Mean: 0.2
+- baseline_income_support:
+  - Type: float
+  - Entity: benunit
+  - Description: Income Support (baseline)
+  - Mean: 20.5
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 14,758,097.593549073
+  - Stddev: 454.70001220703125
+  - Non-zero count: 173,636.80599975586
 
 
-- birth_year:
-  - Type: int
-  - Entity: person
-  - Description: The birth year of the person
-  - Mean: 1,982.9
-  - Median: 1,983.0
-  - Stddev: 23.5
-  - Non-zero count: 67,239,322.06306267
+- income_support:
+  - Type: float
+  - Entity: benunit
+  - Description: Income Support
+  - Mean: 20.5
+  - Median: 0.0
+  - Stddev: 454.70001220703125
+  - Non-zero count: 173,636.80599975586
 
 
-- child_index:
-  - Type: int
-  - Entity: person
-  - Description: Child reference number
-  - Mean: 78.4
-  - Median: 100.0
-  - Stddev: 39.4
-  - Non-zero count: 67,239,322.06306267
+- income_support_applicable_amount:
+  - Type: float
+  - Entity: benunit
+  - Description: Applicable amount of Income Support
+  - Mean: 31.0
+  - Median: 0.0
+  - Stddev: 620.5999755859375
+  - Non-zero count: 182,799.86721801758
 
 
-- current_education:
-  - Type: Categorical
-  - Entity: person
-  - Description: Current education
+- income_support_applicable_income:
+  - Type: float
+  - Entity: benunit
+  - Description: Relevant income for Income Support means test
+  - Mean: 25,328.1
+  - Median: 18,520.9
+  - Stddev: 25,272.30078125
+  - Non-zero count: 32,481,456.446077347
 
 
-- gender:
-  - Type: Categorical
-  - Entity: person
-  - Description: Gender of the person
+- income_support_eligible:
+  - Type: bool
+  - Entity: benunit
+  - Description: Whether eligible for Income Support
+  - Mean: 0.0
+  - Median: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 182,799.86721801758
 
 
 - highest_education:
   - Type: Categorical
   - Entity: person
-  - Description: Highest status education completed
+  - Description: Income Support (reported amount)
+  - Mean: 21.9
+  - Median: 0.0
+  - Stddev: 294.1000061035156
+  - Non-zero count: 363,698.2680358887
 
 
 - in_FE:
@@ -3406,7 +3783,7 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Non-zero count: 36,955,812.870046616
 
 
 - in_HE:
@@ -3415,18 +3792,18 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: In higher education
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 769,238.6797790527
 
 
-- in_social_housing:
-  - Type: bool
-  - Entity: person
-  - Description: Whether this person lives in social housing
-  - Mean: 0.2
+- baseline_pension_credit:
+  - Type: float
+  - Entity: benunit
+  - Description: Pension Credit (baseline)
+  - Mean: 79.6
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 10,230,321.239154816
+  - Stddev: 694.9000244140625
+  - Non-zero count: 769,238.6797790527
 
 
 - is_WA_adult:
@@ -3436,27 +3813,47 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.6
   - Median: 1.0
   - Stddev: 0.5
-  - Non-zero count: 40,987,472.7695055
+  - Non-zero count: 26,258,702.797803402
+
+
+- pension_credit_income:
+  - Type: float
+  - Entity: benunit
+  - Description: Income for Pension Credit
+  - Mean: 37,231.4
+  - Median: 23,920.0
+  - Stddev: 89,633.203125
+  - Non-zero count: 32,548,692.06708145
 
 
 - is_adult:
   - Type: bool
   - Entity: person
-  - Description: Whether this person is an adult
-  - Mean: 0.8
-  - Median: 1.0
-  - Stddev: 0.4
-  - Non-zero count: 52,481,224.469513595
+  - Description: Pension Credit (reported)
+  - Mean: 52.6
+  - Median: 0.0
+  - Stddev: 521.7999877929688
+  - Non-zero count: 991,504.1554584503
 
 
 - is_benunit_eldest_child:
   - Type: bool
-  - Entity: person
-  - Description: Eldest child in the benefit unit
-  - Mean: 0.1
+  - Entity: benunit
+  - Description: Eligible for Pension Credit
+  - Mean: 0.3
   - Median: 0.0
-  - Stddev: 0.3
-  - Non-zero count: 7,885,940.911652118
+  - Stddev: 0.5
+  - Non-zero count: 9,662,355.082067728
+
+
+- pension_credit:
+  - Type: float
+  - Entity: benunit
+  - Description: Pension Credit
+  - Mean: 135.1
+  - Median: 0.0
+  - Stddev: 890.4000244140625
+  - Non-zero count: 1,710,732.5964126587
 
 
 - is_benunit_head:
@@ -3465,8 +3862,28 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Whether this person is the head-of-family
   - Mean: 0.5
   - Median: 1.0
-  - Stddev: 0.5
-  - Non-zero count: 36,144,140.87005857
+  - Stddev: 0.3
+  - Non-zero count: 31,984,025.785312653
+
+
+- savings_credit:
+  - Type: float
+  - Entity: benunit
+  - Description: Savings Credit
+  - Mean: 125.3
+  - Median: 0.0
+  - Stddev: 600.2999877929688
+  - Non-zero count: 3,831,417.858390808
+
+
+- savings_credit_income:
+  - Type: float
+  - Entity: benunit
+  - Description: Income for Savings Credit
+  - Mean: 37,159.0
+  - Median: 23,920.0
+  - Stddev: 89,652.0
+  - Non-zero count: 32,316,419.661655426
 
 
 - is_child:
@@ -3476,73 +3893,97 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.2
   - Median: 0.0
   - Stddev: 0.4
-  - Non-zero count: 14,758,097.593549073
+  - Non-zero count: 10,001,110.31248188
 
 
-- is_eldest_child:
-  - Type: bool
-  - Entity: person
-  - Description: Is the eldest child
-  - Mean: 0.1
+- guarantee_credit:
+  - Type: float
+  - Entity: benunit
+  - Description: Guarantee Credit
+  - Mean: 2,233.5
   - Median: 0.0
-  - Stddev: 0.3
-  - Non-zero count: 8,443,678.907532245
+  - Stddev: 4,139.2001953125
+  - Non-zero count: 10,001,110.31248188
 
 
-- is_female:
-  - Type: bool
-  - Entity: person
-  - Description: Whether the person is female
-  - Mean: 0.5
-  - Median: 1.0
-  - Stddev: 0.5
-  - Non-zero count: 33,959,705.423692435
+- minimum_guarantee:
+  - Type: float
+  - Entity: benunit
+  - Description: Minimum Guarantee
+  - Mean: 12,755.5
+  - Median: 12,708.8
+  - Stddev: 3,850.800048828125
+  - Non-zero count: 36,955,812.870046616
 
 
-- is_household_head:
-  - Type: bool
-  - Entity: person
-  - Description: Whether this person is the head-of-household
-  - Mean: 0.4
+- standard_minimum_guarantee:
+  - Type: float
+  - Entity: benunit
+  - Description: Standard Minimum Guarantee
+  - Mean: 11,466.5
+  - Median: 9,209.2
+  - Stddev: 2,422.199951171875
+  - Non-zero count: 36,955,812.870046616
+
+
+- severe_disability_minimum_guarantee_addition:
+  - Type: float
+  - Entity: benunit
+  - Description: Severe disability-related increase
+  - Mean: 281.8
   - Median: 0.0
-  - Stddev: 0.5
-  - Non-zero count: 28,554,269.10323161
+  - Stddev: 984.4000244140625
+  - Non-zero count: 2,765,413.3859882355
 
 
-- is_male:
-  - Type: bool
-  - Entity: person
-  - Description: Whether the person is male
-  - Mean: 0.5
+- additional_minimum_guarantee:
+  - Type: float
+  - Entity: benunit
+  - Description: Additional Minimum Guarantee
+  - Mean: 1,289.0
   - Median: 0.0
-  - Stddev: 0.5
-  - Non-zero count: 33,279,616.639370233
+  - Stddev: 2,470.199951171875
+  - Non-zero count: 10,863,037.356937408
 
 
-- is_older_child:
-  - Type: bool
-  - Entity: person
-  - Description: Whether the person is over 14 but under 18
-  - Mean: 0.0
+- child_minimum_guarantee_addition:
+  - Type: float
+  - Entity: benunit
+  - Description: Child-related addition
+  - Mean: 971.6
   - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 3,335,915.4918804467
+  - Stddev: 2,353.199951171875
+  - Non-zero count: 7,626,600.520817518
+
+
+- carer_minimum_guarantee_addition:
+  - Type: float
+  - Entity: benunit
+  - Description: Carer-related increase
+  - Mean: 35.6
+  - Median: 0.0
+  - Stddev: 255.0
+  - Non-zero count: 666,621.905736208
 
 
 - is_young_child:
   - Type: bool
   - Entity: person
-  - Description: Whether the person is under 14
-  - Mean: 0.2
+  - Description: DLA (mobility) (reported)
+  - Mean: 36.6
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 11,422,182.101668626
+  - Stddev: 321.79998779296875
+  - Non-zero count: 949,239.9902820587
 
 
 - marital_status:
   - Type: Categorical
   - Entity: person
-  - Description: Marital status
+  - Description: DLA (mobility)
+  - Mean: 36.0
+  - Median: 0.0
+  - Stddev: 314.8999938964844
+  - Non-zero count: 949,239.9902820587
 
 
 - over_16:
@@ -3558,31 +3999,31 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - people:
   - Type: float
   - Entity: person
-  - Description: Variable holding people
-  - Mean: 1.0
-  - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 67,239,322.06306267
+  - Description: Disability Living Allowance
+  - Mean: 89.1
+  - Median: 0.0
+  - Stddev: 699.7000122070312
+  - Non-zero count: 1,245,492.075510025
 
 
 - person_id:
   - Type: int
   - Entity: person
-  - Description: ID for the person
-  - Mean: 96,031,862.3
-  - Median: 95,917,161.3
-  - Stddev: 55,233,272.5
-  - Non-zero count: 67,239,322.06306267
+  - Description: DLA (self-care) (reported)
+  - Mean: 52.1
+  - Median: 0.0
+  - Stddev: 445.70001220703125
+  - Non-zero count: 1,090,476.8275852203
 
 
 - person_weight:
   - Type: float
   - Entity: person
-  - Description: Weight
-  - Mean: 2,118.4
-  - Median: 1,853.2
-  - Stddev: 1,051.9000244140625
-  - Non-zero count: 67,239,322.06306267
+  - Description: DLA (self-care)
+  - Mean: 53.0
+  - Median: 0.0
+  - Stddev: 450.6000061035156
+  - Non-zero count: 1,090,476.8275852203
 
 
 - raw_person_weight:
@@ -3598,33 +4039,41 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - person_benunit_id:
   - Type: float
   - Entity: person
-  - Description: Person's benefit unit ID
-  - Mean: 96,031,658.1
-  - Median: 95,916,971.8
-  - Stddev: 55,233,272.0
-  - Non-zero count: 67,239,322.06306267
+  - Description: Receives at least middle-rate DLA (self-care)
+  - Mean: 0.0
+  - Median: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 826,984.6907215118
 
 
 - person_benunit_role:
   - Type: Categorical
   - Entity: person
-  - Description: Role (adult/child)
+  - Description: Receives the highest DLA (self-care) category
+  - Mean: 0.0
+  - Median: 0.0
+  - Stddev: 0.1
+  - Non-zero count: 424,565.89055633545
 
 
 - person_household_id:
   - Type: float
   - Entity: person
-  - Description: Person's household ID
-  - Mean: 96,030,486.9
-  - Median: 95,915,524.2
-  - Stddev: 55,233,272.0
-  - Non-zero count: 67,239,322.06306267
+  - Description: Disability Living Allowance (mobility) (reported)
+  - Mean: 65.8
+  - Median: 0.0
+  - Stddev: 359.79998779296875
+  - Non-zero count: 1,878,085.1819343567
 
 
 - person_household_role:
   - Type: Categorical
   - Entity: person
-  - Description: Role (adult/child)
+  - Description: PIP (mobility)
+  - Mean: 65.1
+  - Median: 0.0
+  - Stddev: 353.20001220703125
+  - Non-zero count: 1,878,085.1819343567
 
 
 - role:
@@ -3635,22 +4084,22 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - disability_premium:
   - Type: float
-  - Entity: benunit
-  - Description: Disability premium
-  - Mean: 168.8
+  - Entity: person
+  - Description: PIP (self-care) (reported)
+  - Mean: 132.0
   - Median: 0.0
-  - Stddev: 615.7999877929688
-  - Non-zero count: 2,812,444.737687111
+  - Stddev: 601.0999755859375
+  - Non-zero count: 2,380,818.1600227356
 
 
 - enhanced_disability_premium:
   - Type: float
-  - Entity: benunit
-  - Description: Enhanced disability premium
-  - Mean: 10.3
+  - Entity: person
+  - Description: PIP (daily living)
+  - Mean: 135.0
   - Median: 0.0
-  - Stddev: 113.30000305175781
-  - Non-zero count: 349,318.2344055176
+  - Stddev: 614.4000244140625
+  - Non-zero count: 2,380,818.1600227356
 
 
 - is_disabled_for_benefits:
@@ -3670,57 +4119,57 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.1
-  - Non-zero count: 355,189.04092407227
+  - Non-zero count: 1,058,675.3026924133
 
 
 - is_severely_disabled_for_benefits:
   - Type: bool
   - Entity: person
-  - Description: Has a severe disability
-  - Mean: 0.0
+  - Description: Personal Independence Payment
+  - Mean: 200.1
   - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 1,220,639.2119369507
+  - Stddev: 916.2000122070312
+  - Non-zero count: 2,537,686.4105415344
 
 
-- num_disabled_adults:
-  - Type: int
-  - Entity: benunit
-  - Description: Number of disabled adults
-  - Mean: 0.1
+- baseline_corporate_sdlt:
+  - Type: float
+  - Entity: household
+  - Description: Stamp Duty (corporations, baseline)
+  - Mean: 85.2
+  - Median: 1.3
+  - Stddev: 430.29998779296875
+  - Non-zero count: 17,346,084.671941757
+
+
+- baseline_expected_sdlt:
+  - Type: float
+  - Entity: household
+  - Description: Stamp Duty (expected, baseline)
+  - Mean: 298.9
+  - Median: 35.1
+  - Stddev: 934.2999877929688
+  - Non-zero count: 20,894,046.65194416
+
+
+- change_in_expected_sdlt:
+  - Type: float
+  - Entity: household
+  - Description: Change in expected Stamp Duty
+  - Mean: -0.2
   - Median: 0.0
-  - Stddev: 0.3
-  - Non-zero count: 2,812,444.737687111
+  - Stddev: 42.79999923706055
+  - Non-zero count: 1,264,781.4996767044
 
 
-- num_disabled_children:
-  - Type: int
-  - Entity: benunit
-  - Description: Number of disabled children
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 14,319.2021484375
-
-
-- num_enhanced_disabled_adults:
-  - Type: int
-  - Entity: benunit
-  - Description: Number of enhanced disabled adults
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 349,318.2344055176
-
-
-- num_enhanced_disabled_children:
-  - Type: int
-  - Entity: benunit
-  - Description: Number of enhanced disabled children
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+- corporate_sdlt:
+  - Type: float
+  - Entity: household
+  - Description: Stamp Duty (corporations)
+  - Mean: 85.2
+  - Median: 1.3
+  - Stddev: 430.29998779296875
+  - Non-zero count: 17,346,084.671941757
 
 
 - num_severely_disabled_adults:
@@ -3740,17 +4189,17 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
-  - Non-zero count: 8,002.5015869140625
+  - Non-zero count: 0.0
 
 
 - severe_disability_premium:
   - Type: float
-  - Entity: benunit
-  - Description: Severe disability premium
-  - Mean: 164.5
-  - Median: 0.0
-  - Stddev: 978.0
-  - Non-zero count: 1,168,353.4309158325
+  - Entity: household
+  - Description: Stamp Duty (expected)
+  - Mean: 298.6
+  - Median: 35.1
+  - Stddev: 934.4000244140625
+  - Non-zero count: 20,907,646.12324238
 
 
 - person_state_id:
@@ -3759,8 +4208,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: State ID
   - Mean: 1.0
   - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 67,239,322.06306267
+  - Stddev: 0.4
+  - Non-zero count: 27,131,105.072348595
 
 
 - person_state_role:
@@ -3769,14 +4218,14 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: State role
 
 
-- state_id:
-  - Type: int
-  - Entity: state
-  - Description: State ID
-  - Mean: 1.0
-  - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 4.0
+- sdlt_on_non_residential_property_transactions:
+  - Type: float
+  - Entity: household
+  - Description: Stamp Duty on non-residential property
+  - Mean: 63.2
+  - Median: 0.0
+  - Stddev: 1,598.0
+  - Non-zero count: 128,507.42685699463
 
 
 - state_weight:
@@ -3798,155 +4247,181 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - country:
   - Type: Categorical
   - Entity: household
-  - Description: Country of the UK
+  - Description: Stamp Duty on residential property
+  - Mean: 5,470.3
+  - Median: 0.0
+  - Stddev: 19,429.900390625
+  - Non-zero count: 12,792,319.469952583
 
 
 - household_equivalisation_ahc:
   - Type: float
   - Entity: household
-  - Description: Equivalisation factor to account for household composition, after housing costs
-  - Mean: 1.1
-  - Median: 1.0
-  - Stddev: 0.4000000059604645
-  - Non-zero count: 28,554,269.10323161
+  - Description: SDLT on property transactions
+  - Mean: 5,533.4
+  - Median: 0.0
+  - Stddev: 19,672.099609375
+  - Non-zero count: 12,795,356.303997993
 
 
 - household_equivalisation_bhc:
   - Type: float
   - Entity: household
-  - Description: Equivalisation factor to account for household composition, before housing costs
-  - Mean: 1.1
-  - Median: 1.0
-  - Stddev: 0.30000001192092896
-  - Non-zero count: 28,554,269.10323161
+  - Description: Stamp Duty Land Tax
+  - Mean: 4,862.4
+  - Median: 0.0
+  - Stddev: 17,747.400390625
+  - Non-zero count: 11,131,799.68489933
 
 
-- household_id:
-  - Type: int
-  - Entity: household
-  - Description: ID for the household
-  - Mean: 95,806,941.8
-  - Median: 95,591,175.9
-  - Stddev: 55,273,490.5
-  - Non-zero count: 28,554,269.10323161
+- baseline_child_benefit:
+  - Type: float
+  - Entity: benunit
+  - Description: Child Benefit (baseline)
+  - Mean: 243.6
+  - Median: 0.0
+  - Stddev: 680.0999755859375
+  - Non-zero count: 5,747,965.378347397
 
 
-- household_num_benunits:
-  - Type: int
-  - Entity: household
-  - Description: Number of benefit units
-  - Mean: 1.3
-  - Median: 1.0
-  - Stddev: 0.6
-  - Non-zero count: 28,554,269.10323161
+- baseline_has_child_benefit:
+  - Type: bool
+  - Entity: benunit
+  - Description: Receives Child Benefit (baseline)
+  - Mean: 0.2
+  - Median: 0.0
+  - Stddev: 0.4
+  - Non-zero count: 5,747,965.378347397
 
 
-- household_num_people:
-  - Type: int
-  - Entity: household
-  - Description: Number of people
-  - Mean: 2.4
-  - Median: 2.0
-  - Stddev: 1.3
-  - Non-zero count: 28,554,269.10323161
+- child_benefit:
+  - Type: float
+  - Entity: benunit
+  - Description: Child Benefit
+  - Mean: 304.1
+  - Median: 0.0
+  - Stddev: 721.5
+  - Non-zero count: 7,223,334.235639572
 
 
 - household_weight:
   - Type: float
-  - Entity: household
-  - Description: Weight factor for the household
-  - Mean: 2,001.2
-  - Median: 1,762.9
-  - Stddev: 992.2000122070312
-  - Non-zero count: 28,554,269.10323161
+  - Entity: benunit
+  - Description: Child Benefit (less tax charge)
+  - Mean: 253.6
+  - Median: 0.0
+  - Stddev: 668.7999877929688
+  - Non-zero count: 6,254,510.111463547
 
 
 - households:
   - Type: float
-  - Entity: household
-  - Description: Variable holding households
-  - Mean: 1.0
-  - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 28,554,269.10323161
-
-
-- is_renting:
-  - Type: bool
-  - Entity: household
-  - Description: Is renting
-  - Mean: 0.3
+  - Entity: person
+  - Description: Child Benefit (reported amount)
+  - Mean: 145.4
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 7,380,751.182626694
+  - Stddev: 522.0999755859375
+  - Non-zero count: 6,303,536.9667339325
+
+
+- child_benefit_respective_amount:
+  - Type: float
+  - Entity: person
+  - Description: Child Benefit (respective amount)
+  - Mean: 176.7
+  - Median: 0.0
+  - Stddev: 382.29998779296875
+  - Non-zero count: 12,633,341.866535902
 
 
 - is_shared_accommodation:
   - Type: bool
+  - Entity: benunit
+  - Description: Would claim Child Benefit
+  - Mean: 0.8
+  - Median: 1.0
+  - Stddev: 0.4
+  - Non-zero count: 29,790,937.809260845
+
+
+- num_bedrooms:
+  - Type: int
   - Entity: household
-  - Description: Whether the household is shared accommodation
+  - Description: Baseline business rates incidence
+  - Mean: 864.1
+  - Median: 12.8
+  - Stddev: 4,362.60009765625
+  - Non-zero count: 17,346,084.671941757
+
+
+- ons_tenure_type:
+  - Type: Categorical
+  - Entity: household
+  - Description: Business rates incidence
+  - Mean: 864.1
+  - Median: 12.8
+  - Stddev: 4,362.60009765625
+  - Non-zero count: 17,346,084.671941757
+
+
+- region:
+  - Type: Categorical
+  - Entity: household
+  - Description: Business rates changes
   - Mean: 0.0
   - Median: 0.0
   - Stddev: 0.0
   - Non-zero count: 0.0
 
 
-- num_bedrooms:
-  - Type: int
-  - Entity: household
-  - Description: The number of bedrooms in the house
-  - Mean: 2.8
-  - Median: 3.0
-  - Stddev: 1.0
-  - Non-zero count: 28,554,269.10323161
-
-
-- ons_tenure_type:
-  - Type: Categorical
-  - Entity: household
-  - Description: ONS tenure type
-
-
-- region:
-  - Type: Categorical
-  - Entity: household
-  - Description: Region
-
-
 - tenure_type:
   - Type: Categorical
   - Entity: household
-  - Description: Tenure type of the household
+  - Description: Change in expected business rates
+  - Mean: 0.0
+  - Median: 0.0
+  - Stddev: 0.0
+  - Non-zero count: 0.0
 
 
 - benunit_has_carer:
   - Type: bool
   - Entity: benunit
-  - Description: Benefit unit has a carer
-  - Mean: 0.0
-  - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 584,523.5082798004
+  - Description: Benefit unit tax paid
+  - Mean: 7,117.1
+  - Median: 1,749.5
+  - Stddev: 32,181.69921875
+  - Non-zero count: 25,228,098.766114235
+
+
+- household_tax:
+  - Type: float
+  - Entity: household
+  - Description: Taxes
+  - Mean: 9,727.8
+  - Median: 3,715.9
+  - Stddev: 34,815.8984375
+  - Non-zero count: 31,396,342.98155594
 
 
 - carer_premium:
   - Type: float
-  - Entity: benunit
-  - Description: Carer premium
-  - Mean: 31.7
+  - Entity: person
+  - Description: Taxes
+  - Mean: 3,919.4
   - Median: 0.0
-  - Stddev: 265.8999938964844
-  - Non-zero count: 584,523.5082798004
+  - Stddev: 22,374.80078125
+  - Non-zero count: 33,466,004.418924093
 
 
 - is_carer_for_benefits:
   - Type: bool
   - Entity: person
-  - Description: Whether this person is a carer for benefits purposes
-  - Mean: 0.0
+  - Description: Difference between reported and imputed tax liabilities
+  - Mean: 3,919.4
   - Median: 0.0
-  - Stddev: 0.1
-  - Non-zero count: 588,273.4450473785
+  - Stddev: 22,374.80078125
+  - Non-zero count: 33,466,004.418924093
 
 
 - num_carers:
@@ -3959,14 +4434,14 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 584,523.5082798004
 
 
-- benunit_id:
-  - Type: int
-  - Entity: benunit
-  - Description: ID for the family
-  - Mean: 95,760,560.4
-  - Median: 95,591,000.1
-  - Stddev: 55,183,478.6
-  - Non-zero count: 36,144,140.87005857
+- baseline_fuel_duty:
+  - Type: float
+  - Entity: household
+  - Description: Baseline fuel duty (cars only)
+  - Mean: 537.6
+  - Median: 374.0
+  - Stddev: 664.0999755859375
+  - Non-zero count: 20,373,827.748587847
 
 
 - benunit_is_renting:
@@ -3979,260 +4454,284 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Non-zero count: 0.0
 
 
-- benunit_tenure_type:
-  - Type: Categorical
-  - Entity: benunit
-  - Description: Tenure type of the family's household
+- fuel_duty:
+  - Type: float
+  - Entity: household
+  - Description: Fuel duty (cars only)
+  - Mean: 537.6
+  - Median: 374.0
+  - Stddev: 664.0999755859375
+  - Non-zero count: 20,373,827.748587847
 
 
 - benunit_weight:
   - Type: float
-  - Entity: benunit
-  - Description: Weight factor for the benefit unit
-  - Mean: 2,121.6
-  - Median: 1,848.9
-  - Stddev: 1,047.800048828125
-  - Non-zero count: 36,144,140.87005857
+  - Entity: person
+  - Description: Class 2 Contributions for National Insurance for the year
+  - Mean: 7.3
+  - Median: 0.0
+  - Stddev: 33.5
+  - Non-zero count: 3,072,860.927942276
 
 
 - eldest_adult_age:
   - Type: float
-  - Entity: benunit
-  - Description: Eldest adult age
-  - Mean: 47.7
-  - Median: 48.0
-  - Stddev: 19.399999618530273
-  - Non-zero count: 36,144,140.87005857
+  - Entity: person
+  - Description: Class 2 Contributions for National Insurance
+  - Mean: 7.3
+  - Median: 0.0
+  - Stddev: 33.5
+  - Non-zero count: 3,072,860.927942276
 
 
-- eldest_child_age:
-  - Type: float
-  - Entity: benunit
-  - Description: Eldest adult age
-  - Mean: nan
-  - Median: -inf
-  - Stddev: nan
-  - Non-zero count: 7,593,703.518631488
+- NI_exempt:
+  - Type: bool
+  - Entity: person
+  - Description: Exempt from National Insurance
+  - Mean: 0.4
+  - Median: 0.0
+  - Stddev: 0.5
+  - Non-zero count: 23,957,275.119980097
 
 
 - families:
   - Type: float
-  - Entity: benunit
-  - Description: Variable holding families
-  - Mean: 1.0
-  - Median: 1.0
-  - Stddev: 0.0
-  - Non-zero count: 36,144,140.87005857
-
-
-- family_type:
-  - Type: Categorical
-  - Entity: benunit
-  - Description: Family composition
-
-
-- is_married:
-  - Type: bool
-  - Entity: benunit
-  - Description: Married
-  - Mean: 0.0
+  - Entity: person
+  - Description: Employee Class 1 Contributions for National Insurance
+  - Mean: 884.2
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 1,537.4000244140625
+  - Non-zero count: 22,726,338.06562376
 
 
-- num_adults:
-  - Type: int
-  - Entity: benunit
-  - Description: The number of adults in the family
-  - Mean: 1.5
-  - Median: 1.0
-  - Stddev: 0.5
-  - Non-zero count: 35,486,478.47676328
-
-
-- num_children:
-  - Type: int
-  - Entity: benunit
-  - Description: The number of children in the family
-  - Mean: 0.4
+- employer_NI:
+  - Type: float
+  - Entity: person
+  - Description: Employer contributions to National Insurance
+  - Mean: 1,277.7
   - Median: 0.0
-  - Stddev: 0.8
-  - Non-zero count: 8,443,678.907532245
+  - Stddev: 2,801.89990234375
+  - Non-zero count: 23,258,906.319139004
 
 
-- relation_type:
-  - Type: Categorical
-  - Entity: benunit
-  - Description: Whether single or a couple
+- employer_NI_class_1:
+  - Type: float
+  - Entity: person
+  - Description: Employer Class 1 Contributions for National Insurance
+  - Mean: 1,277.7
+  - Median: 0.0
+  - Stddev: 2,801.89990234375
+  - Non-zero count: 23,258,906.319139004
+
+
+- total_NI:
+  - Type: float
+  - Entity: person
+  - Description: National Insurance (total)
+  - Mean: 2,225.2
+  - Median: 0.0
+  - Stddev: 4,235.0
+  - Non-zero count: 26,036,854.41089201
+
+
+- NI_class_4:
+  - Type: float
+  - Entity: person
+  - Description: Class 4 Contributions for National Insurance for the year
+  - Mean: 60.9
+  - Median: 0.0
+  - Stddev: 459.3999938964844
+  - Non-zero count: 2,506,895.3758335114
+
+
+- employee_NI:
+  - Type: float
+  - Entity: person
+  - Description: Employee-side National Insurance
+  - Mean: 884.2
+  - Median: 0.0
+  - Stddev: 1,537.4000244140625
+  - Non-zero count: 22,726,338.06562376
 
 
 - youngest_adult_age:
   - Type: float
-  - Entity: benunit
-  - Description: Eldest adult age
-  - Mean: 46.0
-  - Median: 45.0
-  - Stddev: 19.200000762939453
-  - Non-zero count: 36,144,140.87005857
+  - Entity: person
+  - Description: National Insurance
+  - Mean: 947.5
+  - Median: 0.0
+  - Stddev: 1,575.800048828125
+  - Non-zero count: 25,271,603.388621807
 
 
 - youngest_child_age:
   - Type: float
-  - Entity: benunit
-  - Description: Eldest adult age
-  - Mean: nan
-  - Median: inf
-  - Stddev: nan
-  - Non-zero count: 35,399,583.952204734
+  - Entity: person
+  - Description: Self-employed National Insurance
+  - Mean: 68.2
+  - Median: 0.0
+  - Stddev: 480.70001220703125
+  - Non-zero count: 3,072,860.927942276
 
 
-- BRMA:
-  - Type: Categorical
-  - Entity: household
-  - Description: Broad Rental Market Area
+- add_rate_earned_income:
+  - Type: float
+  - Entity: person
+  - Description: Earned income (non-savings, non-dividend) at the additional rate
+  - Mean: 663.8
+  - Median: 0.0
+  - Stddev: 9,966.5
+  - Non-zero count: 410,085.90745544434
 
 
-- local_authority:
-  - Type: Categorical
-  - Entity: household
-  - Description: The Local Authority for the household
+- add_rate_earned_income_tax:
+  - Type: float
+  - Entity: person
+  - Description: Income tax on earned income at the additional rate
+  - Mean: 298.7
+  - Median: 0.0
+  - Stddev: 4,484.89990234375
+  - Non-zero count: 410,085.90745544434
 
 
 - benunit_rent:
   - Type: float
-  - Entity: benunit
-  - Description: Rent
-  - Mean: 2,168.6
+  - Entity: person
+  - Description: Savings income at the higher rate
+  - Mean: 1.1
   - Median: 0.0
-  - Stddev: 3,905.60009765625
-  - Non-zero count: 11,198,118.913994372
+  - Stddev: 53.0
+  - Non-zero count: 23,043.01806640625
 
 
 - childcare_expenses:
   - Type: float
   - Entity: person
-  - Description: Cost of childcare
-  - Mean: 110.1
+  - Description: Earned income (non-savings, non-dividend) at the basic rate
+  - Mean: 7,448.1
   - Median: 0.0
-  - Stddev: 850.2000122070312
-  - Non-zero count: 2,432,410.7274161577
+  - Stddev: 11,417.7001953125
+  - Non-zero count: 30,539,953.23114562
 
 
 - council_tax:
   - Type: float
-  - Entity: household
-  - Description: Council Tax
-  - Mean: 1,378.3
-  - Median: 1,340.3
-  - Stddev: 654.0
-  - Non-zero count: 27,571,689.00710529
-
-
-- council_tax_band:
-  - Type: Categorical
-  - Entity: household
-  - Description: Council Tax Band
+  - Entity: person
+  - Description: Income tax on earned income at the basic rate
+  - Mean: 1,489.6
+  - Median: 0.0
+  - Stddev: 2,283.5
+  - Non-zero count: 30,539,953.23114562
 
 
 - council_tax_less_benefit:
   - Type: float
-  - Entity: household
-  - Description: Council Tax (less CTB)
-  - Mean: 1,253.2
-  - Median: 1,300.0
-  - Stddev: 777.0
-  - Non-zero count: 25,539,615.035176694
+  - Entity: person
+  - Description: Savings income at the basic rate
+  - Mean: 8.8
+  - Median: 0.0
+  - Stddev: 325.29998779296875
+  - Non-zero count: 98,971.5553894043
 
 
 - employer_pension_contributions:
   - Type: float
   - Entity: person
-  - Description: Employer pension contributions
-  - Mean: 0.0
+  - Description: Savings income which would otherwise be taxed at the basic rate, without the starter rate
+  - Mean: 14.6
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 342.1000061035156
+  - Non-zero count: 515,539.69273757935
 
 
 - family_rent:
   - Type: float
-  - Entity: benunit
-  - Description: Gross rent for the family
-  - Mean: 2,112.6
-  - Median: -52.0
-  - Stddev: 4,222.2001953125
-  - Non-zero count: 10,134,834.55674693
+  - Entity: person
+  - Description: Income tax on dividend income
+  - Mean: 314.3
+  - Median: 0.0
+  - Stddev: 19,739.400390625
+  - Non-zero count: 1,200,547.4918460846
 
 
 - housing_costs:
   - Type: float
-  - Entity: household
-  - Description: Total housing costs
-  - Mean: 4,209.5
-  - Median: 3,016.0
-  - Stddev: 4,576.60009765625
-  - Non-zero count: 28,446,863.455737293
+  - Entity: person
+  - Description: Income tax on earned income
+  - Mean: 2,627.1
+  - Median: 0.0
+  - Stddev: 8,822.0
+  - Non-zero count: 30,539,953.23114562
 
 
 - housing_service_charges:
   - Type: float
-  - Entity: household
-  - Description: Housing service charges
-  - Mean: 66.4
+  - Entity: person
+  - Description: Non-savings, non-dividend income for Income Tax
+  - Mean: 10,188.3
   - Median: 0.0
-  - Stddev: 355.79998779296875
-  - Non-zero count: 2,593,845.60706836
+  - Stddev: 24,750.400390625
+  - Non-zero count: 30,539,953.23114562
 
 
 - maintenance_expenses:
   - Type: float
   - Entity: person
-  - Description: Maintenance expenses
-  - Mean: 38.4
+  - Description: Earned income (non-savings, non-dividend) at the higher rate
+  - Mean: 2,076.4
   - Median: 0.0
-  - Stddev: 628.2000122070312
-  - Non-zero count: 714,935.5672094822
+  - Stddev: 11,551.2001953125
+  - Non-zero count: 4,261,847.404798031
 
 
 - mortgage:
   - Type: float
-  - Entity: household
-  - Description: Total mortgage payments
-  - Mean: 0.0
+  - Entity: person
+  - Description: Income tax on earned income at the higher rate
+  - Mean: 830.6
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 4,620.5
+  - Non-zero count: 4,261,847.404798031
 
 
 - mortgage_capital_repayment:
   - Type: float
-  - Entity: household
-  - Description: Mortgage payments
-  - Mean: 2,276.1
+  - Entity: person
+  - Description: Savings income at the higher rate
+  - Mean: 1.2
   - Median: 0.0
-  - Stddev: 6,055.60009765625
-  - Non-zero count: 8,135,845.406061083
+  - Stddev: 88.4000015258789
+  - Non-zero count: 26,399.959228515625
 
 
 - mortgage_interest_repayment:
   - Type: float
-  - Entity: household
-  - Description: Total mortgage payments
-  - Mean: 882.6
-  - Median: -52.0
-  - Stddev: 2,067.800048828125
-  - Non-zero count: 8,113,820.679307848
+  - Entity: person
+  - Description: Income Tax
+  - Mean: 2,971.9
+  - Median: 0.0
+  - Stddev: 21,972.400390625
+  - Non-zero count: 30,949,564.946080923
 
 
 - occupational_pension_contributions:
   - Type: float
   - Entity: person
-  - Description: Occupational pension contributions
-  - Mean: 452.1
+  - Description: Income Tax before any tax charges
+  - Mean: 2,944.1
   - Median: 0.0
-  - Stddev: 1,271.4000244140625
-  - Non-zero count: 18,102,369.04482028
+  - Stddev: 21,872.0
+  - Non-zero count: 30,949,564.946080923
+
+
+- is_higher_earner:
+  - Type: bool
+  - Entity: person
+  - Description: Whether this person is the highest earner in a family
+  - Mean: 0.6
+  - Median: 1.0
+  - Stddev: 0.5
+  - Non-zero count: 36,955,812.870046616
 
 
 - personal_rent:
@@ -4241,8 +4740,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Rent liable
   - Mean: 1,135.6
   - Median: 0.0
-  - Stddev: 3,318.199951171875
-  - Non-zero count: 10,134,834.55674693
+  - Stddev: 0.30000001192092896
+  - Non-zero count: 5,666,352.686532974
 
 
 - private_pension_contributions:
@@ -4251,48 +4750,54 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Private pension contributions
   - Mean: 27.5
   - Median: 0.0
-  - Stddev: 164.3000030517578
-  - Non-zero count: 2,021,003.1847229302
+  - Stddev: 82.19999694824219
+  - Non-zero count: 137,362.46005249023
 
 
 - water_and_sewerage_charges:
   - Type: float
-  - Entity: household
-  - Description: Water and sewerage charges
-  - Mean: 377.2
-  - Median: 358.8
-  - Stddev: 246.6999969482422
-  - Non-zero count: 27,284,872.602359474
+  - Entity: person
+  - Description: Savings income which is tax-free under the starter rate
+  - Mean: 4,989.5
+  - Median: 5,000.0
+  - Stddev: 176.0
+  - Non-zero count: 67,060,431.48605418
+
+
+- tax_band:
+  - Type: Categorical
+  - Entity: person
+  - Description: Tax band of the individual
 
 
 - weekly_childcare_expenses:
   - Type: float
   - Entity: person
-  - Description: Average cost of childcare
-  - Mean: 2.1
+  - Description: Dividend income which is taxed
+  - Mean: 922.9
   - Median: 0.0
-  - Stddev: 16.299999237060547
-  - Non-zero count: 2,432,410.7274161577
+  - Stddev: 53,703.30078125
+  - Non-zero count: 1,200,547.4918460846
 
 
 - weekly_rent:
   - Type: float
-  - Entity: household
-  - Description: Weekly average rent
-  - Mean: 0.0
+  - Entity: person
+  - Description: Income which is taxed
+  - Mean: 11,122.3
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 59,735.0
+  - Non-zero count: 30,949,564.946080923
 
 
 - additional_residential_property_purchased:
   - Type: float
-  - Entity: household
-  - Description: Residential property bought (additional)
-  - Mean: 31,969.3
+  - Entity: person
+  - Description: Savings income which advances the person's income tax schedule
+  - Mean: 11.1
   - Median: 0.0
-  - Stddev: 137,675.296875
-  - Non-zero count: 3,602,005.252691269
+  - Stddev: 353.79998779296875
+  - Non-zero count: 137,362.46005249023
 
 
 - cumulative_non_residential_rent:
@@ -4307,42 +4812,32 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - cumulative_residential_rent:
   - Type: float
-  - Entity: household
-  - Description: Cumulative residential rent
-  - Mean: 0.0
+  - Entity: person
+  - Description: Statutory Maternity Pay
+  - Mean: 18.4
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 371.5
+  - Non-zero count: 163,312.22109985352
 
 
 - main_residential_property_purchased:
   - Type: float
-  - Entity: household
-  - Description: Residential property bought (main)
-  - Mean: 225,958.1
-  - Median: 149,000.0
-  - Stddev: 310,853.8125
-  - Non-zero count: 18,107,816.797572345
-
-
-- main_residential_property_purchased_is_first_home:
-  - Type: bool
-  - Entity: household
-  - Description: Residential property bought is first home
-  - Mean: 0.2
+  - Entity: person
+  - Description: Statutory Sick Pay
+  - Mean: 5.3
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 5,507,226.005473405
+  - Stddev: 157.5
+  - Non-zero count: 92,887.8032836914
 
 
 - non_residential_property_purchased:
   - Type: float
-  - Entity: household
-  - Description: Non-residential property bought
-  - Mean: 10,070.0
-  - Median: 0.0
-  - Stddev: 93,943.0
-  - Non-zero count: 1,144,783.5358160138
+  - Entity: person
+  - Description: Taxable income after tax reliefs and before allowances
+  - Mean: 18,634.8
+  - Median: 11,010.2
+  - Stddev: 60,228.80078125
+  - Non-zero count: 46,986,198.347275496
 
 
 - non_residential_rent:
@@ -4377,12 +4872,12 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - rent:
   - Type: float
-  - Entity: household
-  - Description: Rent
-  - Mean: 2,674.1
-  - Median: -52.0
-  - Stddev: 4,559.7001953125
-  - Non-zero count: 10,134,834.55674693
+  - Entity: person
+  - Description: Employment benefits
+  - Mean: 23.7
+  - Median: 0.0
+  - Stddev: 403.20001220703125
+  - Non-zero count: 256,200.02438354492
 
 
 - diesel_litres:
@@ -4417,122 +4912,122 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - petrol_price:
   - Type: float
-  - Entity: household
-  - Description: Price of petrol per litre
-  - Mean: 1.5
-  - Median: 1.5
-  - Stddev: 0.0
-  - Non-zero count: 28,554,269.10323161
+  - Entity: person
+  - Description: Amount contributed to registered pension schemes paid by the individual (not the employer)
+  - Mean: 503.4
+  - Median: 0.0
+  - Stddev: 1,323.5
+  - Non-zero count: 18,893,605.628993988
 
 
 - carbon_consumption:
   - Type: float
-  - Entity: household
-  - Description: Carbon consumption
-  - Mean: 19.0
-  - Median: 14.0
-  - Stddev: 18.5
-  - Non-zero count: 28,542,069.03493327
+  - Entity: person
+  - Description: Reduction in taxable income from pension contributions
+  - Mean: 1,770.7
+  - Median: 0.0
+  - Stddev: 2,133.89990234375
+  - Non-zero count: 32,692,779.45243597
 
 
 - alcohol_and_tobacco_consumption:
   - Type: float
-  - Entity: household
-  - Description: Alcohol and tobacco
-  - Mean: 725.9
-  - Median: 240.2
-  - Stddev: 1,298.4000244140625
-  - Non-zero count: 17,884,893.402352035
+  - Entity: person
+  - Description: Income from savings in tax-free accounts
+  - Mean: 45.3
+  - Median: 0.0
+  - Stddev: 410.6000061035156
+  - Non-zero count: 7,507,627.0473566055
 
 
 - clothing_and_footwear_consumption:
   - Type: float
-  - Entity: household
-  - Description: Clothing and footwear
-  - Mean: 1,476.4
-  - Median: 503.6
-  - Stddev: 2,689.89990234375
-  - Non-zero count: 19,258,927.861445636
+  - Entity: person
+  - Description: Amount of dividend income that is taxable
+  - Mean: 982.6
+  - Median: 0.0
+  - Stddev: 53,804.80078125
+  - Non-zero count: 5,456,946.138681412
 
 
 - communication_consumption:
   - Type: float
-  - Entity: household
-  - Description: Communication
-  - Mean: 716.2
-  - Median: 432.9
-  - Stddev: 1,712.0999755859375
-  - Non-zero count: 23,775,385.130108416
+  - Entity: person
+  - Description: Net taxable earnings
+  - Mean: 12,434.2
+  - Median: 0.0
+  - Stddev: 21,975.5
+  - Non-zero count: 32,434,728.249044895
 
 
 - diesel_spending:
   - Type: float
-  - Entity: household
-  - Description: Diesel spending
-  - Mean: 601.0
+  - Entity: person
+  - Description: Amount of miscellaneous income that is taxable
+  - Mean: 42.8
   - Median: 0.0
-  - Stddev: 1,186.0999755859375
-  - Non-zero count: 8,958,554.066563666
+  - Stddev: 824.0
+  - Non-zero count: 815,056.0373458862
 
 
 - education_consumption:
   - Type: float
-  - Entity: household
-  - Description: Education
-  - Mean: 645.2
+  - Entity: person
+  - Description: Amount of pension income that is taxable
+  - Mean: 1,707.0
   - Median: 0.0
-  - Stddev: 4,846.10009765625
-  - Non-zero count: 2,638,581.702819526
+  - Stddev: 8,960.400390625
+  - Non-zero count: 11,405,233.000201702
 
 
 - food_and_non_alcoholic_beverages_consumption:
   - Type: float
-  - Entity: household
-  - Description: Food and alcoholic beverages
-  - Mean: 3,575.9
-  - Median: 3,089.0
-  - Stddev: 2,243.0
-  - Non-zero count: 28,415,837.250731647
+  - Entity: person
+  - Description: Amount of property income that is taxable
+  - Mean: 329.9
+  - Median: 0.0
+  - Stddev: 6,556.2998046875
+  - Non-zero count: 2,092,164.6854732037
 
 
 - health_consumption:
   - Type: float
-  - Entity: household
-  - Description: Health
-  - Mean: 543.6
-  - Median: 59.5
-  - Stddev: 1,832.9000244140625
-  - Non-zero count: 17,901,583.38948545
+  - Entity: person
+  - Description: Amount of savings interest which is taxable
+  - Mean: 48.4
+  - Median: 0.0
+  - Stddev: 460.5
+  - Non-zero count: 12,484,678.904747486
 
 
 - household_furnishings_consumption:
   - Type: float
-  - Entity: household
-  - Description: Household furnishings
-  - Mean: 2,548.3
-  - Median: 772.8
-  - Stddev: 5,302.39990234375
-  - Non-zero count: 27,386,598.92419696
+  - Entity: person
+  - Description: Amount of trading income that is taxable
+  - Mean: 1,383.2
+  - Median: 0.0
+  - Stddev: 11,724.400390625
+  - Non-zero count: 4,201,461.9629917145
 
 
 - housing_water_and_electricity_consumption:
   - Type: float
-  - Entity: household
-  - Description: Housing, water and electricity
-  - Mean: 4,905.4
-  - Median: 2,510.7
-  - Stddev: 6,722.7001953125
-  - Non-zero count: 28,457,050.95742625
+  - Entity: person
+  - Description: Amount of social security income that is taxable
+  - Mean: 1,706.7
+  - Median: 0.0
+  - Stddev: 3,764.5
+  - Non-zero count: 14,028,928.293399334
 
 
 - miscellaneous_consumption:
   - Type: float
-  - Entity: household
-  - Description: Miscellaneous
-  - Mean: 3,577.8
-  - Median: 1,719.1
-  - Stddev: 6,703.89990234375
-  - Non-zero count: 28,256,603.628636062
+  - Entity: person
+  - Description: Taxable income after tax reliefs and before allowances
+  - Mean: 19,200.5
+  - Median: 11,301.5
+  - Stddev: 60,522.5
+  - Non-zero count: 47,092,379.68606639
 
 
 - petrol_spending:
@@ -4547,128 +5042,132 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - recreation_consumption:
   - Type: float
-  - Entity: household
-  - Description: Recreation
-  - Mean: 5,123.2
-  - Median: 2,125.5
-  - Stddev: 9,034.900390625
-  - Non-zero count: 28,323,644.358120143
+  - Entity: person
+  - Description: Income from dividends
+  - Mean: 982.6
+  - Median: 0.0
+  - Stddev: 53,804.80078125
+  - Non-zero count: 5,456,946.138681412
 
 
 - restaurants_and_hotels_consumption:
   - Type: float
-  - Entity: household
-  - Description: Restaurants and hotels
-  - Mean: 3,524.0
-  - Median: 2,024.8
-  - Stddev: 4,587.39990234375
-  - Non-zero count: 25,666,611.029856503
+  - Entity: person
+  - Description: Employment income
+  - Mean: 12,900.5
+  - Median: 0.0
+  - Stddev: 22,749.099609375
+  - Non-zero count: 32,375,604.738317966
 
 
 - transport_consumption:
   - Type: float
-  - Entity: household
-  - Description: Transport
-  - Mean: 6,180.2
-  - Median: 3,133.6
-  - Stddev: 10,641.900390625
-  - Non-zero count: 25,762,526.874604583
+  - Entity: person
+  - Description: Pension income
+  - Mean: 1,707.0
+  - Median: 0.0
+  - Stddev: 8,960.400390625
+  - Non-zero count: 11,405,233.000201702
 
 
 - base_net_income:
   - Type: float
   - Entity: person
-  - Description: Existing net income for the person to use as a base in microsimulation
-  - Mean: 0.0
+  - Description: Rental income
+  - Mean: 364.5
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 6,647.0
+  - Non-zero count: 2,599,205.734575987
 
 
 - capital_income:
   - Type: float
   - Entity: person
-  - Description: Income from savings or dividends
-  - Mean: 1,282.5
+  - Description: Savings interest income
+  - Mean: 77.8
   - Median: 0.0
-  - Stddev: 51,333.3984375
-  - Non-zero count: 23,372,779.198782265
+  - Stddev: 603.5
+  - Non-zero count: 14,624,681.422199726
 
 
 - earned_income:
   - Type: float
   - Entity: person
-  - Description: Total earned income
-  - Mean: 15,723.8
-  - Median: 6,864.0
-  - Stddev: 37,401.8984375
-  - Non-zero count: 40,512,251.02392146
+  - Description: Self-employment income
+  - Mean: 1,418.5
+  - Median: 0.0
+  - Stddev: 11,860.099609375
+  - Non-zero count: 4,633,176.941186905
 
 
 - employment_status:
   - Type: Categorical
   - Entity: person
-  - Description: Employment status of the person
+  - Description: Income from social security for tax purposes
+  - Mean: 1,706.7
+  - Median: 0.0
+  - Stddev: 3,764.5
+  - Non-zero count: 14,028,928.293399334
 
 
 - equiv_hbai_household_net_income:
   - Type: float
-  - Entity: household
-  - Description: Equivalised household net income (HBAI)
-  - Mean: 35,049.7
-  - Median: 28,407.9
-  - Stddev: 51,901.3984375
-  - Non-zero count: 28,486,532.01526469
+  - Entity: person
+  - Description: Total pension income
+  - Mean: 3,338.7
+  - Median: 0.0
+  - Stddev: 10,703.599609375
+  - Non-zero count: 15,453,901.845477581
 
 
 - equiv_hbai_household_net_income_ahc:
   - Type: float
-  - Entity: household
-  - Description: Equivalised household net income, after housing costs (HBAI)
-  - Mean: 31,617.3
-  - Median: 25,580.9
-  - Stddev: 53,321.5
-  - Non-zero count: 28,094,392.990743816
+  - Entity: person
+  - Description: Marriage Allowance for the year (a tax-reducer, rather than an allowance or tax relief)
+  - Mean: 155.1
+  - Median: 0.0
+  - Stddev: 399.3999938964844
+  - Non-zero count: 8,678,772.011915207
 
 
-- equiv_household_net_income:
-  - Type: float
-  - Entity: household
-  - Description: Equivalised household net income
-  - Mean: 35,049.7
-  - Median: 28,407.9
-  - Stddev: 51,901.3984375
-  - Non-zero count: 28,486,532.01526469
+- meets_marriage_allowance_income_conditions:
+  - Type: bool
+  - Entity: person
+  - Description: Meets Marriage Allowance income conditions
+  - Mean: 0.9
+  - Median: 1.0
+  - Stddev: 0.2
+  - Non-zero count: 62,543,141.740659
 
 
 - gross_income:
   - Type: float
   - Entity: person
-  - Description: Gross income, including benefits
-  - Mean: 21,233.0
-  - Median: 15,017.8
-  - Stddev: 64,194.3984375
-  - Non-zero count: 51,412,765.94594991
+  - Description: Partner's unused personal allowance
+  - Mean: 241.6
+  - Median: 0.0
+  - Stddev: 5,599.39990234375
+  - Non-zero count: 14,329,339.717634201
 
 
 - hbai_household_net_income:
   - Type: float
-  - Entity: household
-  - Description: Household net income (HBAI definition)
-  - Mean: 38,270.0
-  - Median: 29,202.8
-  - Stddev: 64,256.8984375
-  - Non-zero count: 28,486,532.01526469
+  - Entity: person
+  - Description: Unused personal allowance
+  - Mean: 5,041.1
+  - Median: 1,559.8
+  - Stddev: 5,571.60009765625
+  - Non-zero count: 35,916,484.426096916
 
 
 - hbai_household_net_income_ahc:
   - Type: float
-  - Entity: household
-  - Description: Household net income, after housing costs
-  - Mean: 34,060.5
-  - Median: 25,310.3
-  - Stddev: 63,873.1015625
-  - Non-zero count: 28,094,392.990743816
+  - Entity: person
+  - Description: Allowances applicable to adjusted net income
+  - Mean: 12,414.8
+  - Median: 12,570.0
+  - Stddev: 1,390.300048828125
+  - Non-zero count: 66,471,833.08945274
 
 
 - hours_worked:
@@ -4703,12 +5202,12 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - household_net_income:
   - Type: float
-  - Entity: household
-  - Description: Household net income
-  - Mean: 38,270.0
-  - Median: 29,202.8
-  - Stddev: 64,256.8984375
-  - Non-zero count: 28,486,532.01526469
+  - Entity: person
+  - Description: Dividend allowance for the person
+  - Mean: 2,000.0
+  - Median: 2,000.0
+  - Stddev: 0.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - in_work:
@@ -4754,57 +5253,71 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - market_income:
   - Type: float
   - Entity: person
-  - Description: Market income
-  - Mean: 17,694.4
-  - Median: 7,740.0
-  - Stddev: 64,480.1015625
-  - Non-zero count: 45,220,909.67612827
+  - Description: Annual Allowance for pension contributions
+  - Mean: 39,898.2
+  - Median: 40,000.0
+  - Stddev: 2,186.10009765625
+  - Non-zero count: 67,106,864.33584666
 
 
 - minimum_wage:
   - Type: float
   - Entity: person
-  - Description: Minimum wage
-  - Mean: 7.9
-  - Median: 8.9
-  - Stddev: 1.7000000476837158
-  - Non-zero count: 67,239,322.06306267
+  - Description: Personal Allowance for the year
+  - Mean: 12,414.8
+  - Median: 12,570.0
+  - Stddev: 1,390.300048828125
+  - Non-zero count: 66,471,833.08945274
 
 
 - minimum_wage_category:
   - Type: Categorical
   - Entity: person
-  - Description: Minimum wage category
+  - Description: Property Allowance for the year
+  - Mean: 1,000.0
+  - Median: 1,000.0
+  - Stddev: 0.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - miscellaneous_income:
   - Type: float
   - Entity: person
-  - Description: Income from other sources
-  - Mean: 59.5
+  - Description: Deduction applied by the property allowance
+  - Mean: 34.6
   - Median: 0.0
-  - Stddev: 1,002.9000244140625
-  - Non-zero count: 771,787.4630403519
+  - Stddev: 200.6999969482422
+  - Non-zero count: 2,599,205.734575987
+
+
+- savings_allowance:
+  - Type: float
+  - Entity: person
+  - Description: Savings Allowance for the year
+  - Mean: 962.6
+  - Median: 1,000.0
+  - Stddev: 144.8000030517578
+  - Non-zero count: 66,646,034.3602798
 
 
 - net_income:
   - Type: float
   - Entity: person
-  - Description: Net income
-  - Mean: 17,257.3
-  - Median: 14,492.5
-  - Stddev: 39,686.69921875
-  - Non-zero count: 51,412,765.94594991
+  - Description: Trading Allowance for the year
+  - Mean: 1,000.0
+  - Median: 1,000.0
+  - Stddev: 0.0
+  - Non-zero count: 67,106,864.33584666
 
 
 - private_transfer_income:
   - Type: float
   - Entity: person
-  - Description: Private transfers
-  - Mean: 110.9
+  - Description: Deduction applied by the trading allowance
+  - Mean: 35.3
   - Median: 0.0
-  - Stddev: 1,486.699951171875
-  - Non-zero count: 1,171,882.585793972
+  - Stddev: 775.7000122070312
+  - Non-zero count: 4,633,176.941186905
 
 
 - real_household_net_income:
@@ -4820,21 +5333,21 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - sublet_income:
   - Type: float
   - Entity: person
-  - Description: Income received from sublet agreements
-  - Mean: 0.0
+  - Description: Child Benefit High-Income Tax Charge
+  - Mean: 27.8
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 227.1999969482422
+  - Non-zero count: 1,429,062.0640563965
 
 
 - weekly_hours:
   - Type: float
-  - Entity: person
-  - Description: Weekly hours
-  - Mean: 16.8
+  - Entity: household
+  - Description: LBTT (expected, baseline)
+  - Mean: 31.3
   - Median: 0.0
-  - Stddev: 19.899999618530273
-  - Non-zero count: 31,855,637.068116903
+  - Stddev: 515.5
+  - Non-zero count: 1,111,561.378479004
 
 
 - baseline_hbai_excluded_income:
@@ -4843,28 +5356,28 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: HBAI-excluded income (baseline)
   - Mean: 0.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 3.0999999046325684
+  - Non-zero count: 150,019.1499862671
 
 
 - hbai_excluded_income:
   - Type: float
   - Entity: household
-  - Description: HBAI-excluded income
-  - Mean: 0.0
+  - Description: Land and Buildings Transaction Tax (expected)
+  - Mean: 31.3
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 515.5999755859375
+  - Non-zero count: 1,105,971.032737732
 
 
 - hbai_excluded_income_change:
   - Type: float
   - Entity: household
-  - Description: Change in HBAI-excluded income
-  - Mean: 0.0
+  - Description: Land and Buildings Transaction Tax
+  - Mean: 714.0
   - Median: 0.0
-  - Stddev: 0.0
-  - Non-zero count: 0.0
+  - Stddev: 11,747.5
+  - Non-zero count: 1,105,971.032737732
 
 
 - in_deep_poverty_ahc:
@@ -4873,8 +5386,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Whether the household is in deep absolute poverty (below half the poverty line), after housing costs
   - Mean: 0.1
   - Median: 0.0
-  - Stddev: 0.2
-  - Non-zero count: 1,813,798.3362865448
+  - Stddev: 0.3
+  - Non-zero count: 2,877,085.677221298
 
 
 - in_deep_poverty_bhc:
@@ -4890,11 +5403,11 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - in_poverty_ahc:
   - Type: bool
   - Entity: household
-  - Description: Whether the household is in absolute poverty, after housing costs
-  - Mean: 0.2
+  - Description: LBTT on non-residential property transactions
+  - Mean: 60.0
   - Median: 0.0
-  - Stddev: 0.4
-  - Non-zero count: 5,434,051.158005714
+  - Stddev: 1,561.5999755859375
+  - Non-zero count: 128,507.42685699463
 
 
 - in_poverty_bhc:
@@ -4920,31 +5433,31 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 - poverty_gap_bhc:
   - Type: float
   - Entity: household
-  - Description: Positive financial gap between net household income and the poverty line
-  - Mean: 742.3
+  - Description: LBTT on residential property
+  - Mean: 8,199.7
   - Median: 0.0
-  - Stddev: 2,230.0
-  - Non-zero count: 4,611,527.674956322
+  - Stddev: 28,030.099609375
+  - Non-zero count: 13,050,436.734113693
 
 
 - poverty_line_ahc:
   - Type: float
   - Entity: household
-  - Description: The poverty line for the household, after housing costs
-  - Mean: 15,339.6
-  - Median: 14,455.1
-  - Stddev: 6,114.7998046875
-  - Non-zero count: 28,554,269.10323161
+  - Description: LBTT on property transactions
+  - Mean: 8,259.7
+  - Median: 0.0
+  - Stddev: 28,248.900390625
+  - Non-zero count: 13,053,473.568159103
 
 
 - poverty_line_bhc:
   - Type: float
   - Entity: household
-  - Description: The poverty line for the household, before housing costs
-  - Mean: 17,971.4
-  - Median: 16,871.0
-  - Stddev: 5,899.7001953125
-  - Non-zero count: 28,554,269.10323161
+  - Description: Land Transaction Tax (baseline, expected)
+  - Mean: 9.7
+  - Median: 0.0
+  - Stddev: 216.39999389648438
+  - Non-zero count: 514,097.75186538696
 
 
 - poverty_threshold_bhc:
@@ -4959,22 +5472,22 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - benefits:
   - Type: float
-  - Entity: person
-  - Description: Total benefits
-  - Mean: 3,538.6
+  - Entity: household
+  - Description: Land Transaction Tax (expected)
+  - Mean: 9.7
   - Median: 0.0
-  - Stddev: 5,789.7998046875
-  - Non-zero count: 26,616,841.26214692
+  - Stddev: 216.39999389648438
+  - Non-zero count: 514,097.75186538696
 
 
 - benefits_modelling:
   - Type: float
-  - Entity: person
-  - Description: Difference between reported and simulated benefits for this person
-  - Mean: 630.4
+  - Entity: household
+  - Description: Land Transaction Tax
+  - Mean: 221.3
   - Median: 0.0
-  - Stddev: 3,444.5
-  - Non-zero count: 14,300,055.42207089
+  - Stddev: 4,930.89990234375
+  - Non-zero count: 514,097.75186538696
 
 
 - benefits_premiums:
@@ -4983,8 +5496,8 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
   - Description: Value of premiums for disability and carer status
   - Mean: 375.3
   - Median: 0.0
-  - Stddev: 1,579.300048828125
-  - Non-zero count: 3,135,688.1490659714
+  - Stddev: 0.2
+  - Non-zero count: 1,558,630.486937523
 
 
 - benefits_reported:
@@ -5029,12 +5542,12 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - family_benefits:
   - Type: float
-  - Entity: person
-  - Description: Total simulated family benefits for this person
-  - Mean: 1,250.8
+  - Entity: household
+  - Description: LTT on non-residential property transactions
+  - Mean: 0.0
   - Median: 0.0
-  - Stddev: 3,386.699951171875
-  - Non-zero count: 14,651,614.868334204
+  - Stddev: 0.0
+  - Non-zero count: 0.0
 
 
 - family_benefits_reported:
@@ -5119,30 +5632,20 @@ All statistics generated from the uprated (to 2022) 2019-20 Family Resources Sur
 
 - other_benefits:
   - Type: float
-  - Entity: person
-  - Description: Income from benefits not modelled or detailed in the model
-  - Mean: -630.4
+  - Entity: household
+  - Description: LTT on residential property
+  - Mean: 6,651.4
   - Median: 0.0
-  - Stddev: 3,444.5
-  - Non-zero count: 6,550,203.4326581955
+  - Stddev: 23,257.400390625
+  - Non-zero count: 11,390,334.375713348
 
 
 - personal_benefits:
   - Type: float
-  - Entity: person
-  - Description: Value of personal, non-means-tested benefits
-  - Mean: 2,287.8
+  - Entity: household
+  - Description: LTT on property transactions
+  - Mean: 6,651.4
   - Median: 0.0
-  - Stddev: 4,516.89990234375
-  - Non-zero count: 17,704,902.935673177
-
-
-- personal_benefits_reported:
-  - Type: float
-  - Entity: person
-  - Description: Value of personal, non-means-tested benefits
-  - Mean: 1,970.6
-  - Median: 0.0
-  - Stddev: 4,205.5
-  - Non-zero count: 15,672,064.596939504
+  - Stddev: 23,257.400390625
+  - Non-zero count: 11,390,334.375713348
 

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/baseline_variables.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/baseline_variables.py
@@ -1,6 +1,9 @@
 from openfisca_core.variables import Variable
 from typing import Callable, Type
 import h5py
+from openfisca_uk.data.datasets.frs.enhanced.stages.extension.extended_frs import (
+    ExtendedFRS,
+)
 from openfisca_uk.data.datasets.frs.enhanced.stages.imputation.enhanced_frs import (
     EnhancedFRS,
 )
@@ -60,38 +63,12 @@ def generate_baseline_variables(dataset: Dataset, year: int):
 
     variable_metadata = baseline.simulation.tax_benefit_system.variables
 
-    for variable in variable_metadata:
+    variables = []
+
+    for variable in variable_metadata.keys():
         if variable[:9] == "baseline_":
-            for subyear in YEARS:
-                baseline.simulation.set_input(
-                    variable,
-                    subyear,
-                    [True]
-                    * len(
-                        baseline.calc(
-                            variable_metadata[variable].entity.key + "_id"
-                        )
-                    ),
-                )
+            variables += [variable_metadata[variable[9:]]]
 
-    # First, find variables which need baseline storage.
-
-    variables = list(
-        filter(
-            lambda variable: hasattr(variable, "formula")
-            and variable.formula.__doc__ is not None
-            and "Baseline-requiring formula" in variable.formula.__doc__,
-            variable_metadata.values(),
-        )
-    )
-    variables = list(
-        map(
-            lambda variable: variable_metadata[
-                variable.formula.__doc__.split(" for ")[1]
-            ],
-            variables,
-        )
-    )
     print(f"Found {len(variables)} variables to store baseline values for:")
     print("\n* " + "\n* ".join([variable.label for variable in variables]))
 
@@ -120,4 +97,4 @@ def generate_baseline_variables(dataset: Dataset, year: int):
 
 
 if __name__ == "__main__":
-    generate_baseline_variables(EnhancedFRS, 2022)
+    generate_baseline_variables(ExtendedFRS, 2022)

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/baseline_variables.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/baseline_variables.py
@@ -59,7 +59,7 @@ def generate_baseline_variables(dataset: Dataset, year: int):
     from openfisca_uk import Microsimulation
 
     YEARS = list(range(year, 2026))
-    baseline = Microsimulation(dataset=dataset, add_baseline_values=False)
+    baseline = Microsimulation(dataset=dataset)
 
     variable_metadata = baseline.simulation.tax_benefit_system.variables
 

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/calibration/calibrated_frs.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/calibration/calibrated_frs.py
@@ -40,7 +40,7 @@ class CalibratedFRS(PrivateDataset):
         )
         weights.calibrate(
             validation_split=0,
-            num_epochs=300,
+            num_epochs=32,
             learning_rate=1e2,
             dataset=self,
         )

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/calibration/calibrated_frs.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/calibration/calibrated_frs.py
@@ -40,7 +40,7 @@ class CalibratedFRS(PrivateDataset):
         )
         weights.calibrate(
             validation_split=0,
-            num_epochs=32,
+            num_epochs=256,
             learning_rate=1e2,
             dataset=self,
         )

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/extension/extended_frs.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/extension/extended_frs.py
@@ -77,6 +77,10 @@ class ExtendedFRS(PrivateDataset):
             },
             weighting=0,
         )
+        from ..baseline_variables import generate_baseline_variables
+
+        # Import here to avoid circular dependency
+        generate_baseline_variables(self, year)
 
         self.save(
             year,

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/imputation/enhanced_frs.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/imputation/enhanced_frs.py
@@ -53,10 +53,6 @@ class EnhancedFRS(PrivateDataset):
                 for field in pred_wealth.columns
             },
         )
-        from ..baseline_variables import generate_baseline_variables
-
-        # Import here to avoid circular dependency
-        generate_baseline_variables(self, year)
 
         from ..remove_zero_weight_households import (
             remove_zero_weight_households,

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/imputation/enhanced_frs.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/imputation/enhanced_frs.py
@@ -12,7 +12,7 @@ class EnhancedFRS(PrivateDataset):
     label = "Enhanced FRS"
     data_format = Dataset.TIME_PERIOD_ARRAYS
     folder_path = OPENFISCA_UK_MICRODATA_FOLDER
-    filename_by_year = {2022: "enhanced_frs_2022_v0_22.h5"}
+    filename_by_year = {2022: "enhanced_frs_2022_v0_23.h5"}
 
     def generate(self, year: int):
         if year not in CalibratedFRS.years:

--- a/openfisca_uk/data/datasets/frs/enhanced/stages/remove_zero_weight_households.py
+++ b/openfisca_uk/data/datasets/frs/enhanced/stages/remove_zero_weight_households.py
@@ -24,6 +24,8 @@ def remove_zero_weight_households(dataset: Dataset, year: int):
     variables = dataset.keys(year)
 
     for variable in variables:
+        if variable not in sim.simulation.tax_benefit_system.variables:
+            continue
         entity = sim.simulation.tax_benefit_system.variables[
             variable
         ].entity.key

--- a/openfisca_uk/variables/gov/dwp/housing_benefit.py
+++ b/openfisca_uk/variables/gov/dwp/housing_benefit.py
@@ -37,10 +37,11 @@ class would_claim_HB(Variable):
             "claims_all_entitled_benefits", period
         )
         reported_hb = aggr(benunit, period, ["housing_benefit_reported"]) > 0
-        baseline = benunit("baseline_has_housing_benefit", period)
+        baseline = benunit("baseline_housing_benefit_eligible", period)
+        eligible = benunit("housing_benefit_eligible", period)
         takeup_rate = parameters(period).benefit.housing_benefit.takeup
         return select(
-            [reported_hb | claims_all_entitled_benefits, ~baseline, True],
+            [reported_hb | claims_all_entitled_benefits, ~baseline & eligible, True],
             [
                 True,
                 random(benunit) < takeup_rate,
@@ -254,19 +255,10 @@ class housing_benefit(Variable):
         return max_(0, final_amount)
 
 
-class baseline_housing_benefit(Variable):
-    label = "Housing Benefit (baseline)"
-    entity = BenUnit
-    definition_period = YEAR
-    value_type = float
-    unit = GBP
-
-
-class baseline_has_housing_benefit(Variable):
-    label = "Receives Housing Benefit (baseline)"
+class baseline_housing_benefit_eligible(Variable):
+    label = "Housing Benefit eligible (baseline)"
     entity = BenUnit
     definition_period = YEAR
     value_type = bool
-    default_value = True
+    unit = GBP
 
-    formula = baseline_is_nonzero(housing_benefit)

--- a/openfisca_uk/variables/gov/dwp/housing_benefit.py
+++ b/openfisca_uk/variables/gov/dwp/housing_benefit.py
@@ -37,11 +37,15 @@ class would_claim_HB(Variable):
             "claims_all_entitled_benefits", period
         )
         reported_hb = aggr(benunit, period, ["housing_benefit_reported"]) > 0
-        baseline = benunit("baseline_housing_benefit_eligible", period)
-        eligible = benunit("housing_benefit_eligible", period)
+        baseline = benunit("baseline_housing_benefit_entitlement", period) > 0
+        eligible = benunit("housing_benefit_entitlement", period) > 0
         takeup_rate = parameters(period).benefit.housing_benefit.takeup
         return select(
-            [reported_hb | claims_all_entitled_benefits, ~baseline & eligible, True],
+            [
+                reported_hb | claims_all_entitled_benefits,
+                ~baseline & eligible,
+                True,
+            ],
             [
                 True,
                 random(benunit) < takeup_rate,
@@ -200,12 +204,12 @@ class HB_non_dep_deductions(Variable):
         return non_dep_deductions_in_hh - non_dep_deductions_in_bu
 
 
-class housing_benefit(Variable):
-    value_type = float
+class housing_benefit_entitlement(Variable):
+    label = "HB entitlement"
     entity = BenUnit
-    label = "Housing Benefit"
     definition_period = YEAR
-    unit = GBP
+    value_type = float
+    unit = "currency-GBP"
 
     def formula(benunit, period, parameters):
         rent = benunit("benunit_rent", period)
@@ -245,20 +249,28 @@ class housing_benefit(Variable):
         )
         amount = max_(0, amount - benunit("HB_non_dep_deductions", period))
         final_amount = min_(
-            amount
-            * (
-                benunit("housing_benefit_eligible", period)
-                & benunit("would_claim_HB", period)
-            ),
+            amount * (benunit("housing_benefit_eligible", period)),
             benunit("benefit_cap", period) - other_capped_benefits,
         )
         return max_(0, final_amount)
 
 
-class baseline_housing_benefit_eligible(Variable):
-    label = "Housing Benefit eligible (baseline)"
+class housing_benefit(Variable):
+    value_type = float
     entity = BenUnit
+    label = "Housing Benefit"
     definition_period = YEAR
-    value_type = bool
     unit = GBP
 
+    def formula(benunit, period, parameters):
+        entitlement = benunit("housing_benefit_entitlement", period)
+        would_claim = benunit("would_claim_HB", period)
+        return would_claim * entitlement
+
+
+class baseline_housing_benefit_entitlement(Variable):
+    label = "Housing Benefit entitlement (baseline)"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = float
+    unit = GBP

--- a/openfisca_uk/variables/gov/dwp/income_support.py
+++ b/openfisca_uk/variables/gov/dwp/income_support.py
@@ -23,10 +23,11 @@ class would_claim_IS(Variable):
         claims_all_entitled_benefits = benunit(
             "claims_all_entitled_benefits", period
         )
-        baseline = benunit("baseline_has_income_support", period)
+        baseline = benunit("baseline_income_support_eligible", period)
+        eligible = benunit("income_support_eligible", period)
         takeup_rate = parameters(period).benefit.housing_benefit.takeup
         return select(
-            [reported_is | claims_all_entitled_benefits, ~baseline, True],
+            [reported_is | claims_all_entitled_benefits, ~baseline & eligible, True],
             [
                 True,
                 random(benunit) < takeup_rate,
@@ -174,19 +175,10 @@ class income_support(Variable):
         return max_(0, amount - income)
 
 
-class baseline_income_support(Variable):
-    label = "Income Support (baseline)"
-    entity = BenUnit
-    definition_period = YEAR
-    value_type = float
-    unit = GBP
-
-
-class baseline_has_income_support(Variable):
-    label = "Receives Income Support (baseline)"
+class baseline_income_support_eligible(Variable):
+    label = "Income Support eligible (baseline)"
     entity = BenUnit
     definition_period = YEAR
     value_type = bool
-    default_value = True
+    unit = GBP
 
-    formula = baseline_is_nonzero(income_support)

--- a/openfisca_uk/variables/gov/dwp/pension_credit/baseline_pension_credit_entitlement.py
+++ b/openfisca_uk/variables/gov/dwp/pension_credit/baseline_pension_credit_entitlement.py
@@ -1,0 +1,9 @@
+from openfisca_uk.model_api import *
+
+
+class baseline_pension_credit_entitlement(Variable):
+    label = "PC entitlement (baseline)"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = float
+    unit = "currency-GBP"

--- a/openfisca_uk/variables/gov/dwp/pension_credit/pension_credit.py
+++ b/openfisca_uk/variables/gov/dwp/pension_credit/pension_credit.py
@@ -10,8 +10,6 @@ class pension_credit(Variable):
     reference = "https://www.legislation.gov.uk/ukpga/2002/16/contents"
 
     def formula(benunit, period, parameters):
-        gc = benunit("guarantee_credit", period)
-        sc = benunit("savings_credit", period)
-        eligible = benunit("is_pension_credit_eligible", period)
+        entitlement = benunit("pension_credit_entitlement", period)
         would_claim = benunit("would_claim_pc", period)
-        return (eligible & would_claim) * (gc + sc)
+        return entitlement * would_claim

--- a/openfisca_uk/variables/gov/dwp/pension_credit/pension_credit_entitlement.py
+++ b/openfisca_uk/variables/gov/dwp/pension_credit/pension_credit_entitlement.py
@@ -1,0 +1,15 @@
+from openfisca_uk.model_api import *
+
+
+class pension_credit_entitlement(Variable):
+    label = "PC entitlement"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = float
+    unit = "currency-GBP"
+
+    def formula(benunit, period, parameters):
+        gc = benunit("guarantee_credit", period)
+        sc = benunit("savings_credit", period)
+        eligible = benunit("is_pension_credit_eligible", period)
+        return eligible * (gc + sc)

--- a/openfisca_uk/variables/gov/dwp/pension_credit/would_claim.py
+++ b/openfisca_uk/variables/gov/dwp/pension_credit/would_claim.py
@@ -4,13 +4,6 @@ from openfisca_uk.variables.gov.dwp.pension_credit.pension_credit import (
 )
 
 
-class baseline_is_pension_credit_eligible(Variable):
-    label = "Pension Credit (baseline)"
-    entity = BenUnit
-    definition_period = YEAR
-    value_type = bool
-
-
 class would_claim_pc(Variable):
     label = "Would claim Pension Credit"
     entity = BenUnit
@@ -22,11 +15,15 @@ class would_claim_pc(Variable):
         claims_all_entitled_benefits = benunit(
             "claims_all_entitled_benefits", period
         )
-        baseline = benunit("baseline_is_pension_credit_eligible", period)
-        eligible = benunit("is_pension_credit_eligible", period)
+        baseline = benunit("baseline_pension_credit_entitlement", period) > 0
+        eligible = benunit("pension_credit_entitlement", period) > 0
         takeup_rate = parameters(period).dwp.pension_credit.takeup
         return select(
-            [reported_pc | claims_all_entitled_benefits, ~baseline & eligible, True],
+            [
+                reported_pc | claims_all_entitled_benefits,
+                ~baseline & eligible,
+                True,
+            ],
             [
                 True,
                 random(benunit) < takeup_rate,

--- a/openfisca_uk/variables/gov/dwp/pension_credit/would_claim.py
+++ b/openfisca_uk/variables/gov/dwp/pension_credit/would_claim.py
@@ -4,22 +4,11 @@ from openfisca_uk.variables.gov.dwp.pension_credit.pension_credit import (
 )
 
 
-class baseline_pension_credit(Variable):
+class baseline_is_pension_credit_eligible(Variable):
     label = "Pension Credit (baseline)"
     entity = BenUnit
     definition_period = YEAR
-    value_type = float
-    unit = GBP
-
-
-class baseline_has_pension_credit(Variable):
-    label = "Receives Pension Credit (baseline)"
-    entity = BenUnit
-    definition_period = YEAR
     value_type = bool
-    default_value = True
-
-    formula = baseline_is_nonzero(pension_credit)
 
 
 class would_claim_pc(Variable):
@@ -33,10 +22,11 @@ class would_claim_pc(Variable):
         claims_all_entitled_benefits = benunit(
             "claims_all_entitled_benefits", period
         )
-        baseline = benunit("baseline_has_pension_credit", period)
+        baseline = benunit("baseline_is_pension_credit_eligible", period)
+        eligible = benunit("is_pension_credit_eligible", period)
         takeup_rate = parameters(period).dwp.pension_credit.takeup
         return select(
-            [reported_pc | claims_all_entitled_benefits, ~baseline, True],
+            [reported_pc | claims_all_entitled_benefits, ~baseline & eligible, True],
             [
                 True,
                 random(benunit) < takeup_rate,

--- a/openfisca_uk/variables/gov/dwp/tax_credits.py
+++ b/openfisca_uk/variables/gov/dwp/tax_credits.py
@@ -108,11 +108,15 @@ class would_claim_CTC(Variable):
         claims_all_entitled_benefits = benunit(
             "claims_all_entitled_benefits", period
         )
-        baseline = benunit("baseline_is_CTC_eligible", period)
-        eligible = benunit("is_CTC_eligible", period)
+        baseline = benunit("baseline_ctc_entitlement", period) > 0
+        eligible = benunit("ctc_entitlement", period) > 0
         takeup_rate = parameters(period).benefit.housing_benefit.takeup
         return select(
-            [reported_ctc | claims_all_entitled_benefits, ~baseline & eligible, True],
+            [
+                reported_ctc | claims_all_entitled_benefits,
+                ~baseline & eligible,
+                True,
+            ],
             [
                 True,
                 random(benunit) < takeup_rate,
@@ -279,11 +283,15 @@ class would_claim_WTC(Variable):
         claims_all_entitled_benefits = benunit(
             "claims_all_entitled_benefits", period
         )
-        baseline = benunit("baseline_is_WTC_eligible", period)
-        eligible = benunit("is_WTC_eligible", period)
+        baseline = benunit("baseline_wtc_entitlement", period) > 0
+        eligible = benunit("wtc_entitlement", period) > 0
         takeup_rate = parameters(period).benefit.housing_benefit.takeup
         return select(
-            [reported_wtc | claims_all_entitled_benefits, ~baseline & eligible, True],
+            [
+                reported_wtc | claims_all_entitled_benefits,
+                ~baseline & eligible,
+                True,
+            ],
             [
                 True,
                 random(benunit) < takeup_rate,
@@ -525,6 +533,21 @@ class tax_credits(Variable):
         return where(amount < min_benefit, 0, amount)
 
 
+class ctc_entitlement(Variable):
+    label = "CTC entitlement"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = float
+    unit = "currency-GBP"
+
+    def formula(benunit, period, parameters):
+        return where(
+            benunit("tax_credits", period) > 0,
+            benunit("child_tax_credit_pre_minimum", period),
+            0,
+        ) * (benunit("is_CTC_eligible", period))
+
+
 class child_tax_credit(Variable):
     value_type = float
     entity = BenUnit
@@ -533,14 +556,24 @@ class child_tax_credit(Variable):
     unit = GBP
 
     def formula(benunit, period, parameters):
+        entitlement = benunit("ctc_entitlement", period)
+        would_claim = benunit("would_claim_CTC", period)
+        return entitlement * would_claim
+
+
+class wtc_entitlement(Variable):
+    label = "WTC entitlement"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = float
+    unit = "currency-GBP"
+
+    def formula(benunit, period, parameters):
         return where(
             benunit("tax_credits", period) > 0,
-            benunit("child_tax_credit_pre_minimum", period),
+            benunit("working_tax_credit_pre_minimum", period),
             0,
-        ) * (
-            benunit("is_CTC_eligible", period)
-            & benunit("would_claim_CTC", period)
-        )
+        ) * (benunit("is_WTC_eligible", period))
 
 
 class working_tax_credit(Variable):
@@ -551,26 +584,20 @@ class working_tax_credit(Variable):
     unit = GBP
 
     def formula(benunit, period, parameters):
-        return where(
-            benunit("tax_credits", period) > 0,
-            benunit("working_tax_credit_pre_minimum", period),
-            0,
-        ) * (
-            benunit("is_WTC_eligible", period)
-            & benunit("would_claim_WTC", period)
-        )
+        entitlement = benunit("wtc_entitlement", period)
+        would_claim = benunit("would_claim_WTC", period)
+        return entitlement * would_claim
 
 
-class baseline_is_WTC_eligible(Variable):
+class baseline_wtc_entitlement(Variable):
     label = "Baseline Working Tax Credit"
     entity = BenUnit
     definition_period = YEAR
-    value_type = bool
+    value_type = float
 
 
-class baseline_is_CTC_eligible(Variable):
+class baseline_ctc_entitlement(Variable):
     label = "Receives Child Tax Credit (baseline)"
     entity = BenUnit
     definition_period = YEAR
-    value_type = bool
-    default_value = True
+    value_type = float

--- a/openfisca_uk/variables/gov/dwp/tax_credits.py
+++ b/openfisca_uk/variables/gov/dwp/tax_credits.py
@@ -108,10 +108,11 @@ class would_claim_CTC(Variable):
         claims_all_entitled_benefits = benunit(
             "claims_all_entitled_benefits", period
         )
-        baseline = benunit("baseline_has_working_tax_credit", period)
+        baseline = benunit("baseline_is_CTC_eligible", period)
+        eligible = benunit("is_CTC_eligible", period)
         takeup_rate = parameters(period).benefit.housing_benefit.takeup
         return select(
-            [reported_ctc | claims_all_entitled_benefits, ~baseline, True],
+            [reported_ctc | claims_all_entitled_benefits, ~baseline & eligible, True],
             [
                 True,
                 random(benunit) < takeup_rate,
@@ -278,10 +279,11 @@ class would_claim_WTC(Variable):
         claims_all_entitled_benefits = benunit(
             "claims_all_entitled_benefits", period
         )
-        baseline = benunit("baseline_has_child_tax_credit", period)
+        baseline = benunit("baseline_is_WTC_eligible", period)
+        eligible = benunit("is_WTC_eligible", period)
         takeup_rate = parameters(period).benefit.housing_benefit.takeup
         return select(
-            [reported_wtc | claims_all_entitled_benefits, ~baseline, True],
+            [reported_wtc | claims_all_entitled_benefits, ~baseline & eligible, True],
             [
                 True,
                 random(benunit) < takeup_rate,
@@ -559,31 +561,14 @@ class working_tax_credit(Variable):
         )
 
 
-class baseline_working_tax_credit(Variable):
+class baseline_is_WTC_eligible(Variable):
     label = "Baseline Working Tax Credit"
     entity = BenUnit
     definition_period = YEAR
-    value_type = float
-    unit = GBP
-
-
-class baseline_child_tax_credit(Variable):
-    label = "Baseline Child Tax Credit"
-    entity = BenUnit
-    definition_period = YEAR
-    value_type = float
-    unit = GBP
-
-
-class baseline_has_working_tax_credit(Variable):
-    label = "Receives Working Tax Credit (baseline)"
-    entity = BenUnit
-    definition_period = YEAR
     value_type = bool
-    default_value = True
 
 
-class baseline_has_child_tax_credit(Variable):
+class baseline_is_CTC_eligible(Variable):
     label = "Receives Child Tax Credit (baseline)"
     entity = BenUnit
     definition_period = YEAR

--- a/openfisca_uk/variables/gov/dwp/universal_credit.py
+++ b/openfisca_uk/variables/gov/dwp/universal_credit.py
@@ -38,13 +38,14 @@ class would_claim_UC(Variable):
         current_uc_claimant = (
             aggr(benunit, period, ["universal_credit_reported"]) > 0
         )
-        baseline_uc = benunit("baseline_has_universal_credit", period)
+        baseline_uc = benunit("baseline_is_UC_eligible", period)
+        eligible = benunit("is_UC_eligible", period)
         takeup_rate = parameters(period).benefit.universal_credit.takeup
         return select(
             [
                 current_uc_claimant
                 | (claims_all_entitled_benefits & ~on_legacy_benefits),
-                (~baseline_uc & ~on_legacy_benefits),
+                (~baseline_uc & eligible & ~on_legacy_benefits),
                 True,
             ],
             [
@@ -652,19 +653,10 @@ class UC_MIF_capped_earned_income(Variable):
         return max_(personal_gross_earned_income, floor)
 
 
-class baseline_universal_credit(Variable):
-    label = "Universal Credit (baseline)"
-    entity = BenUnit
-    definition_period = YEAR
-    value_type = float
-    unit = GBP
-
-
-class baseline_has_universal_credit(Variable):
-    label = "Receives Universal Credit (baseline)"
+class baseline_is_UC_eligible(Variable):
+    label = "Universal Credit eligible (baseline)"
     entity = BenUnit
     definition_period = YEAR
     value_type = bool
-    default_value = True
+    unit = GBP
 
-    formula = baseline_is_nonzero(universal_credit)

--- a/openfisca_uk/variables/gov/hmrc/child_benefit.py
+++ b/openfisca_uk/variables/gov/hmrc/child_benefit.py
@@ -25,11 +25,12 @@ class would_claim_child_benefit(Variable):
             aggr(benunit, period, ["child_benefit_reported"]) > 0
         )
         takeup_rate = parameters(period).hmrc.child_benefit.takeup
-        baseline_cb = benunit("baseline_has_child_benefit", period)
+        baseline_cb = benunit("baseline_is_cb_eligible", period)
+        eligible = benunit("is_cb_eligible", period)
         return select(
             [
                 already_claiming | claims_benefits,
-                ~baseline_cb,
+                ~baseline_cb & eligible,
                 True,
             ],
             [
@@ -40,6 +41,14 @@ class would_claim_child_benefit(Variable):
             ],
         )
 
+
+class is_cb_eligible(Variable):
+    label = "Child benefit eligible"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = bool
+
+    formula = sum_of_variables(["is_child_or_QYP"])
 
 class child_benefit_respective_amount(Variable):
     label = "Child Benefit (respective amount)"
@@ -98,19 +107,10 @@ class child_benefit_less_tax_charge(Variable):
         return benefit - charge
 
 
-class baseline_child_benefit(Variable):
+class baseline_is_cb_eligible(Variable):
     label = "Child Benefit (baseline)"
     entity = BenUnit
     definition_period = YEAR
-    value_type = float
-    unit = GBP
-
-
-class baseline_has_child_benefit(Variable):
-    label = "Receives Child Benefit (baseline)"
-    entity = BenUnit
-    definition_period = YEAR
     value_type = bool
-    default_value = True
 
-    formula = baseline_is_nonzero(child_benefit)
+

--- a/openfisca_uk/variables/gov/hmrc/child_benefit.py
+++ b/openfisca_uk/variables/gov/hmrc/child_benefit.py
@@ -25,8 +25,8 @@ class would_claim_child_benefit(Variable):
             aggr(benunit, period, ["child_benefit_reported"]) > 0
         )
         takeup_rate = parameters(period).hmrc.child_benefit.takeup
-        baseline_cb = benunit("baseline_is_cb_eligible", period)
-        eligible = benunit("is_cb_eligible", period)
+        baseline_cb = benunit("baseline_child_benefit_entitlement", period) > 0
+        eligible = benunit("child_benefit_entitlement", period) > 0
         return select(
             [
                 already_claiming | claims_benefits,
@@ -41,14 +41,6 @@ class would_claim_child_benefit(Variable):
             ],
         )
 
-
-class is_cb_eligible(Variable):
-    label = "Child benefit eligible"
-    entity = BenUnit
-    definition_period = YEAR
-    value_type = bool
-
-    formula = sum_of_variables(["is_child_or_QYP"])
 
 class child_benefit_respective_amount(Variable):
     label = "Child Benefit (respective amount)"
@@ -76,6 +68,16 @@ class child_benefit_respective_amount(Variable):
         return eligible * amount * WEEKS_IN_YEAR
 
 
+class child_benefit_entitlement(Variable):
+    label = "CB entitlement"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = float
+    unit = "currency-GBP"
+
+    formula = sum_of_variables(["child_benefit_respective_amount"])
+
+
 class child_benefit(Variable):
     label = "Child Benefit"
     documentation = "Total Child Benefit for the benefit unit"
@@ -85,10 +87,9 @@ class child_benefit(Variable):
     unit = GBP
 
     def formula(benunit, period):
-        entitlement = benunit.sum(
-            benunit.members("child_benefit_respective_amount", period)
-        )
-        return entitlement * benunit("would_claim_child_benefit", period)
+        entitlement = benunit("child_benefit_entitlement", period)
+        would_claim = benunit("would_claim_child_benefit", period)
+        return would_claim * entitlement
 
 
 class child_benefit_less_tax_charge(Variable):
@@ -107,10 +108,8 @@ class child_benefit_less_tax_charge(Variable):
         return benefit - charge
 
 
-class baseline_is_cb_eligible(Variable):
+class baseline_child_benefit_entitlement(Variable):
     label = "Child Benefit (baseline)"
     entity = BenUnit
     definition_period = YEAR
-    value_type = bool
-
-
+    value_type = float

--- a/openfisca_uk/variables/gov/hmrc/child_benefit.py
+++ b/openfisca_uk/variables/gov/hmrc/child_benefit.py
@@ -73,7 +73,7 @@ class child_benefit_entitlement(Variable):
     entity = BenUnit
     definition_period = YEAR
     value_type = float
-    unit = "currency-GBP"
+    unit = GBP
 
     formula = sum_of_variables(["child_benefit_respective_amount"])
 


### PR DESCRIPTION
I think this is what's causing some overestimation of Universal Credit participants (~600k families). Fixed when re-running the dataset generation after these changes are applied.