### PR TITLE
Add Child Tax Credit two-child limit age exemption reform

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Two-child limit age exemption reform for Child Tax Credit.

--- a/policyengine_uk/tests/policy/reforms/parametric/two_child_limit/ctc_age_exemption.yaml
+++ b/policyengine_uk/tests/policy/reforms/parametric/two_child_limit/ctc_age_exemption.yaml
@@ -1,0 +1,137 @@
+- name: With no age exemption, only first 2 children get CTC
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2
+        birth_year: 2021
+      child_4:
+        age: 1
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 6140  # CTC for only the first 2 children
+
+- name: With age exemption, all children get CTC when any child is below threshold
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    gov.contrib.two_child_limit.age_exemption: 3
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2  # This child is under the threshold
+        birth_year: 2021
+      child_4:
+        age: 1
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 12280  # CTC for all children
+
+- name: No exemption when all children above age threshold
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    gov.contrib.two_child_limit.age_exemption: 3
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 3  # No child below threshold
+        birth_year: 2020  
+      child_4:
+        age: 3
+        birth_year: 2020
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 6140  # CTC for only first 2 children
+
+- name: Shows baseline CTC for a family with children under age 3
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2  # This child is under the threshold
+        birth_year: 2021
+      child_4:
+        age: 1  # This child is under the threshold
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 6140  # CTC for only first 2 children
+
+- name: Shows increased CTC after applying age exemption reform
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    gov.contrib.two_child_limit.age_exemption: 3  # Exempt families with under-3s
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2  # This child is under the threshold
+        birth_year: 2021
+      child_4:
+        age: 1  # This child is under the threshold
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 12280  # CTC for all children due to exemption

--- a/policyengine_uk/variables/gov/dwp/tax_credits.py
+++ b/policyengine_uk/variables/gov/dwp/tax_credits.py
@@ -65,7 +65,19 @@ class is_CTC_child_limit_exempt(Variable):
         ).gov.dwp.tax_credits.child_tax_credit.limit.start_year
         # Children must be born before April 2017.
         # We use < 2017 as the closer approximation than <= 2017.
-        return person("birth_year", period) < limit_year
+        born_before_limit = person("birth_year", period) < limit_year
+        
+        # Reform proposal
+        age_exemption = parameters.gov.contrib.two_child_limit.age_exemption(
+            period
+        )
+        if age_exemption > 0:
+            is_exempt = person.benunit.any(
+                person("age", period) < age_exemption
+            )
+            return born_before_limit | is_exempt
+            
+        return born_before_limit
 
 
 class is_child_for_CTC(Variable):

--- a/policyengine_uk/variables/gov/dwp/tax_credits.py
+++ b/policyengine_uk/variables/gov/dwp/tax_credits.py
@@ -66,7 +66,7 @@ class is_CTC_child_limit_exempt(Variable):
         # Children must be born before April 2017.
         # We use < 2017 as the closer approximation than <= 2017.
         born_before_limit = person("birth_year", period) < limit_year
-        
+
         # Reform proposal
         age_exemption = parameters.gov.contrib.two_child_limit.age_exemption(
             period
@@ -76,7 +76,7 @@ class is_CTC_child_limit_exempt(Variable):
                 person("age", period) < age_exemption
             )
             return born_before_limit | is_exempt
-            
+
         return born_before_limit
 
 


### PR DESCRIPTION
Follows PR #1058 to add the same age exemption mechanism for Child Tax Credit (CTC) as was added for Universal Credit's two-child limit. When a child in the family is below the specified age threshold, the two-child limit is waived for all children in the family.