### PR TITLE
Fix pension contributions deduction

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Bug causing pension contributions to not be correctly deducted from taxable income.

--- a/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/lcfs_imputation.py
+++ b/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/lcfs_imputation.py
@@ -63,12 +63,18 @@ def impute_consumption(year: int, dataset: type = FRS) -> pd.Series:
 
     from policyengine_uk import Microsimulation
 
-    sender = Microsimulation(dataset=LCFS, dataset_year=year,).df(
+    sender = Microsimulation(
+        dataset=LCFS,
+        dataset_year=year,
+    ).df(
         PREDICTOR_VARIABLES + IMPUTE_VARIABLES,
         map_to="household",
     )
 
-    receiver = Microsimulation(dataset=dataset, dataset_year=year,).df(
+    receiver = Microsimulation(
+        dataset=dataset,
+        dataset_year=year,
+    ).df(
         PREDICTOR_VARIABLES,
         map_to="household",
     )

--- a/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/lcfs_imputation.py
+++ b/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/lcfs_imputation.py
@@ -63,18 +63,12 @@ def impute_consumption(year: int, dataset: type = FRS) -> pd.Series:
 
     from policyengine_uk import Microsimulation
 
-    sender = Microsimulation(
-        dataset=LCFS,
-        dataset_year=year,
-    ).df(
+    sender = Microsimulation(dataset=LCFS, dataset_year=year,).df(
         PREDICTOR_VARIABLES + IMPUTE_VARIABLES,
         map_to="household",
     )
 
-    receiver = Microsimulation(
-        dataset=dataset,
-        dataset_year=year,
-    ).df(
+    receiver = Microsimulation(dataset=dataset, dataset_year=year,).df(
         PREDICTOR_VARIABLES,
         map_to="household",
     )

--- a/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/was_imputation.py
+++ b/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/was_imputation.py
@@ -59,12 +59,18 @@ def impute_wealth(year: int, dataset: type = FRS) -> pd.Series:
 
     from policyengine_uk import Microsimulation
 
-    sender = Microsimulation(dataset=WAS, dataset_year=year,).df(
+    sender = Microsimulation(
+        dataset=WAS,
+        dataset_year=year,
+    ).df(
         PREDICTOR_VARIABLES + IMPUTE_VARIABLES,
         map_to="household",
     )
 
-    receiver = Microsimulation(dataset=dataset, dataset_year=year,).df(
+    receiver = Microsimulation(
+        dataset=dataset,
+        dataset_year=year,
+    ).df(
         PREDICTOR_VARIABLES,
         map_to="household",
     )

--- a/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/was_imputation.py
+++ b/policyengine_uk/data/datasets/frs/enhanced/stages/imputation/was_imputation.py
@@ -59,18 +59,12 @@ def impute_wealth(year: int, dataset: type = FRS) -> pd.Series:
 
     from policyengine_uk import Microsimulation
 
-    sender = Microsimulation(
-        dataset=WAS,
-        dataset_year=year,
-    ).df(
+    sender = Microsimulation(dataset=WAS, dataset_year=year,).df(
         PREDICTOR_VARIABLES + IMPUTE_VARIABLES,
         map_to="household",
     )
 
-    receiver = Microsimulation(
-        dataset=dataset,
-        dataset_year=year,
-    ).df(
+    receiver = Microsimulation(dataset=dataset, dataset_year=year,).df(
         PREDICTOR_VARIABLES,
         map_to="household",
     )

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit.yaml
@@ -19,7 +19,7 @@
         rent: 10000
   output:
     universal_credit: 0
-    income_tax: 3286
+    income_tax: 3086
     national_insurance: 2451.83
 - name: Renting, single, 30, employed with little earnings
   period: 2022

--- a/policyengine_uk/tests/policy/baseline/finance/tax/income_tax/income_tax.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/tax/income_tax/income_tax.yaml
@@ -12,7 +12,7 @@
     employment_income: 34000
     pension_contributions: 1200
   output:
-    income_tax: 4058
+    income_tax: 3820
 - name: Income Tax for earner with pension contributions in 2018
   period: 2018
   absolute_error_margin: 10
@@ -20,7 +20,7 @@
     employment_income: 34000
     pension_contributions: 1200
   output:
-    income_tax: 4258
+    income_tax: 4020
 - name: Income Tax for earner with pension contributions in 2019
   period: 2019
   absolute_error_margin: 10
@@ -28,7 +28,7 @@
     employment_income: 34000
     pension_contributions: 1200
   output:
-    income_tax: 4188
+    income_tax: 3950
 - name: Income Tax for earner in 2019
   period: 2019
   absolute_error_margin: 10

--- a/policyengine_uk/variables/gov/hmrc/income_tax/liability.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/liability.py
@@ -19,6 +19,7 @@ class earned_taxable_income(Variable):
             "taxable_dividend_income",
             "allowances",
             "marriage_allowance",
+            "pension_contributions_relief",
         ]
         ANI = person("adjusted_net_income", period)
         exclusions = add(person, period, EXCLUSIONS)

--- a/policyengine_uk/variables/gov/hmrc/income_tax/relief.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/relief.py
@@ -107,7 +107,7 @@ class pension_contributions_relief(Variable):
         basic_amount = parameters(
             period
         ).gov.hmrc.income_tax.reliefs.pension_contribution.basic_amount
-        tax_relief = min_(pay, max_(basic_amount, contributions)) * under_75
+        tax_relief = min_(pay, min_(basic_amount, contributions)) * under_75
         return min_(tax_relief, person("pension_annual_allowance", period))
 
 

--- a/policyengine_uk/variables/gov/hmrc/income_tax/relief.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/relief.py
@@ -107,8 +107,11 @@ class pension_contributions_relief(Variable):
         basic_amount = parameters(
             period
         ).gov.hmrc.income_tax.reliefs.pension_contribution.basic_amount
-        tax_relief = min_(pay, min_(basic_amount, contributions)) * under_75
-        return min_(tax_relief, person("pension_annual_allowance", period))
+        tax_relief = min_(pay, contributions) * under_75
+        return min_(
+            tax_relief,
+            max_(basic_amount, person("pension_annual_allowance", period)),
+        )
 
 
 # Savings interest income


### PR DESCRIPTION
This reduces income tax revenues by around £5bn so should need a recalibration, but I think I'm pretty close with the data package so will leave for that. After this fix I checked the total relief value of pension contributions and got £23bn in the model compared to [£27bn official estimate by the SPI](https://www.gov.uk/government/statistics/main-tax-expenditures-and-structural-reliefs/non-structural-tax-relief-statistics-january-2023).