### PR TITLE
Update PIP, DLA, and AA parameters

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    changed:
+    - Uprated PIP, DLA, and Accessibility Account
+    - Re-enabled PIP and DLA within webapp
+    - Corrected mistakes in PIP

--- a/policyengine_uk/parameters/gov/dwp/attendance_allowance/higher.yaml
+++ b/policyengine_uk/parameters/gov/dwp/attendance_allowance/higher.yaml
@@ -8,7 +8,11 @@ values:
   2020-04-01: 89.15
   2021-04-01: 89.60
   2022-04-01: 92.40
-  2023-04-01: 101.75
+  2023-04-01: 
+    value: 101.75
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
   2024-04-01: 
     value: 108.55
     reference:

--- a/policyengine_uk/parameters/gov/dwp/attendance_allowance/lower.yaml
+++ b/policyengine_uk/parameters/gov/dwp/attendance_allowance/lower.yaml
@@ -8,7 +8,11 @@ values:
   2020-04-01: 59.70
   2021-04-01: 60.00
   2022-04-01: 61.85
-  2023-04-01: 68.10
+  2023-04-01:
+    value: 68.10
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
   2024-04-01: 
     value: 72.65
     reference:

--- a/policyengine_uk/parameters/gov/dwp/dla/README.md
+++ b/policyengine_uk/parameters/gov/dwp/dla/README.md
@@ -1,1 +1,1 @@
-# DLA
+# Disability Living Allowance

--- a/policyengine_uk/parameters/gov/dwp/dla/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/dla/index.yaml
@@ -1,4 +1,2 @@
 metadata:
-  economy: false
-  household: false
   propagate_metadata_to_children: true

--- a/policyengine_uk/parameters/gov/dwp/dla/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/dla/index.yaml
@@ -1,2 +1,0 @@
-metadata:
-  propagate_metadata_to_children: true

--- a/policyengine_uk/parameters/gov/dwp/dla/mobility/higher.yaml
+++ b/policyengine_uk/parameters/gov/dwp/dla/mobility/higher.yaml
@@ -1,23 +1,28 @@
 description: Higher rate for Disability Living Allowance (mobility component).
 values:
-  2015-04-01: 55.10
-  2016-04-01: 55.10
-  2017-04-01: 55.65
-  2018-04-01: 57.30
-  2019-04-01: 58.70
-  2020-04-01: 59.70
-  2021-04-01: 60.00
-  2022-04-01: 61.85
-  2024-04-01: 
-    value: 75.75
-    reference:
-      - title: Benefits Uprating 2024/25 | Commons Library Briefing
-        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
+  2015-04-01: 
+    value: 57.45
+    reference: 
+      - title: Benefits Uprating 2022/23
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+  2016-04-01:
+    value: 57.45
+    reference: 
+      - title: Benefits Uprating 2022/23
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+  2017-04-01: 58.00
+  2018-04-01: 59.75
+  2019-04-01: 61.20
+  2020-04-01: 62.25
+  2021-04-01: 62.55
+  2022-04-01: 64.50
+  2023-04-01: 71.00
+  2024-04-01: 75.75
 metadata:
   period: week
   unit: currency-GBP
   name: dla_m_higher
   label: DLA (mobility) (higher rate)
-  reference: 
-    - title: Benefits Uprating 2022/23
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+  reference:
+    - title: Benefits Uprating 2024/25 | Commons Library Briefing
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf

--- a/policyengine_uk/parameters/gov/dwp/dla/mobility/lower.yaml
+++ b/policyengine_uk/parameters/gov/dwp/dla/mobility/lower.yaml
@@ -8,6 +8,11 @@ values:
   2020-04-01: 23.60
   2021-04-01: 23.70
   2022-04-01: 24.45
+  2023-04-01: 
+    value: 26.90
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
   2024-04-01: 
     value: 28.70
     reference:

--- a/policyengine_uk/parameters/gov/dwp/dla/self_care/higher.yaml
+++ b/policyengine_uk/parameters/gov/dwp/dla/self_care/higher.yaml
@@ -8,6 +8,11 @@ values:
   2020-04-01: 89.15
   2021-04-01: 89.60
   2022-04-01: 92.40
