### PR TITLE
Update National Insurance rates to align with Autumn Update 2023

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - Lowered rates for Class 1 and Class 4 NICs, pursuant to the Autumn Update 2023
+    - Set Class 2 NIC rate to 0%, pursuant to the Autumn Update 2023

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,5 +1,5 @@
 - bump: patch
   changes:
     changed:
-    - Lowered rates for Class 1 and Class 4 NICs, pursuant to the Autumn Update 2023
-    - Set Class 2 NIC rate to 0%, pursuant to the Autumn Update 2023
+    - Lowered rates for Class 1 and Class 4 NICs, pursuant to the Autumn Statement 2023
+    - Set Class 2 NIC rate to 0%, pursuant to the Autumn Statement 2023

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/class_1/rates/employee/main.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/class_1/rates/employee/main.yaml
@@ -17,8 +17,7 @@ values:
     value: 0.1
     metadata:
       reference:
-        - title: >-
-          Autumn Statement 2023: National Insurance Factsheet
+        - title: "Autumn Statement 2023: National Insurance Factsheet"
           href: https://www.gov.uk/government/publications/autumn-statement-2023-national-insurance-factsheet/autumn-statement-2023-national-insurance-factsheet
 metadata:
   label: NI Class 1 main rate

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/class_1/rates/employee/main.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/class_1/rates/employee/main.yaml
@@ -13,6 +13,13 @@ values:
       reference:
         - title: Health and Social Care Levy Act (Repeal) 2022
           href: https://www.legislation.gov.uk/ukpga/2022/43/section/2
+  2024-01-06:
+    value: 0.1
+    metadata:
+      reference:
+        - title: >-
+          Autumn Statement 2023: National Insurance Factsheet
+          href: https://www.gov.uk/government/publications/autumn-statement-2023-national-insurance-factsheet/autumn-statement-2023-national-insurance-factsheet
 metadata:
   label: NI Class 1 main rate
   name: NI_main_rate

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/class_2/flat_rate.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/class_2/flat_rate.yaml
@@ -15,8 +15,7 @@ values:
     value: 0
     metadata:
       reference:
-        - title: >-
-          Autumn Statement 2023: National Insurance Factsheet 
+        - title: "Autumn Statement 2023: National Insurance Factsheet"
           href: https://www.gov.uk/government/publications/autumn-statement-2023-national-insurance-factsheet/autumn-statement-2023-national-insurance-factsheet
 metadata:
   unit: currency-GBP

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/class_2/flat_rate.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/class_2/flat_rate.yaml
@@ -11,6 +11,13 @@ values:
       reference:
         - title: The Social Security (Contributions) (Rates, Limits and Thresholds Amendments and National Insurance Funds Payments) Regulations 2022(3)(a)
           href: https://www.legislation.gov.uk/uksi/2022/232/regulation/3/made#regulation-3-a
+  2024-04-06:
+    value: 0
+    metadata:
+      reference:
+        - title: >-
+          Autumn Statement 2023: National Insurance Factsheet 
+          href: https://www.gov.uk/government/publications/autumn-statement-2023-national-insurance-factsheet/autumn-statement-2023-national-insurance-factsheet
 metadata:
   unit: currency-GBP
   label: NI Class 2 Flat Rate

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/class_4/rates/main.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/class_4/rates/main.yaml
@@ -17,8 +17,7 @@ values:
     value: 0.08
     metadata:
       reference:
-        - title: >-
-          Autumn Statement 2023: National Insurance Factsheet
+        - title: "Autumn Statement 2023: National Insurance Factsheet"
           href: https://www.gov.uk/government/publications/autumn-statement-2023-national-insurance-factsheet/autumn-statement-2023-national-insurance-factsheet
 metadata:
   label: NI Class 4 main rate

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/class_4/rates/main.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/class_4/rates/main.yaml
@@ -13,6 +13,13 @@ values:
       reference:
         - title: Health and Social Care Levy Act (Repeal) 2022
           href: https://www.legislation.gov.uk/ukpga/2022/43/section/2
+  2024-04-06:
+    value: 0.08
+    metadata:
+      reference:
+        - title: >-
+          Autumn Statement 2023: National Insurance Factsheet
+          href: https://www.gov.uk/government/publications/autumn-statement-2023-national-insurance-factsheet/autumn-statement-2023-national-insurance-factsheet
 metadata:
   label: NI Class 4 main rate
   name: NI_class_4_main_rate


### PR DESCRIPTION
Fixes #824
Fixes #825 
Fixes #826 

This PR updates NIC rates to align with the Autumn Update 2023. It does not deal with any other reforms, if any, introduced by the update. Additionally, it does not write any new tests for the relevant portions of the NIC variable, as tests already exist for them.