### PR TITLE
Update microdf dependency to >=1.0.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,1 @@
+- bump: Update microdf dependency from microdf_python to microdf>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     install_requires=[
         "PolicyEngine-Core>=3.6.4",
-        "microdf_python",
+        "microdf>=1.0.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary
- Update microdf dependency from `microdf_python` to `microdf>=1.0.0` in setup.py
- The codebase already imports from 'microdf' (not 'microdf_python') in model_api.py
- This aligns the dependency name with the actual import statements

## Test plan
- CI tests should pass
- The import statements in the codebase already use 'microdf', so this change makes the dependencies consistent

🤖 Generated with [Claude Code](https://claude.ai/code)