### PR TITLE
Add tests to `private_school_vat` and `attends_private_school`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,7 @@
+- bump: patch
+  changes:
+    added:
+    - Test suite for private_school_vat
+    - Test suite for attends_private_school
+    removed:
+    - Unnecessary print statement in winter_fuel_allowance

--- a/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
+++ b/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
@@ -1,0 +1,63 @@
+- name: Attends private school returns True when attendance rate is 100%
+  period: 2024
+  input:
+    gov.simulation.private_school_vat.private_school_attendance_rate.100: 1
+    gov.simulation.private_school_vat.private_school_attendance_rate.95: 1
+    people:
+      adult: 
+        age: 25
+      child:
+        age: 10
+    households:
+      household:
+        household_weight: 0.001
+        household_market_income: 1_000_000_000
+        household_benefits: 0
+        members: [
+          adult,
+          child
+        ]
+  output:
+    attends_private_school: [False, True]
+
+- name: Attends private school returns False when attendance rate is 0%
+  period: 2024
+  input:
+    gov.simulation.private_school_vat.private_school_attendance_rate.100: 0
+    gov.simulation.private_school_vat.private_school_attendance_rate.95: 0
+    people:
+      adult: 
+        age: 25
+      child:
+        age: 10
+    households:
+      household:
+        household_weight: 0.001
+        household_market_income: 1_000_000_000
+        household_benefits: 0
+        members: [
+          adult,
+          child
+        ]
+  output:
+    attends_private_school: [False, False]
+
+- name: Attends private school successfully returns False when household weights are 0
+  period: 2024
+  input:
+    people:
+      adult: 
+        age: 25
+      child:
+        age: 10
+    households:
+      household:
+        household_weight: 0
+        household_market_income: 1_000_000_000
+        household_benefits: 0
+        members: [
+          adult,
+          child
+        ]
+  output:
+    attends_private_school: [False, False]

--- a/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
+++ b/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
@@ -61,3 +61,25 @@
         ]
   output:
     attends_private_school: [False, False]
+
+- name: Correctly interpolates individual percentiles into ventiles
+  period: 2024
+  input:
+    gov.simulation.private_school_vat.private_school_attendance_rate.0: 0
+    gov.simulation.private_school_vat.private_school_attendance_rate.5: 1
+    people:
+      adult: 
+        age: 25
+      child:
+        age: 10
+    households:
+      household:
+        household_weight: 0.001
+        household_benefits: 0
+        household_market_income: 0
+        members: [
+          adult,
+          child
+        ]
+  output:
+    attends_private_school: [False, False]

--- a/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
+++ b/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
@@ -61,25 +61,3 @@
         ]
   output:
     attends_private_school: [False, False]
-
-- name: Correctly interpolates individual percentiles into ventiles
-  period: 2024
-  input:
-    gov.simulation.private_school_vat.private_school_attendance_rate.0: 0
-    gov.simulation.private_school_vat.private_school_attendance_rate.5: 1
-    people:
-      adult: 
-        age: 25
-      child:
-        age: 10
-    households:
-      household:
-        household_weight: 0.001
-        household_benefits: 0
-        household_market_income: 0
-        members: [
-          adult,
-          child
-        ]
-  output:
-    attends_private_school: [False, False]

--- a/policyengine_uk/tests/policy/baseline/contrib/labour/private_school_vat.yaml
+++ b/policyengine_uk/tests/policy/baseline/contrib/labour/private_school_vat.yaml
@@ -1,0 +1,65 @@
+- name: Returns 0 when no children
+  period: 2024
+  input:
+    # Set private school VAT rate to 25% to ensure correct testing
+    gov.contrib.labour.private_school_vat: 0.25
+    people:
+      adult: 
+        age: 25
+    households:
+      household:
+        members: [
+          adult,
+        ]
+  output:
+    private_school_vat: 0
+
+- name: Returns correctly with one child
+  period: 2024
+  input:
+    # Set private school VAT rate to 25% to ensure correct testing
+    gov.contrib.labour.private_school_vat: 0.25
+    # Override other default settings for easier testing
+    gov.simulation.private_school_vat.private_school_vat_basis: 1
+    gov.simulation.private_school_vat.private_school_fees: 10_000
+    people:
+      adult: 
+        age: 25
+      child:
+        age: 10
+        attends_private_school: True
+    households:
+      household:
+        members: [
+          adult,
+          child
+        ]
+  output:
+    private_school_vat: 2_500
+
+- name: Returns correct value with 2+ children
+  period: 2024
+  input:
+    # Set private school VAT rate to 25% to ensure correct testing
+    gov.contrib.labour.private_school_vat: 0.25
+    # Override other default settings for easier testing
+    gov.simulation.private_school_vat.private_school_vat_basis: 1
+    gov.simulation.private_school_vat.private_school_fees: 10_000
+    people:
+      adult: 
+        age: 25
+      child1:
+        age: 10
+        attends_private_school: True
+      child2:
+        age: 12
+        attends_private_school: True
+    households:
+      household:
+        members: [
+          adult,
+          child1,
+          child2
+        ]
+  output:
+    private_school_vat: 5_000

--- a/policyengine_uk/variables/gov/dwp/WFA.py
+++ b/policyengine_uk/variables/gov/dwp/WFA.py
@@ -34,7 +34,6 @@ class winter_fuel_allowance(Variable):
             > 0
         )
         meets_mtb_requirement = on_mtb | ~wfp.eligibility.require_benefits
-        print(wfp.eligibility.require_benefits)
         meets_spa_requirement = (
             household.any(is_SP_age)
             | ~wfp.eligibility.state_pension_age_requirement


### PR DESCRIPTION
Fixes #932. This is meant to be a continuation to the fix introduced in #928 meant to harden `private_school_vat` and prevent a similar error from arising in the future.