### PR TITLE
Add two-child limit age exemption documentation

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
     added:
-    - Two-child limit age exemption reform for Child Tax Credit.
+    - Documentation on the two-child limit age exemption reform for Universal Credit and Child Tax Credit, developed for the Women's Budget Group.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     added:
-    - Documentation on the two-child limit age exemption reform for Universal Credit and Child Tax Credit, developed for the Women's Budget Group.
+    - Documentation on the two-child limit age exemption reform for Universal Credit and Child Tax Credit.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Two-child limit age exemption reform for Child Tax Credit.

--- a/docs/book/_toc.yml
+++ b/docs/book/_toc.yml
@@ -22,7 +22,7 @@ parts:
       - file: programs/gov/hmrc/fuel-duty
       - file: programs/gov/hmrc/stamp-duty
       - file: programs/contrib/ubi-center/carbon-tax
-      - file: programs/contrib/womens-budget-group/two-child-limit
+      - file: programs/contrib/reforms/two-child-limit
       - file: programs/gov/ofgem/energy-price-guarantee
       - file: programs/gov/dcms/bbc/tv-licence
       - file: programs/gov/revenue_scotland/land-and-buildings-transaction-tax

--- a/docs/book/_toc.yml
+++ b/docs/book/_toc.yml
@@ -22,6 +22,7 @@ parts:
       - file: programs/gov/hmrc/fuel-duty
       - file: programs/gov/hmrc/stamp-duty
       - file: programs/contrib/ubi-center/carbon-tax
+      - file: programs/contrib/womens-budget-group/two-child-limit
       - file: programs/gov/ofgem/energy-price-guarantee
       - file: programs/gov/dcms/bbc/tv-licence
       - file: programs/gov/revenue_scotland/land-and-buildings-transaction-tax

