### PR TITLE
Fix cliff impacts

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,7 @@
+- bump: patch
+  changes:
+    added:
+    - marginal_tax_rate_delta parameter
+    changed:
+    - Refactored cliff_gap variable to use marginal_tax_rate_delta parameter
+    - Refactored marginal_tax_rate variable to use marginal_tax_rate_delta parameter

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,6 +2,7 @@
   changes:
     added:
     - marginal_tax_rate_delta parameter
+    - marginal_tax_rate_adults parameter
     changed:
     - Refactored cliff_gap variable to use marginal_tax_rate_delta parameter
-    - Refactored marginal_tax_rate variable to use marginal_tax_rate_delta parameter
+    - Refactored marginal_tax_rate variable to use both new parameters

--- a/policyengine_uk/parameters/gov/simulation/marginal_tax_rate_adults.yaml
+++ b/policyengine_uk/parameters/gov/simulation/marginal_tax_rate_adults.yaml
@@ -1,0 +1,6 @@
+description: Number of adults to simulate a marginal tax rate for, in each household.
+values:
+  0000-01-01: 2
+metadata:
+  unit: int
+  label: Number of adults to simulate a marginal tax rate for

--- a/policyengine_uk/parameters/gov/simulation/marginal_tax_rate_delta.yaml
+++ b/policyengine_uk/parameters/gov/simulation/marginal_tax_rate_delta.yaml
@@ -1,0 +1,5 @@
+description: Amount by which employment_income is increased to calculate marginal tax rate.
+values:
+  0000-01-01: 1_000
+metadata:
+  unit: currency-GBP

--- a/policyengine_uk/variables/household/cliff.py
+++ b/policyengine_uk/variables/household/cliff.py
@@ -20,47 +20,20 @@ class cliff_gap(Variable):
     entity = Person
     label = "cliff gap"
     unit = GBP
-    documentation = "Amount of income lost if this person's employment income increased by £2,000."
+    documentation = "Amount of income lost if this person's employment income increased by delta amount."
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        DELTA = 2_000
-        cliff_values = np.zeros(person.count, dtype=np.float32)
-        simulation = person.simulation
-        adult_index_values = person("adult_index", period)
-        cliff_adult_count = 2
-        for adult_index in range(1, 1 + cliff_adult_count):
-            alt_simulation = simulation.get_branch(
-                f"adult_{adult_index}_2k_pay_rise"
-            )
-            mask = adult_index_values == adult_index
-            for variable in simulation.tax_benefit_system.variables:
-                if variable not in simulation.input_variables:
-                    alt_simulation.delete_arrays(variable)
-            alt_simulation.set_input(
-                "employment_income",
-                period,
-                person("employment_income", period) + mask * DELTA,
-            )
-            alt_person = alt_simulation.person
-            household_net_income = person.household(
-                "household_net_income", period
-            )
-            household_net_income_higher_earnings = alt_person.household(
-                "household_net_income", period
-            )
-            increase = (
-                household_net_income_higher_earnings - household_net_income
-            )
-            cliff_values += where(mask & (increase < 0), -increase, 0)
-        return cliff_values
+        delta = parameters(period).gov.simulation.marginal_tax_rate_delta
+        mtr = person("marginal_tax_rate", period)
+        return max_(0, (mtr - 1) * delta)
 
 
 class is_on_cliff(Variable):
     value_type = bool
     entity = Person
     label = "is on a tax-benefit cliff"
-    documentation = "Whether this person would be worse off if their employment income were $2,000 higher."
+    documentation = "Whether this person would be worse off if their employment income were higher by delta amount."
     definition_period = YEAR
 
     def formula(person, period, parameters):

--- a/policyengine_uk/variables/household/cliff.py
+++ b/policyengine_uk/variables/household/cliff.py
@@ -11,7 +11,9 @@ class cliff_evaluated(Variable):
 
     def formula(person, period, parameters):
         adult_index_values = person("adult_index", period)
-        cliff_adult_count = parameters(period).gov.simulation.marginal_tax_rate_adults
+        cliff_adult_count = parameters(
+            period
+        ).gov.simulation.marginal_tax_rate_adults
         return adult_index_values <= cliff_adult_count
 
 

--- a/policyengine_uk/variables/household/cliff.py
+++ b/policyengine_uk/variables/household/cliff.py
@@ -11,7 +11,7 @@ class cliff_evaluated(Variable):
 
     def formula(person, period, parameters):
         adult_index_values = person("adult_index", period)
-        cliff_adult_count = 2
+        cliff_adult_count = parameters(period).gov.simulation.marginal_tax_rate_adults
         return adult_index_values <= cliff_adult_count
 
 

--- a/policyengine_uk/variables/household/marginal_tax_rate.py
+++ b/policyengine_uk/variables/household/marginal_tax_rate.py
@@ -16,7 +16,8 @@ class marginal_tax_rate(Variable):
         simulation = person.simulation
         adult_index_values = person("adult_index", period)
         delta = p.marginal_tax_rate_delta
-        for adult_index in [1, 2]:
+        adult_count = p.marginal_tax_rate_adults
+        for adult_index in range(1, 1 + adult_count):
             alt_simulation = simulation.get_branch(
                 f"adult_{adult_index}_pay_rise"
             )

--- a/policyengine_uk/variables/household/marginal_tax_rate.py
+++ b/policyengine_uk/variables/household/marginal_tax_rate.py
@@ -11,10 +11,11 @@ class marginal_tax_rate(Variable):
     unit = "/1"
 
     def formula(person, period, parameters):
+        p = parameters(period).gov.simulation
         mtr_values = np.zeros(person.count, dtype=np.float32)
         simulation = person.simulation
         adult_index_values = person("adult_index", period)
-        DELTA = 1_000
+        delta = p.marginal_tax_rate_delta
         for adult_index in [1, 2]:
             alt_simulation = simulation.get_branch(
                 f"adult_{adult_index}_pay_rise"
@@ -32,7 +33,7 @@ class marginal_tax_rate(Variable):
             alt_simulation.set_input(
                 "employment_income",
                 period,
-                person("employment_income", period) + mask * DELTA,
+                person("employment_income", period) + mask * delta,
             )
             alt_person = alt_simulation.person
             household_net_income = person.household(
@@ -44,5 +45,5 @@ class marginal_tax_rate(Variable):
             increase = (
                 household_net_income_higher_earnings - household_net_income
             )
-            mtr_values += where(mask, 1 - increase / DELTA, 0)
+            mtr_values += where(mask, 1 - increase / delta, 0)
         return mtr_values


### PR DESCRIPTION
Fixes #996. This PR adds two new parameters, `marginal_tax_rate_adults` and `marginal_tax_rate_delta` in order to mirror the US package's handling of MTR. It then modifies the `marginal_tax_rate` and `cliff_gap` variables to use these parameter values.