### PR TITLE
Add mask to `private_school_vat`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Mask applied to private_school_vat to prevent calculation error when household weights aren't provided

--- a/policyengine_uk/variables/contrib/labour/private_school_vat.py
+++ b/policyengine_uk/variables/contrib/labour/private_school_vat.py
@@ -34,8 +34,13 @@ class attends_private_school(Variable):
 
         household_weight = household("household_weight", period)
         weighted_income = MicroSeries(net_income, weights=household_weight)
-        percentile = (
-            weighted_income.percentile_rank()
+
+        percentile = np.zeros_like(weighted_income).astype(numpy.int64)
+        mask = household_weight > 0
+
+        percentile[mask] = (
+            weighted_income[mask]
+            .percentile_rank()
             .clip(0, 100)
             .values.astype(numpy.int64)
         )


### PR DESCRIPTION
Fixes #928 

PR adds a mask to `private_school_vat` to prevent crashing in cases where household weights aren't provided (e.g., household calculator runs).

This PR does not yet add tests for `private_school_vat` itself, which was previously untested. I will try to do so and add them to this PR, but considering the priority level of these fixes, wanted to give an option for quick merging.