+  2023-04-01: 
+    value: 101.75
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
   2024-04-01: 
     value: 108.55
     reference:

--- a/policyengine_uk/parameters/gov/dwp/dla/self_care/lower.yaml
+++ b/policyengine_uk/parameters/gov/dwp/dla/self_care/lower.yaml
@@ -8,6 +8,11 @@ values:
   2020-04-01: 23.60
   2021-04-01: 23.70
   2022-04-01: 24.45
+  2023-04-01: 
+    value: 26.90
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
   2024-04-01: 
     value: 28.70
     reference:

--- a/policyengine_uk/parameters/gov/dwp/dla/self_care/middle.yaml
+++ b/policyengine_uk/parameters/gov/dwp/dla/self_care/middle.yaml
@@ -8,6 +8,11 @@ values:
   2020-04-01: 59.70
   2021-04-01: 60.00
   2022-04-01: 61.85
+  2023-04-01: 
+    value: 68.10
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
   2024-04-01: 
     value: 72.65
     reference:

--- a/policyengine_uk/parameters/gov/dwp/pip/daily_living/enhanced.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/daily_living/enhanced.yaml
@@ -8,11 +8,13 @@ values:
   2020-04-01: 89.15
   2021-04-01: 89.60
   2022-04-01: 92.40
+  2023-04-01: 101.75
+  2024-04-01: 108.55
 metadata:
   period: week
   unit: currency-GBP
   name: pip_dl_enhanced
   label: PIP (daily living) (enhanced rate)
   reference: 
-    - title: Benefits Uprating 2022/23
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+    - title: Benefits Uprating 2024/25
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/daily_living/enhanced.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/daily_living/enhanced.yaml
@@ -8,13 +8,21 @@ values:
   2020-04-01: 89.15
   2021-04-01: 89.60
   2022-04-01: 92.40
-  2023-04-01: 101.75
-  2024-04-01: 108.55
+  2023-04-01:
+    value: 101.75
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
+  2024-04-01:
+    value: 108.55
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
 metadata:
   period: week
   unit: currency-GBP
   name: pip_dl_enhanced
   label: PIP (daily living) (enhanced rate)
   reference: 
-    - title: Benefits Uprating 2024/25
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
+    - title: Benefits Uprating 2022/23
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/daily_living/standard.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/daily_living/standard.yaml
@@ -8,11 +8,13 @@ values:
   2020-04-01: 59.70
   2021-04-01: 60.00
   2022-04-01: 61.85
+  2023-04-01: 68.10
+  2024-04-01: 72.65
 metadata:
   period: week
   unit: currency-GBP
   name: pip_dl_standard
   label: PIP (daily living) (standard rate)
   reference: 
-    - title: Benefits Uprating 2022/23
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+    - title: Benefits Uprating 2024/25
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/daily_living/standard.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/daily_living/standard.yaml
@@ -8,13 +8,21 @@ values:
   2020-04-01: 59.70
   2021-04-01: 60.00
   2022-04-01: 61.85
-  2023-04-01: 68.10
-  2024-04-01: 72.65
+  2023-04-01: 
+    value: 68.10
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
+  2024-04-01:
+    value: 72.65
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
 metadata:
   period: week
   unit: currency-GBP
   name: pip_dl_standard
   label: PIP (daily living) (standard rate)
   reference: 
-    - title: Benefits Uprating 2024/25
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
+    - title: Benefits Uprating 2022/23
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/index.yaml
@@ -1,4 +1,2 @@
 metadata:
-  economy: false
-  household: false
   propagate_metadata_to_children: true

--- a/policyengine_uk/parameters/gov/dwp/pip/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/index.yaml
@@ -1,2 +1,0 @@
-metadata:
-  propagate_metadata_to_children: true

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/enhanced.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/enhanced.yaml
@@ -1,7 +1,15 @@
 description: Enhanced rate for Personal Independence Payment (mobility component).
 values:
