### PR TITLE
Ensure household API version bumps UK correctly

### DIFF
--- a/.github/update_api.py
+++ b/.github/update_api.py
@@ -21,8 +21,9 @@ def main():
         f"git clone https://nikhilwodruff:{pat}@github.com/policyengine/policyengine-household-api"
     )
 
+    # Then, cd inside and run gcp/bump_country_package.py --country policyengine-uk --version {version}
     os.system(
-        f"cd policyengine-household-api && python gcp/bump_country_package.py --country policyengine-us --version {version}"
+        f"cd policyengine-household-api && python gcp/bump_country_package.py --country policyengine-uk --version {version}"
     )
 
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Ensure household API version script bumps UK version


### PR DESCRIPTION
Fixes #895.

Ensures that this packages bumps the UK version of the household API, not US