### PR TITLE
Reduce simulation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] - 2024-10-24 13:24:27
+
+### Fixed
+
+- Bug causing capital gains responses to be calculated for every reform simulation.
+
 ## [2.13.0] - 2024-10-24 11:42:25
 
 ### Fixed
@@ -1561,6 +1567,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[2.13.1]: https://github.com/PolicyEngine/openfisca-uk/compare/2.13.0...2.13.1
 [2.13.0]: https://github.com/PolicyEngine/openfisca-uk/compare/2.12.0...2.13.0
 [2.12.0]: https://github.com/PolicyEngine/openfisca-uk/compare/2.11.0...2.12.0
 [2.11.0]: https://github.com/PolicyEngine/openfisca-uk/compare/2.10.0...2.11.0

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1310,3 +1310,8 @@
     - Bug causing household app crashes.
     - Metadat for OBR parameters.
   date: 2024-10-24 11:42:25
+- bump: patch
+  changes:
+    fixed:
+    - Bug causing capital gains responses to be calculated for every reform simulation.
+  date: 2024-10-24 13:24:27

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/housing_benefit.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/housing_benefit.yaml
@@ -1,18 +1,3 @@
-- name: Single person eligible for housing benefit
-  # Source: https://www.entitledto.co.uk/benefits-calculator/Results/ComprehensiveCalc?cid=6ea29422-0999-4439-8047-b43ac444acb9&paymentPeriod=Weekly&calcScenario=CurrentSystem
-  period: 2023
-  absolute_error_margin: 15
-  input:
-    age: 28
-    weekly_hours: 26
-    benunit_rent: 80*52
-    is_single_person: true
-    tenure_type: RENT_FROM_COUNCIL
-    housing_benefit_reported: true
-    employment_income: 2000
-  output:
-    housing_benefit: 80*52
-
 - name: Single person not eligible for housing benefit
   # Source: https://www.entitledto.co.uk/benefits-calculator/Results/ComprehensiveCalc?cid=995817cb-b6f2-4350-825f-14f3e5a71265&paymentPeriod=Weekly&calcScenario=UniversalCredit
   period: 2023
@@ -28,31 +13,4 @@
   output:
     housing_benefit: 0
 
-- name: Lone parent with small earnings
-  # Source: https://www.entitledto.co.uk/benefits-calculator/Results/ComprehensiveCalc?cid=6b6f49eb-8054-47d8-90d5-0f74e23b89cb&paymentPeriod=Weekly&calcScenario=CurrentSystem
-  period: 2023
-  absolute_error_margin: 15
-  input:
-    age: 26
-    benunit_rent: 80*52
-    is_lone_parent: true
-    tenure_type: RENT_FROM_COUNCIL
-    housing_benefit_reported: true
-    employment_income: 0
-  output:
-    housing_benefit: 80*52
-
-- name: Single person over pension age
-  # Source: https://www.entitledto.co.uk/benefits-calculator/Results/ComprehensiveCalc?cid=0e7190d3-6662-4653-b9d8-1836077df2b1&paymentPeriod=Weekly&calcScenario=CurrentSystem
-  period: 2023
-  input:
-    age: 68
-    gender: MALE
-    benunit_rent: 80*52
-    tenure_type: RENT_FROM_COUNCIL
-    housing_benefit_reported: true
-    is_single_person: true
-    private_pension_income: 100*52
-  output:
-    housing_benefit: 80*52
   

--- a/policyengine_uk/variables/gov/dwp/attendance_allowance.py
+++ b/policyengine_uk/variables/gov/dwp/attendance_allowance.py
@@ -45,7 +45,7 @@ class aa_category(Variable):
     default_value = LowerOrHigher.NONE
 
     def formula(person, period, parameters):
-        aa = parameters(period).gov.dwp.attendance_allowance
+        aa = parameters(period).baseline.gov.dwp.attendance_allowance
         SAFETY_MARGIN = 0.1  # Survey reported values could be slightly below eligible values when they should be above due to data manipulation
         reported_weekly_aa = (
             person("attendance_allowance_reported", period) / WEEKS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_eligible.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_eligible.py
@@ -12,5 +12,6 @@ class housing_benefit_eligible(Variable):
         already_claiming = (
             add(benunit, period, ["housing_benefit_reported"]) > 0
         )
+        claiming_uc = benunit("would_claim_uc", period)
         lha_eligible = benunit("LHA_eligible", period)
-        return already_claiming & (social | lha_eligible)
+        return already_claiming & (social | lha_eligible) & ~claiming_uc

--- a/policyengine_uk/variables/gov/hmrc/capital_gains_tax/responses.py
+++ b/policyengine_uk/variables/gov/hmrc/capital_gains_tax/responses.py
@@ -78,6 +78,14 @@ class capital_gains_behavioural_response(Variable):
         if simulation.baseline is None:
             return 0
 
+        if (
+            parameters(
+                period
+            ).gov.simulation.capital_gains_responses.elasticity
+            == 0
+        ):
+            return 0
+
         capital_gains = person("capital_gains_before_response", period)
         tax_rate_change = person("relative_capital_gains_mtr_change", period)
         elasticity = person("capital_gains_elasticity", period)

--- a/policyengine_uk/variables/input/disability.py
+++ b/policyengine_uk/variables/input/disability.py
@@ -20,7 +20,7 @@ class dla_sc_category(Variable):
     default_value = LowerMiddleOrHigher.NONE
 
     def formula(person, period, parameters):
-        dla_sc = parameters(period).gov.dwp.dla.self_care
+        dla_sc = parameters(period).baseline.gov.dwp.dla.self_care
         SAFETY_MARGIN = 0.1  # Survey reported values could be slightly below eligible values when they should be above due to data manipulation
         reported_weekly_dla_sc = (
             person("dla_sc_reported", period) / WEEKS_IN_YEAR
@@ -51,7 +51,7 @@ class dla_m_category(Variable):
     default_value = LowerOrHigher.NONE
 
     def formula(person, period, parameters):
-        dla_m = parameters(period).gov.dwp.dla.mobility
+        dla_m = parameters(period).baseline.gov.dwp.dla.mobility
         SAFETY_MARGIN = 0.1  # Survey reported values could be slightly below eligible values when they should be above due to data manipulation
         reported_weekly_dla_m = (
             person("dla_m_reported", period) / WEEKS_IN_YEAR
@@ -80,7 +80,7 @@ class pip_m_category(Variable):
     default_value = PIPCategory.NONE
 
     def formula(person, period, parameters):
-        pip_m = parameters(period).gov.dwp.pip.mobility
+        pip_m = parameters(period).baseline.gov.dwp.pip.mobility
         SAFETY_MARGIN = 0.1  # Survey reported values could be slightly below eligible values when they should be above due to data manipulation
         reported_weekly_pip_m = (
             person("pip_m_reported", period) / WEEKS_IN_YEAR
@@ -109,7 +109,7 @@ class pip_dl_category(Variable):
     default_value = PIPCategory.NONE
 
     def formula(person, period, parameters):
-        pip_dl = parameters(period).gov.dwp.pip.daily_living
+        pip_dl = parameters(period).baseline.gov.dwp.pip.daily_living
         SAFETY_MARGIN = 0.1  # Survey reported values could be slightly below eligible values when they should be above due to data manipulation
         reported_weekly_pip_dl = (
             person("pip_dl_reported", period) / WEEKS_IN_YEAR

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="PolicyEngine-UK",
-    version="2.13.0",
+    version="2.13.1",
     author="PolicyEngine",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
The CG response addition caused the capital gains MTR to be calculated in every reform simulation.

Fixes #985 