### PR TITLE
Update script to open automated API update PRs

### DIFF
--- a/.github/update_api.py
+++ b/.github/update_api.py
@@ -1,12 +1,13 @@
 import argparse
+import tomllib
 import os
 
 
 def main():
     # First, find the current package version number from the setup.py file
-    with open("pyproject.toml", "r") as f:
-        setup = f.read()
-    version = setup.split("version = ")[1].split(",")[0].strip('"')
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+        version = data["project"]["version"]
     # Then, clone the https://github.com/policyengine/policyengine-api repo using the GitHub CLI
     pat = os.environ["GITHUB_TOKEN"]
     os.system(
@@ -18,7 +19,7 @@ def main():
     )
     # Repeat the above for https://github.com/policyengine/policyengine-household-api
     os.system(
-        f"git clone https://nikhilwodruff:{pat}@github.com/policyengine/policyengine-household-api"
+        f"git clone https://nikhilwoodruff:{pat}@github.com/policyengine/policyengine-household-api"
     )
 
     # Then, cd inside and run gcp/bump_country_package.py --country policyengine-uk --version {version}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Updated script to open automated API update PRs


### PR DESCRIPTION
Fixes #1292.

Updates `-uk` code to properly open automated API PRs. Follows the model implemented in https://github.com/PolicyEngine/policyengine-us/pull/6342/files.