### PR TITLE
Fix bug in income-splitting

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - A bug in the income-splitting logic that caused taxable incomes to be too low.

--- a/policyengine_uk/reforms/cps/marriage_tax_reforms.py
+++ b/policyengine_uk/reforms/cps/marriage_tax_reforms.py
@@ -175,7 +175,7 @@ def create_marriage_neutral_income_tax_reform(
             originally_split_income_branch.set_input(
                 "adjusted_net_income", period, income
             )
-            originally_split_income_tax = (
+            originally_split_income_tax = person.benunit.sum(
                 originally_split_income_branch.calculate("income_tax", period)
             )
 
@@ -190,12 +190,12 @@ def create_marriage_neutral_income_tax_reform(
             split_income_branch.set_input(
                 "adjusted_net_income", period, split_income
             )
-            split_income_tax = split_income_branch.calculate(
-                "income_tax", period
+            split_income_tax = person.benunit.sum(
+                split_income_branch.calculate("income_tax", period)
             )
 
             return where(
-                split_income_tax < originally_split_income_tax,
+                split_income_tax <= originally_split_income_tax,
                 split_income,
                 income,
             )


### PR DESCRIPTION
This fixes a bug in the income-splitting procedure that caused taxable incomes to be too low, and therefore a too-large tax cut. 