### PR TITLE
Auto-updating for household API

### DIFF
--- a/.github/update_api.py
+++ b/.github/update_api.py
@@ -16,6 +16,14 @@ def main():
     os.system(
         f"cd policyengine-api && python gcp/bump_country_package.py --country policyengine-uk --version {version}"
     )
+    # Repeat the above for https://github.com/policyengine/policyengine-household-api
+    os.system(
+        f"git clone https://nikhilwodruff:{pat}@github.com/policyengine/policyengine-household-api"
+    )
+
+    os.system(
+        f"cd policyengine-household-api && python gcp/bump_country_package.py --country policyengine-us --version {version}"
+    )
 
 
 if __name__ == "__main__":

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Auto-updating of the household API when this package is updated


### PR DESCRIPTION
Fixes #861. This duplicates what was done in PolicyEngine/policyengine-us#4537 in order to add auto-updating of this package to the household API.