--- a/docs/book/programs/contrib/reforms/two-child-limit.ipynb
+++ b/docs/book/programs/contrib/reforms/two-child-limit.ipynb
@@ -162,17 +162,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Modeling Considerations\n",
-    "\n",
-    "When using these parameters for policy analysis:\n",
-    "\n",
-    "1. The age exemption applies to the family as a whole - if any child is under the threshold, all children are exempt\n",
-    "2. The exemption works alongside existing exemptions (e.g., children born before April 2017)\n",
-    "3. The parameter can be varied to model different age thresholds and estimate impacts\n",
-    "\n",
-    "This parameter was added at the request of the Women's Budget Group to model potential reforms to the two-child limit policy."
-   ]
+   "source": "## Modeling Considerations\n\nWhen using these parameters for policy analysis:\n\n1. The age exemption applies to the family as a whole - if any child is under the threshold, all children are exempt\n2. The exemption works alongside existing exemptions (e.g., children born before April 2017)\n3. The parameter can be varied to model different age thresholds and estimate impacts\n\nThis parameter enables modeling potential reforms to the two-child limit policy.",
+   "outputs": []
   }
  ],
  "metadata": {

--- a/docs/book/programs/contrib/womens-budget-group/two-child-limit.ipynb
+++ b/docs/book/programs/contrib/womens-budget-group/two-child-limit.ipynb
@@ -1,0 +1,185 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Two-Child Limit Policy Parameters\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The two-child limit is a UK welfare policy that restricts child-related benefits to the first two children in a family for children born after April 2017. This policy affects both Universal Credit (UC) and Child Tax Credit (CTC).\n",
+    "\n",
+    "PolicyEngine allows modeling both the current implementation and policy reforms to the two-child limit, including an age-based exemption mechanism."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Current Policy Implementation\n",
+    "\n",
+    "The two-child limit currently applies to:\n",
+    "\n",
+    "- Universal Credit child elements\n",
+    "- Child Tax Credit child elements\n",
+    "\n",
+    "By default, families can only claim these benefits for their first two children, with some exceptions:\n",
+    "\n",
+    "1. Children born before April 6, 2017 are exempt from the limit\n",
+    "2. Multiple births (e.g., twins or triplets) where only one child would take the family over the two-child limit\n",
+    "3. Children adopted from local authority care\n",
+    "4. Children living with family or friends (kinship care)\n",
+    "5. Children born as a result of non-consensual conception\n",
+    "\n",
+    "Our model currently simulates the date-based exemption (children born before April 2017)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Policy Parameters\n",
+    "\n",
+    "### Two-Child Limit Age Exemption\n",
+    "\n",
+    "```\n",
+    "gov.contrib.two_child_limit.age_exemption\n",
+    "```\n",
+    "\n",
+    "This parameter defines an age below which the two-child limit is waived for all children in a family. When set to a value greater than 0, if any child in the family is younger than this age threshold, the two-child limit does not apply to that family.\n",
+    "\n",
+    "- **Default value**: 0 (no age-based exemption)\n",
+    "- **Unit**: years\n",
+    "- **Description**: Parents of children under this age are exempt from the two-child limit\n",
+    "- **Example usage**: Setting this to 3 would exempt all families with at least one child under 3 years old from the two-child limit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How Age Exemption Works\n",
+    "\n",
+    "When the `age_exemption` parameter is set to a value greater than 0:\n",
+    "\n",
+    "1. The model checks if any child in the family is younger than the specified age\n",
+    "2. If true, the two-child limit does not apply to that family\n",
+    "3. All eligible children in the family receive the child element, regardless of birth order\n",
+    "\n",
+    "This works across both benefit systems:\n",
+    "- For Universal Credit, all eligible children receive the UC child element\n",
+    "- For Child Tax Credit, all eligible children receive the CTC child element"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Effects on Family Income\n",
+    "\n",
+    "The two-child limit can significantly impact family incomes, especially for larger families. For 2023-24:\n",
+    "\n",
+    "- Universal Credit child element: approximately £287 per month per child (£3,444 annually)\n",
+    "- Child Tax Credit child element: approximately £3,070 annually per child\n",
+    "\n",
+    "For a family with four children where all would otherwise be eligible, the two-child limit could reduce support by over £6,000 per year.\n",
+    "\n",
+    "The age exemption reform allows policy analysts to model how exempting families with young children would affect household incomes and government expenditure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Examples\n",
+    "\n",
+    "### Example 1: Family with children of different ages, no exemption\n",
+    "\n",
+    "A family with four children aged 6, 4, 2, and 1 years old. With no age exemption (default policy):\n",
+    "- Only the first two children (aged 6 and 4) would receive the child element\n",
+    "- Total support is approximately £6,888 annually (UC) or £6,140 annually (CTC)\n",
+    "\n",
+    "### Example 2: Same family with age exemption of 3 years\n",
+    "\n",
+    "With an age exemption of 3 years:\n",
+    "- Because the family has children aged 2 and 1 (under 3), the limit is waived\n",
+    "- All four children would receive the child element\n",
+    "- Total support is approximately £13,776 annually (UC) or £12,280 annually (CTC)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PolicyEngine Analysis Example\n",
+    "\n",
+    "Below is a code example for analyzing the impact of implementing a 3-year age exemption to the two-child limit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import policyengine_uk\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Set up the baseline simulation\n",
+    "baseline = policyengine_uk.Microsimulation()\n",
+    "\n",
+    "# Set up the reform simulation with 3-year age exemption\n",
+    "reform = policyengine_uk.Microsimulation(\n",
+    "    reforms={\n",
+    "        \"gov.contrib.two_child_limit.age_exemption\": 3\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# Calculate the impact of the reform\n",
+    "impact = reform.calc(\"household_net_income\") - baseline.calc(\"household_net_income\")\n",
+    "\n",
+    "# Identify families affected by the reform\n",
+    "has_children = baseline.calc(\"benunit_num_children\") > 0\n",
+    "has_young_children = baseline.calc(\"benunit_has_children_under_age\", age=3)\n",
+    "more_than_two_children = baseline.calc(\"benunit_num_children\") > 2\n",
+    "\n",
+    "affected_families = has_children & has_young_children & more_than_two_children\n",
+    "\n",
+    "# Calculate average gain for affected families\n",
+    "avg_gain = (impact[affected_families] * baseline.calc(\"household_weight\")[affected_families]).sum() / \\\n",
+    "           baseline.calc(\"household_weight\")[affected_families].sum()\n",
+    "\n",
+    "print(f\"Average annual gain for affected families: £{avg_gain:.2f}\")\n",
+    "\n",
+    "# Calculate total cost\n",
+    "total_cost = (impact * baseline.calc(\"household_weight\")).sum()\n",
+    "\n",
+    "print(f\"Total annual cost of reform: £{total_cost/1e6:.1f} million\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modeling Considerations\n",
+    "\n",
+    "When using these parameters for policy analysis:\n",
+    "\n",
+    "1. The age exemption applies to the family as a whole - if any child is under the threshold, all children are exempt\n",
+    "2. The exemption works alongside existing exemptions (e.g., children born before April 2017)\n",
+    "3. The parameter can be varied to model different age thresholds and estimate impacts\n",
+    "\n",
+    "This parameter was added at the request of the Women's Budget Group to model potential reforms to the two-child limit policy."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/policyengine_uk/tests/policy/reforms/parametric/two_child_limit/ctc_age_exemption.yaml
+++ b/policyengine_uk/tests/policy/reforms/parametric/two_child_limit/ctc_age_exemption.yaml
@@ -1,0 +1,137 @@
+- name: With no age exemption, only first 2 children get CTC
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2
+        birth_year: 2021
+      child_4:
+        age: 1
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 6140  # CTC for only the first 2 children
+
+- name: With age exemption, all children get CTC when any child is below threshold
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    gov.contrib.two_child_limit.age_exemption: 3
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2  # This child is under the threshold
+        birth_year: 2021
+      child_4:
+        age: 1
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 12280  # CTC for all children
+
+- name: No exemption when all children above age threshold
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    gov.contrib.two_child_limit.age_exemption: 3
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 3  # No child below threshold
+        birth_year: 2020  
+      child_4:
+        age: 3
+        birth_year: 2020
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 6140  # CTC for only first 2 children
+
+- name: Shows baseline CTC for a family with children under age 3
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2  # This child is under the threshold
+        birth_year: 2021
+      child_4:
+        age: 1  # This child is under the threshold
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 6140  # CTC for only first 2 children
+
+- name: Shows increased CTC after applying age exemption reform
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    gov.contrib.two_child_limit.age_exemption: 3  # Exempt families with under-3s
+    people:
+      parent:
+        age: 30
+        child_tax_credit_reported: 8000
+      child_1:
+        age: 5
+        birth_year: 2018
+      child_2:
+        age: 4
+        birth_year: 2019
+      child_3:
+        age: 2  # This child is under the threshold
+        birth_year: 2021
+      child_4:
+        age: 1  # This child is under the threshold
+        birth_year: 2022
+    benunits:
+      benunit:
+        members: [parent, child_1, child_2, child_3, child_4]
+        claims_all_entitled_benefits: true
+  output:
+    CTC_child_element: 12280  # CTC for all children due to exemption

--- a/policyengine_uk/variables/gov/dwp/tax_credits.py
+++ b/policyengine_uk/variables/gov/dwp/tax_credits.py
@@ -65,7 +65,19 @@ class is_CTC_child_limit_exempt(Variable):
         ).gov.dwp.tax_credits.child_tax_credit.limit.start_year
         # Children must be born before April 2017.
         # We use < 2017 as the closer approximation than <= 2017.
-        return person("birth_year", period) < limit_year
+        born_before_limit = person("birth_year", period) < limit_year
+        
+        # Reform proposal
+        age_exemption = parameters.gov.contrib.two_child_limit.age_exemption(
+            period
+        )
+        if age_exemption > 0:
+            is_exempt = person.benunit.any(
+                person("age", period) < age_exemption
+            )
+            return born_before_limit | is_exempt
+            
+        return born_before_limit
 
 
 class is_child_for_CTC(Variable):


### PR DESCRIPTION
Adds documentation for the two-child limit age exemption reform for both Universal Credit and Child Tax Credit. The documentation includes an overview of the policy, parameter details, examples, and a code sample for analyzing the impact of the reform.

Helps users understand and analyze the policy reforms implemented in PRs #1058 and #1059.