### PR TITLE
Fix cgt elasticities bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Issue causing capital gains elasticities to not take effect.

--- a/policyengine_uk/simulation.py
+++ b/policyengine_uk/simulation.py
@@ -122,6 +122,9 @@ class Simulation(CoreSimulation):
 
         self.tax_benefit_system.reset_parameter_caches()
 
+        self.move_values("capital_gains", "capital_gains_before_response")
+        self.move_values("employment_income", "employment_income_before_lsr")
+
         if scenario is not None:
             if scenario.simulation_modifier is not None:
                 scenario.simulation_modifier(self)

--- a/policyengine_uk/tests/microsimulation/reforms_config.yaml
+++ b/policyengine_uk/tests/microsimulation/reforms_config.yaml
@@ -16,7 +16,7 @@ reforms:
   parameters:
     gov.hmrc.child_benefit.amount.additional: 25
 - name: Reduce Universal Credit taper rate to 20%
-  expected_impact: -33.8
+  expected_impact: -33.7
   parameters:
     gov.dwp.universal_credit.means_test.reduction_rate: 0.2
 - name: Raise Class 1 main employee NICs rate to 10%


### PR DESCRIPTION
This PR fixes an issue where capital gains elasticities were not taking effect in simulations.

The problem was that `capital_gains_before_response` and `employment_income_before_lsr` values needed to be initialized at the start of the simulation process. Without these values being properly moved from their baseline values, the behavioural response calculations couldn't access the necessary data.

The fix adds the required `move_values()` calls in the Simulation class initialization to ensure these baseline values are set before any scenario modifications are applied.

Fixes #1319