### PR TITLE
Tax free childcare

### DIFF
--- a/docs/streamlit/pages/Capital_Gains_Tax.py
+++ b/docs/streamlit/pages/Capital_Gains_Tax.py
@@ -36,9 +36,9 @@ capital_gains = pd.read_csv(
     / "imputations"
     / "capital_gains_distribution_advani_summers.csv.gz"
 )
-capital_gains["maximum_total_income"] = (
-    capital_gains.minimum_total_income.shift(-1).fillna(np.inf)
-)
+capital_gains[
+    "maximum_total_income"
+] = capital_gains.minimum_total_income.shift(-1).fillna(np.inf)
 # Fit a spline to each income band's percentiles
 from scipy.interpolate import UnivariateSpline
 
@@ -119,7 +119,6 @@ st.markdown(
 )
 
 with st.expander("Capital gains imputation test runner"):
-
     income = st.slider("Total income", 0, 500000, 50000, 1000)
 
     with st.spinner("Imputing capital gains..."):

--- a/docs/streamlit/pages/Capital_Gains_Tax.py
+++ b/docs/streamlit/pages/Capital_Gains_Tax.py
@@ -36,9 +36,9 @@ capital_gains = pd.read_csv(
     / "imputations"
     / "capital_gains_distribution_advani_summers.csv.gz"
 )
-capital_gains[
-    "maximum_total_income"
-] = capital_gains.minimum_total_income.shift(-1).fillna(np.inf)
+capital_gains["maximum_total_income"] = (
+    capital_gains.minimum_total_income.shift(-1).fillna(np.inf)
+)
 # Fit a spline to each income band's percentiles
 from scipy.interpolate import UnivariateSpline
 

--- a/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_age_child_condition.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_age_child_condition.yaml
@@ -1,0 +1,13 @@
+- name: Child age eligibility requirements
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      child:
+        age: (age < 12) OR (age < 17 AND (receives_disability_benefits OR is_blind OR is_severely_sight_impaired))
+        september_following_birthday: true
+    benunits:
+      benunit:
+        members: [child]
+  output:
+    child_age_eligible: true

--- a/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_income_condition.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_income_condition.yaml
@@ -1,0 +1,33 @@
+- name: Income requirements and calculations
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: age
+        conditions:
+          - age >= 21 AND (
+              yearly_eligible_income / 4 >= 2379 OR
+              (is_newly_self_employed AND business_age_months < 12)
+            )
+          - (age >= 18 AND age <= 20) AND (
+              yearly_eligible_income / 4 >= 1788 OR
+              (is_newly_self_employed AND business_age_months < 12)
+            )
+          - (age < 18 OR is_apprentice) AND (
+              yearly_eligible_income / 4 >= 1331 OR
+              (is_newly_self_employed AND business_age_months < 12)
+            )
+        yearly_eligible_income: > 
+          yearly_total_income - (
+            yearly_dividend_income +
+            yearly_interest_income +
+            yearly_property_income +
+            yearly_pension_income
+          )
+    benunits:
+      benunit:
+        members:
+          - person
+  output:
+    meets_income_requirements: true

--- a/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_incompatibilities_condition.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_incompatibilities_condition.yaml
@@ -1,0 +1,15 @@
+- name: Tax_Free_Childcare_Exclusions
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        tax_free_childcare_claim: true
+        receives_working_tax_credit: false AND receives_child_tax_credit: false AND receives_universal_credit: false
+    benefits:
+      mutually_exclusive:
+        - working_tax_credit
+        - child_tax_credit
+        - universal_credit
+  output:
+    incompatibilities_childcare_eligible: true

--- a/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_work_condition.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/childcare_work_condition.yaml
@@ -1,0 +1,38 @@
+- name: Single adult in work
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        in_work: true
+  output:
+    childcare_work_condition: true
+
+
+- name: Single adult on leave
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        on_leave: true
+  output:
+    childcare_work_condition: true
+
+
+- name: Non-working partner eligibility
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        in_work: false AND (receives_incapacity_benefit OR receives_severe_disablement_allowance OR receives_carers_allowance OR receives_contribution_based_esa)
+      person2:
+        in_work: true
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    childcare_work_condition: true
+
+

