### PR TITLE
Assume 100% consumer incidence for fuel duty

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+    - Fuel duty incidence assumed to be 100% on consumers.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/fuel_duty/fuel_duty.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/fuel_duty/fuel_duty.yaml
@@ -5,4 +5,4 @@
     petrol_spending: 1_200
   output:
     petrol_litres: 805
-    fuel_duty: 470
+    fuel_duty: 470 / 0.51

--- a/policyengine_uk/tests/policy/reforms/parametric/fuel_duty_cut.yaml
+++ b/policyengine_uk/tests/policy/reforms/parametric/fuel_duty_cut.yaml
@@ -4,7 +4,7 @@
   input:
     petrol_spending: 100
   output:
-    fuel_duty: 54.32
+    fuel_duty: 54.32 / 0.51
   
 - name: Reduction from 5p cut
   period: 2021
@@ -12,6 +12,6 @@
   input:
     gov.hmrc.fuel_duty.petrol_and_diesel: 0.5295
     petrol_spending: 100
-    baseline_fuel_duty: 54.32
+    baseline_fuel_duty: 54.32 / 0.51
   output:
-    change_in_fuel_duty: -5
+    change_in_fuel_duty: -5 / 0.51

--- a/policyengine_uk/variables/gov/hmrc/fuel_duty/fuel_duty.py
+++ b/policyengine_uk/variables/gov/hmrc/fuel_duty/fuel_duty.py
@@ -1,6 +1,10 @@
 from policyengine_uk.model_api import *
 
 
+STATUTORY_CONSUMER_INCIDENCE = 0.508
+ECONOMIC_CONSUMER_INCIDENCE = 1
+
+
 class fuel_duty(Variable):
     label = "Fuel duty (cars only)"
     entity = Household
@@ -12,7 +16,12 @@ class fuel_duty(Variable):
         fd = parameters(period).gov.hmrc.fuel_duty
         petrol_litres = household("petrol_litres", period)
         diesel_litres = household("diesel_litres", period)
-        return fd.petrol_and_diesel * (petrol_litres + diesel_litres)
+        return (
+            fd.petrol_and_diesel
+            * (petrol_litres + diesel_litres)
+            / STATUTORY_CONSUMER_INCIDENCE
+            * ECONOMIC_CONSUMER_INCIDENCE
+        )
 
 
 class baseline_fuel_duty(Variable):


### PR DESCRIPTION
How should we handle fuel duty paid by firms, not households? This change adds an assumption that non-household fuel duty is borne by households, proportionately according to their household fuel duty statutory incidence.