-  2015-04-01: 55.10
-  2016-04-01: 55.10
+  2015-04-01:
+    value: 57.45
+    reference: 
+      - title: Benefits Uprating 2022/23
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+  2016-04-01:
+    value: 57.45
+    reference: 
+      - title: Benefits Uprating 2022/23
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
   2017-04-01: 58.00
   2018-04-01: 59.75
   2019-04-01: 61.20

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/enhanced.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/enhanced.yaml
@@ -23,7 +23,7 @@ metadata:
   period: week
   unit: currency-GBP
   name: dla_m_enhanced
-  label: DLA (mobility) (enhanced rate)
+  label: PIP (mobility) (enhanced rate)
   reference: 
     - title: Benefits Uprating 2024/25
       href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/enhanced.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/enhanced.yaml
@@ -2,17 +2,20 @@ description: Enhanced rate for Personal Independence Payment (mobility component
 values:
   2015-04-01: 55.10
   2016-04-01: 55.10
-  2017-04-01: 55.65
-  2018-04-01: 57.30
-  2019-04-01: 58.70
-  2020-04-01: 59.70
-  2021-04-01: 60.00
-  2022-04-01: 61.85
+  2017-04-01: 58.00
+  2018-04-01: 59.75
+  2019-04-01: 61.20
+  2020-04-01: 62.25
+  2021-04-01: 62.55
+  2022-04-01: 64.50
+  2023-04-01: 71.00
+  2024-04-01: 75.75
+
 metadata:
   period: week
   unit: currency-GBP
   name: dla_m_enhanced
   label: DLA (mobility) (enhanced rate)
   reference: 
-    - title: Benefits Uprating 2022/23
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+    - title: Benefits Uprating 2024/25
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/standard.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/standard.yaml
@@ -8,11 +8,13 @@ values:
   2020-04-01: 23.60
   2021-04-01: 23.70
   2022-04-01: 24.45
+  2023-04-01: 26.90
+  2024-04-01: 28.70
 metadata:
   period: week
   unit: currency-GBP
   name: dla_m_standard
   label: DLA (mobility) (standard rate)
   reference: 
-    - title: Benefits Uprating 2022/23
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf
+    - title: Benefits Uprating 2024/25
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/standard.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/standard.yaml
@@ -22,7 +22,7 @@ metadata:
   period: week
   unit: currency-GBP
   name: dla_m_standard
-  label: DLA (mobility) (standard rate)
+  label: PIP (mobility) (standard rate)
   reference: 
     - title: Benefits Uprating 2022/23
       href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/standard.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/standard.yaml
@@ -8,13 +8,21 @@ values:
   2020-04-01: 23.60
   2021-04-01: 23.70
   2022-04-01: 24.45
-  2023-04-01: 26.90
-  2024-04-01: 28.70
+  2023-04-01: 
+    value: 26.90
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
+  2024-04-01:
+    value: 28.70
+    reference:
+      - title: Benefits Uprating 2024/25 | Commons Library Briefing
+        href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
 metadata:
   period: week
   unit: currency-GBP
   name: dla_m_standard
   label: DLA (mobility) (standard rate)
   reference: 
-    - title: Benefits Uprating 2024/25
-      href: https://researchbriefings.files.parliament.uk/documents/CBP-9872/CBP-9872.pdf
+    - title: Benefits Uprating 2022/23
+      href: https://researchbriefings.files.parliament.uk/documents/CBP-9439/CBP-9439.pdf

--- a/policyengine_uk/variables/gov/dwp/pip/mobility.py
+++ b/policyengine_uk/variables/gov/dwp/pip/mobility.py
@@ -5,7 +5,7 @@ from policyengine_uk.variables.gov.dwp.pip.pip import PIPCategory
 class PIP_M_reported(Variable):
     value_type = float
     entity = Person
-    label = "Disability Living Allowance (mobility) (reported)"
+    label = "PIP (mobility) (reported)"
     definition_period = YEAR
     unit = GBP
 


### PR DESCRIPTION
Fixes #874. Fixes #875. Fixes #876. This PR uprates three parameters in order to enable analysis of the Green Party manifesto: the Personal Independence Payment, Disability Living Allowance, and Attendance Allowance. It also reactivates the PIP and DLA in the web app.