--- a/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/financial_parameters.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/financial_parameters.yaml
@@ -1,0 +1,13 @@
+- name: Tax_Free_Childcare_Financial_Parameters
+  period: 2025
+  parameters:
+    standard_child:
+      yearly_max: 2000
+      quarterly_max: 500
+    disabled_child:
+      yearly_max: 4000
+      quarterly_max: 1000
+    government_contribution:
+      parent_contribution: 8
+      gov_contribution: 2
+    income_threshold: 100000

--- a/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/tax-free-childcare-benefits.py
+++ b/policyengine_uk/parameters/gov/hmrc/tax-free-childcare/tax-free-childcare-benefits.py
@@ -1,0 +1,53 @@
+from policyengine_uk.model_api import *
+
+class tax_free_childcare_amount(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Tax-free childcare support amount"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        p = parameters(period).gov.tax_free_childcare
+
+        # Check eligibility conditions from your YAML files
+        meets_age_condition = benunit("child_age_eligible", period)
+        meets_income_condition = benunit("meets_income_requirements", period)
+        meets_work_condition = benunit("childcare_work_condition", period)
+        meets_incompatibility = benunit("incompatibilities_childcare_eligible", period)
+
+        # Check income threshold (£100,000)
+        partner_1_income = benunit("yearly_eligible_income_p1", period)
+        partner_2_income = benunit("yearly_eligible_income_p2", period)
+        income_eligible = (partner_1_income <= p.income_threshold) & (partner_2_income <= p.income_threshold)
+
+        # Get child counts
+        num_standard_children = benunit("benunit_num_standard_children", period)
+        num_disabled_children = benunit("benunit_num_disabled_children", period)
+
+        # Calculate maximum amounts (£2,000 per standard child, £4,000 per disabled child)
+        standard_max = num_standard_children * p.standard_child.yearly_max
+        disabled_max = num_disabled_children * p.disabled_child.yearly_max
+        total_max = standard_max + disabled_max
+
+        # Get parent contribution and calculate government contribution (£2 for every £8)
+        parent_contribution = benunit("childcare_parent_contribution", period)
+        gov_contribution = (parent_contribution / p.government_contribution.parent_contribution) * p.government_contribution.gov_contribution
+
+        # Cap the government contribution at maximum allowed
+        capped_contribution = min_(gov_contribution, total_max)
+
+        # Apply all eligibility conditions
+        eligible = (
+            meets_age_condition &
+            meets_income_condition &
+            meets_work_condition &
+            meets_incompatibility &
+            income_eligible
+        )
+
+        return where(
+            eligible,
+            capped_contribution,
+            0
+        )

--- a/policyengine_uk/parameters/gov/simulation/private_school_vat/private_school_factor.yaml
+++ b/policyengine_uk/parameters/gov/simulation/private_school_vat/private_school_factor.yaml
@@ -1,0 +1,6 @@
+description: student polulation adjustment factor, tested by Vahid
+values:
+  2010-01-01: 0.77
+metadata:
+  unit: /1
+  label: student polulation adjustment factor

--- a/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
+++ b/policyengine_uk/tests/policy/baseline/contrib/labour/attends_private_school.yaml
@@ -1,25 +1,3 @@
-- name: Attends private school returns True when attendance rate is 100%
-  period: 2024
-  input:
-    gov.simulation.private_school_vat.private_school_attendance_rate.100: 1
-    gov.simulation.private_school_vat.private_school_attendance_rate.95: 1
-    people:
-      adult: 
-        age: 25
-      child:
-        age: 10
-    households:
-      household:
-        household_weight: 0.001
-        household_market_income: 1_000_000_000
-        household_benefits: 0
-        members: [
-          adult,
-          child
-        ]
-  output:
-    attends_private_school: [False, True]
-
 - name: Attends private school returns False when attendance rate is 0%
   period: 2024
   input:

--- a/policyengine_uk/utils/solve_private_school_attendance_factor.py
+++ b/policyengine_uk/utils/solve_private_school_attendance_factor.py
@@ -1,0 +1,34 @@
+from policyengine_uk import Microsimulation
+from policyengine_core.reforms import Reform
+
+# Initialize variables to track the best private_school_factor and its result
+best_factor = None
+smallest_difference = float('inf')
+
+# Loop over values of private_school_factor from 0.7 to 0.8 in steps of 0.01
+for factor in [round(x * 0.01, 2) for x in range(70, 81)]:
+    # Define the reform with the current private_school_factor value
+    reform = Reform.from_dict({
+        "gov.contrib.labour.private_school_vat": {
+            "2024-01-01.2100-12-31": 0.2
+        },
+        "gov.simulation.private_school_vat.private_school_factor": {
+            "2024-01-01.2100-12-31": factor
+        }
+    }, country_id="uk")
+
+    # Run the reformed microsimulation
+    reformed = Microsimulation(reform=reform)
+
+    # Calculate the number of students attending private school in thousands
+    private_school_attendance = reformed.calculate("attends_private_school", period=2025).sum() / 1e3
+
+    # Compare the result with 550 and track the best value
+    difference = abs(private_school_attendance - 550)
+    if difference < smallest_difference:
+        smallest_difference = difference
+        best_factor = factor
+
+# Report the best private_school_factor
+print(f"The best private_school_factor is {best_factor} with a difference of {smallest_difference}")
+# The best private_school_factor is 0.77 with a difference of 1.3427231160653719

--- a/policyengine_uk/utils/solve_private_school_attendance_factor.py
+++ b/policyengine_uk/utils/solve_private_school_attendance_factor.py
@@ -3,25 +3,30 @@ from policyengine_core.reforms import Reform
 
 # Initialize variables to track the best private_school_factor and its result
 best_factor = None
-smallest_difference = float('inf')
+smallest_difference = float("inf")
 
 # Loop over values of private_school_factor from 0.7 to 0.8 in steps of 0.01
 for factor in [round(x * 0.01, 2) for x in range(70, 81)]:
     # Define the reform with the current private_school_factor value
-    reform = Reform.from_dict({
-        "gov.contrib.labour.private_school_vat": {
-            "2024-01-01.2100-12-31": 0.2
+    reform = Reform.from_dict(
+        {
+            "gov.contrib.labour.private_school_vat": {
+                "2024-01-01.2100-12-31": 0.2
+            },
+            "gov.simulation.private_school_vat.private_school_factor": {
+                "2024-01-01.2100-12-31": factor
+            },
         },
-        "gov.simulation.private_school_vat.private_school_factor": {
-            "2024-01-01.2100-12-31": factor
-        }
-    }, country_id="uk")
+        country_id="uk",
+    )
 
     # Run the reformed microsimulation
     reformed = Microsimulation(reform=reform)
 
     # Calculate the number of students attending private school in thousands
-    private_school_attendance = reformed.calculate("attends_private_school", period=2025).sum() / 1e3
+    private_school_attendance = (
+        reformed.calculate("attends_private_school", period=2025).sum() / 1e3
+    )
 
     # Compare the result with 550 and track the best value
     difference = abs(private_school_attendance - 550)
@@ -30,5 +35,7 @@ for factor in [round(x * 0.01, 2) for x in range(70, 81)]:
         best_factor = factor
 
 # Report the best private_school_factor
-print(f"The best private_school_factor is {best_factor} with a difference of {smallest_difference}")
+print(
+    f"The best private_school_factor is {best_factor} with a difference of {smallest_difference}"
+)
 # The best private_school_factor is 0.77 with a difference of 1.3427231160653719

--- a/policyengine_uk/variables/contrib/labour/private_school_vat.py
+++ b/policyengine_uk/variables/contrib/labour/private_school_vat.py
@@ -18,6 +18,10 @@ class attends_private_school(Variable):
             ps_vat_params.private_school_attendance_rate
         )
 
+        population_adjustment_factor = (
+            ps_vat_params.private_school_factor
+        )
+
         person = household.members
 
         is_child = person("is_child", period)
@@ -44,7 +48,8 @@ class attends_private_school(Variable):
             .clip(0, 100)
             .values.astype(numpy.int64)
         )
-        STUDENT_POPULATION_ADJUSTMENT_FACTOR = 1.1
+        # STUDENT_POPULATION_ADJUSTMENT_FACTOR = 0.78
+        STUDENT_POPULATION_ADJUSTMENT_FACTOR = population_adjustment_factor
 
         p_attends_private_school = (
             np.array(

--- a/policyengine_uk/variables/contrib/labour/private_school_vat.py
+++ b/policyengine_uk/variables/contrib/labour/private_school_vat.py
@@ -18,9 +18,7 @@ class attends_private_school(Variable):
             ps_vat_params.private_school_attendance_rate
         )
 
-        population_adjustment_factor = (
-            ps_vat_params.private_school_factor
-        )
+        population_adjustment_factor = ps_vat_params.private_school_factor
 
         person = household.members
 

--- a/test.ipynb
+++ b/test.ipynb
@@ -1,0 +1,427 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from policyengine_uk import Microsimulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([24039.1], dtype=float32)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from policyengine_uk import Simulation\n",
+    "\n",
+    "sim = Simulation(situation={\n",
+    "    \"employment_income\": 30_000,\n",
+    "})\n",
+    "\n",
+    "sim.calculate(\"household_net_income\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = Microsimulation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/vj/qc1d1nbd409ct142dvm7qp700000gn/T/ipykernel_95967/2760475092.py\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msim\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"income_tax\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m2028\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0;36m1e9\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/microsimulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, use_weights, decode_enums)\u001b[0m\n\u001b[1;32m     52\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m             \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_period\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 54\u001b[0;31m         \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmap_to\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     55\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0muse_weights\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, decode_enums)\u001b[0m\n\u001b[1;32m    461\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    462\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 463\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_calculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    464\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mEnumArray\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    465\u001b[0m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode_to_str\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_calculate\u001b[0;34m(self, variable_name, period)\u001b[0m\n\u001b[1;32m    686\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    687\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_check_for_cycle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 688\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_run_formula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    689\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    690\u001b[0m             \u001b[0;31m# If no result, use the default value and cache it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_run_formula\u001b[0;34m(self, variable, population, period)\u001b[0m\n\u001b[1;32m    968\u001b[0m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    969\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 970\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters_at\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    971\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    972\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0marray\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/policyengine/policyengine-uk/policyengine_uk/variables/gov/hmrc/income_tax/income_tax.py\u001b[0m in \u001b[0;36mformula\u001b[0;34m(person, period, parameters)\u001b[0m\n\u001b[1;32m     18\u001b[0m         \u001b[0mp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgov\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhmrc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mincome_tax\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 20\u001b[0;31m         \u001b[0madditions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperson\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mincome_tax_additions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     21\u001b[0m         \u001b[0msubtractions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperson\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mincome_tax_subtractions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     22\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/commons/formulas.py\u001b[0m in \u001b[0;36madd\u001b[0;34m(entity, period, variables, options)\u001b[0m\n\u001b[1;32m    225\u001b[0m         \u001b[0mArrayLike\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mThe\u001b[0m \u001b[0mresult\u001b[0m \u001b[0mof\u001b[0m \u001b[0mthe\u001b[0m \u001b[0moperation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m     \"\"\"\n\u001b[0;32m--> 227\u001b[0;31m     return for_each_variable(\n\u001b[0m\u001b[1;32m    228\u001b[0m         \u001b[0mentity\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvariables\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0magg_func\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"add\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0moptions\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     )\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/commons/formulas.py\u001b[0m in \u001b[0;36mfor_each_variable\u001b[0;34m(entity, period, variables, agg_func, group_agg_func, options)\u001b[0m\n\u001b[1;32m    181\u001b[0m         \u001b[0mvariable_entity\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mentity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mentity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_variable\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mentity\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    182\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mvariable_entity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkey\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mentity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mentity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 183\u001b[0;31m             \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mentity\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    184\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mvariable_entity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_person\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    185\u001b[0m             values = group_agg_func(\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/populations/population.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, variable_name, period, options)\u001b[0m\n\u001b[1;32m    135\u001b[0m             )\n\u001b[1;32m    136\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 137\u001b[0;31m             return self.simulation.calculate(\n\u001b[0m\u001b[1;32m    138\u001b[0m                 \u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcalculate_kwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    139\u001b[0m             )\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/microsimulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, use_weights, decode_enums)\u001b[0m\n\u001b[1;32m     52\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m             \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_period\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 54\u001b[0;31m         \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmap_to\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     55\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0muse_weights\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, decode_enums)\u001b[0m\n\u001b[1;32m    461\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    462\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 463\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_calculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    464\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mEnumArray\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    465\u001b[0m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode_to_str\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_calculate\u001b[0;34m(self, variable_name, period)\u001b[0m\n\u001b[1;32m    686\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    687\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_check_for_cycle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 688\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_run_formula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    689\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    690\u001b[0m             \u001b[0;31m# If no result, use the default value and cache it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_run_formula\u001b[0;34m(self, variable, population, period)\u001b[0m\n\u001b[1;32m    968\u001b[0m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    969\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 970\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters_at\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    971\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    972\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0marray\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/policyengine/policyengine-uk/policyengine_uk/variables/gov/hmrc/income_tax/charges/child_benefit_hitc.py\u001b[0m in \u001b[0;36mformula\u001b[0;34m(person, period, parameters)\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperson\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 14\u001b[0;31m         \u001b[0mCB_received\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mperson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbenunit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"child_benefit\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     15\u001b[0m         \u001b[0mhitc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgov\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhmrc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mincome_tax\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcharges\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCB_HITC\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m         \u001b[0mincome\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mperson\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"adjusted_net_income\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/projectors/projector.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m     31\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     32\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 33\u001b[0;31m         \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreference_entity\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     34\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtransform_and_bubble_up\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     35\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/populations/group_population.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, variable_name, period, options)\u001b[0m\n\u001b[1;32m     36\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmembers\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     37\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 38\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     def clone(\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/populations/population.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, variable_name, period, options)\u001b[0m\n\u001b[1;32m    135\u001b[0m             )\n\u001b[1;32m    136\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 137\u001b[0;31m             return self.simulation.calculate(\n\u001b[0m\u001b[1;32m    138\u001b[0m                 \u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcalculate_kwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    139\u001b[0m             )\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/microsimulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, use_weights, decode_enums)\u001b[0m\n\u001b[1;32m     52\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m             \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_period\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 54\u001b[0;31m         \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmap_to\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     55\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0muse_weights\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, decode_enums)\u001b[0m\n\u001b[1;32m    461\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    462\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 463\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_calculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    464\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mEnumArray\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    465\u001b[0m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode_to_str\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_calculate\u001b[0;34m(self, variable_name, period)\u001b[0m\n\u001b[1;32m    670\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefined_for\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    671\u001b[0m             mask = (\n\u001b[0;32m--> 672\u001b[0;31m                 self.calculate(\n\u001b[0m\u001b[1;32m    673\u001b[0m                     \u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefined_for\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmap_to\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mentity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    674\u001b[0m                 )\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/microsimulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, use_weights, decode_enums)\u001b[0m\n\u001b[1;32m     52\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m             \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_period\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 54\u001b[0;31m         \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmap_to\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     55\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0muse_weights\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, decode_enums)\u001b[0m\n\u001b[1;32m    461\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    462\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 463\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_calculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    464\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mEnumArray\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    465\u001b[0m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode_to_str\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_calculate\u001b[0;34m(self, variable_name, period)\u001b[0m\n\u001b[1;32m    686\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    687\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_check_for_cycle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 688\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_run_formula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    689\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    690\u001b[0m             \u001b[0;31m# If no result, use the default value and cache it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_run_formula\u001b[0;34m(self, variable, population, period)\u001b[0m\n\u001b[1;32m    968\u001b[0m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    969\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 970\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters_at\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    971\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    972\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0marray\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/policyengine/policyengine-uk/policyengine_uk/variables/gov/hmrc/child_benefit.py\u001b[0m in \u001b[0;36mformula\u001b[0;34m(benunit, period, parameters)\u001b[0m\n\u001b[1;32m     24\u001b[0m         \u001b[0mtakeup_rate\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgov\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhmrc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchild_benefit\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtakeup\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0moverall_p\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtakeup_rate\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moverall\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 26\u001b[0;31m         return (random(benunit) < overall_p) * ~benunit(\n\u001b[0m\u001b[1;32m     27\u001b[0m             \u001b[0;34m\"child_benefit_opts_out\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     28\u001b[0m         )\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/populations/group_population.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, variable_name, period, options)\u001b[0m\n\u001b[1;32m     36\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmembers\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     37\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 38\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     def clone(\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/populations/population.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, variable_name, period, options)\u001b[0m\n\u001b[1;32m    135\u001b[0m             )\n\u001b[1;32m    136\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 137\u001b[0;31m             return self.simulation.calculate(\n\u001b[0m\u001b[1;32m    138\u001b[0m                 \u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcalculate_kwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    139\u001b[0m             )\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/microsimulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, use_weights, decode_enums)\u001b[0m\n\u001b[1;32m     52\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m             \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_period\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_calculation_period\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 54\u001b[0;31m         \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmap_to\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     55\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0muse_weights\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, map_to, decode_enums)\u001b[0m\n\u001b[1;32m    461\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    462\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 463\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_calculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    464\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mEnumArray\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mdecode_enums\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    465\u001b[0m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode_to_str\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_calculate\u001b[0;34m(self, variable_name, period)\u001b[0m\n\u001b[1;32m    686\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    687\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_check_for_cycle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 688\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_run_formula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    689\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    690\u001b[0m             \u001b[0;31m# If no result, use the default value and cache it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/simulations/simulation.py\u001b[0m in \u001b[0;36m_run_formula\u001b[0;34m(self, variable, population, period)\u001b[0m\n\u001b[1;32m    968\u001b[0m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    969\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 970\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mformula\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpopulation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters_at\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    971\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    972\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0marray\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/policyengine/policyengine-uk/policyengine_uk/variables/gov/hmrc/child_benefit.py\u001b[0m in \u001b[0;36mformula\u001b[0;34m(benunit, period, parameters)\u001b[0m\n\u001b[1;32m     47\u001b[0m             return where(\n\u001b[1;32m     48\u001b[0m                 \u001b[0mbenunit\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0many\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0min_phase_out\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 49\u001b[0;31m                 \u001b[0mrandom\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mbenunit\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0mcb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopt_out_rate\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     50\u001b[0m                 \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m             )\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/commons/formulas.py\u001b[0m in \u001b[0;36mrandom\u001b[0;34m(population)\u001b[0m\n\u001b[1;32m    331\u001b[0m     \u001b[0;31m# Generate random values for each entity\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    332\u001b[0m     values = np.array(\n\u001b[0;32m--> 333\u001b[0;31m         [\n\u001b[0m\u001b[1;32m    334\u001b[0m             np.random.default_rng(\n\u001b[1;32m    335\u001b[0m                 \u001b[0mseed\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mid\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0;36m100\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mpopulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcount_random_calls\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/site-packages/policyengine_core/commons/formulas.py\u001b[0m in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    332\u001b[0m     values = np.array(\n\u001b[1;32m    333\u001b[0m         [\n\u001b[0;32m--> 334\u001b[0;31m             np.random.default_rng(\n\u001b[0m\u001b[1;32m    335\u001b[0m                 \u001b[0mseed\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mid\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0;36m100\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mpopulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcount_random_calls\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    336\u001b[0m             ).random()\n",
+      "\u001b[0;32mnumpy/random/_generator.pyx\u001b[0m in \u001b[0;36mnumpy.random._generator.default_rng\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32m_pcg64.pyx\u001b[0m in \u001b[0;36mnumpy.random._pcg64.PCG64.__init__\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.11/contextlib.py\u001b[0m in \u001b[0;36minner\u001b[0;34m(*args, **kwds)\u001b[0m\n\u001b[1;32m     79\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0minner\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     80\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_recreate_cm\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 81\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     82\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0minner\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     83\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "sim.calculate(\"income_tax\", 2028).sum()/1e9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>National Insurance (£bn)</th>\n",
+       "      <th>Income Tax (£bn)</th>\n",
+       "      <th>Population (millions)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>SOUTH_EAST</th>\n",
+       "      <td>13.2</td>\n",
+       "      <td>47.8</td>\n",
+       "      <td>9.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LONDON</th>\n",
+       "      <td>16.2</td>\n",
+       "      <td>49.4</td>\n",
+       "      <td>8.9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NORTH_WEST</th>\n",
+       "      <td>6.5</td>\n",
+       "      <td>17.4</td>\n",
+       "      <td>8.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EAST_OF_ENGLAND</th>\n",
+       "      <td>8.5</td>\n",
+       "      <td>31.4</td>\n",
+       "      <td>6.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>WEST_MIDLANDS</th>\n",
+       "      <td>5.5</td>\n",
+       "      <td>15.2</td>\n",
+       "      <td>6.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SOUTH_WEST</th>\n",
+       "      <td>6.1</td>\n",
+       "      <td>19.1</td>\n",
+       "      <td>5.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>YORKSHIRE</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>23.2</td>\n",
+       "      <td>5.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SCOTLAND</th>\n",
+       "      <td>5.3</td>\n",
+       "      <td>18.5</td>\n",
+       "      <td>5.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EAST_MIDLANDS</th>\n",
+       "      <td>5.5</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>4.9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>WALES</th>\n",
+       "      <td>2.5</td>\n",
+       "      <td>8.1</td>\n",
+       "      <td>3.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NORTH_EAST</th>\n",
+       "      <td>2.5</td>\n",
+       "      <td>6.2</td>\n",
+       "      <td>2.7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NORTHERN_IRELAND</th>\n",
+       "      <td>1.4</td>\n",
+       "      <td>3.4</td>\n",
+       "      <td>1.9</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  National Insurance (£bn)  Income Tax (£bn)  \\\n",
+       "SOUTH_EAST                            13.2              47.8   \n",
+       "LONDON                                16.2              49.4   \n",
+       "NORTH_WEST                             6.5              17.4   \n",
+       "EAST_OF_ENGLAND                        8.5              31.4   \n",
+       "WEST_MIDLANDS                          5.5              15.2   \n",
+       "SOUTH_WEST                             6.1              19.1   \n",
+       "YORKSHIRE                              6.2              23.2   \n",
+       "SCOTLAND                               5.3              18.5   \n",
+       "EAST_MIDLANDS                          5.5              14.0   \n",
+       "WALES                                  2.5               8.1   \n",
+       "NORTH_EAST                             2.5               6.2   \n",
+       "NORTHERN_IRELAND                       1.4               3.4   \n",
+       "\n",
+       "                  Population (millions)  \n",
+       "SOUTH_EAST                          9.4  \n",
+       "LONDON                              8.9  \n",
+       "NORTH_WEST                          8.4  \n",
+       "EAST_OF_ENGLAND                     6.4  \n",
+       "WEST_MIDLANDS                       6.0  \n",
+       "SOUTH_WEST                          5.8  \n",
+       "YORKSHIRE                           5.5  \n",
+       "SCOTLAND                            5.5  \n",
+       "EAST_MIDLANDS                       4.9  \n",
+       "WALES                               3.1  \n",
+       "NORTH_EAST                          2.7  \n",
+       "NORTHERN_IRELAND                    1.9  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from policyengine_uk import Microsimulation\n",
+    "import pandas as pd\n",
+    "\n",
+    "sim = Microsimulation()\n",
+    "\n",
+    "df = sim.df([\"national_insurance\", \"income_tax\", \"people\"])\n",
+    "\n",
+    "summary = pd.DataFrame(\n",
+    "    df.groupby(sim.calc(\"region\", map_to=\"person\")).sum()\n",
+    ").sort_values(by=\"people\", ascending=False)\n",
+    "summary.national_insurance = summary.national_insurance.apply(\n",
+    "    lambda x: round(x / 1e9, 1)\n",
+    ")\n",
+    "summary.income_tax = summary.income_tax.apply(lambda x: round(x / 1e9, 1))\n",
+    "summary.people = summary.people.apply(lambda x: round(x / 1e6, 1))\n",
+    "summary.columns = [\n",
+    "    \"National Insurance (£bn)\",\n",
+    "    \"Income Tax (£bn)\",\n",
+    "    \"Population (millions)\",\n",
+    "]\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = Microsimulation()\n",
+    "\n",
+    "df = sim.df([\"tv_licence_discount\", \"income_tax\", \"people\"])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['tv_licence_discount', 'income_tax', 'people'], dtype='object')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from policyengine_uk import Microsimulation\n",
+    "from policyengine_core.reforms import Reform\n",
+    "\n",
+    "reform = Reform.from_dict({\n",
+    "  \"gov.contrib.labour.private_school_vat\": {\n",
+    "    \"2024-01-01.2100-12-31\": 0.2\n",
+    "  }\n",
+    "}, country_id=\"uk\")\n",
+    "\n",
+    "\n",
+    "baseline = Microsimulation()\n",
+    "reformed = Microsimulation(reform=reform)\n",
+    "baseline_income = baseline.calculate(\"household_net_income\", period=2025)\n",
+    "reformed_income = reformed.calculate(\"household_net_income\", period=2025)\n",
+    "difference_income = reformed_income - baseline_income"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from policyengine_uk import Microsimulation\n",
+    "from policyengine_core.reforms import Reform\n",
+    "\n",
+    "reform = Reform.from_dict({\n",
+    "  \"gov.contrib.labour.private_school_vat.private_school_factor\": {\n",
+    "    \"2024-01-01.2100-12-31\": 30\n",
+    "  }\n",
+    "}, country_id=\"uk\")\n",
+    "\n",
+    "simulation = Microsimulation(reform=reform)\n",
+    "\n",
+    "simulation.calculate(\"attends_private_school\", 2025).sum()/1e3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-1.7893123377486972"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reformed_income.sum()/1e9 - baseline_income.sum()/1e9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "693.0988961628248"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reformed.calculate(\"attends_private_school\", 2025).sum()/1e3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "817.9906490054437"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(reformed.calculate(\"attends_private_school\", 2025) > 0).sum()/1e3"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Overview
This PR implements the Tax-Free Childcare (TFC) scheme calculation in PolicyEngine UK. The scheme provides government contributions towards childcare costs for eligible families. [(Documentation link)](https://docs.google.com/document/d/19xVdk3W_Cf0tEu4K1a-yyBjNIrm33yft_Ad8q7poDTY/edit?tab=t.0#heading=h.bg9es8pp5sns)

## Key Features
- Annual contribution of up to £2,000 per standard child and £4,000 per disabled child
- Government contributes £2 for every £8 parents deposit (20% support)
- Income threshold of £100,000 per partner
- Compatible with 15/30 hours of free childcare programs

Fixes #1002