### PR TITLE
Fix birth_year calculation for two-child limit projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.55.0] - 2025-10-02 14:33:05
+
+### Fixed
+
+- Fix two-child limit cost projections by ensuring birth_year is calculated from age and period rather than using static dataset values, allowing the number of affected children to increase correctly over time
+
 ## [2.54.0] - 2025-09-30 14:40:31
 
 ### Added
@@ -1673,6 +1679,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.29.0] - 2022-08-28 14:45:36
 
+### Changed
+
+- Refactored the parameter tree into the (gov/hh/calibration/contrib)|(dept) format.
+
 ## [0.28.1] - 2022-08-25 17:36:23
 
 ### Fixed
@@ -2264,6 +2274,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[2.55.0]: https://github.com/PolicyEngine/openfisca-uk/compare/2.54.0...2.55.0
 [2.54.0]: https://github.com/PolicyEngine/openfisca-uk/compare/2.53.1...2.54.0
 [2.53.1]: https://github.com/PolicyEngine/openfisca-uk/compare/2.53.0...2.53.1
 [2.53.0]: https://github.com/PolicyEngine/openfisca-uk/compare/2.52.1...2.53.0

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -493,7 +493,8 @@
   date: 2022-08-25 17:36:23
 - bump: minor
   changes:
-  - Refactored the parameter tree into the (gov/hh/calibration/contrib)|(dept) format.
+    changed:
+    - Refactored the parameter tree into the (gov/hh/calibration/contrib)|(dept) format.
   date: 2022-08-28 14:45:36
 - bump: minor
   changes:
@@ -1917,3 +1918,10 @@
       of marginal rates.
     - Potential bug in labour supply response variable initialization order.
   date: 2025-09-30 14:40:31
+- bump: minor
+  changes:
+    fixed:
+    - Fix two-child limit cost projections by ensuring birth_year is calculated from
+      age and period rather than using static dataset values, allowing the number
+      of affected children to increase correctly over time
+  date: 2025-10-02 14:33:05

--- a/policyengine_uk/simulation.py
+++ b/policyengine_uk/simulation.py
@@ -272,6 +272,9 @@ class Simulation(CoreSimulation):
             variable, time_period = column.split("__")
             if variable not in self.tax_benefit_system.variables:
                 continue
+            # Skip birth_year - it should be calculated from age and period
+            if variable == "birth_year":
+                continue
             self.set_input(variable, time_period, df[column])
 
     def build_from_dataset(self, dataset: Dataset) -> None:
@@ -310,6 +313,9 @@ class Simulation(CoreSimulation):
         for variable in data:
             for time_period in data[variable]:
                 if variable not in self.tax_benefit_system.variables:
+                    continue
+                # Skip birth_year - it should be calculated from age and period
+                if variable == "birth_year":
                     continue
                 self.set_input(
                     variable, time_period, data[variable][time_period]
@@ -362,6 +368,10 @@ class Simulation(CoreSimulation):
             for table in dataset[year].tables:
                 for variable in table.columns:
                     if variable not in self.tax_benefit_system.variables:
+                        continue
+                    # Skip birth_year - it should be calculated from age and period
+                    # to properly reflect the projection year in multi-year datasets
+                    if variable == "birth_year":
                         continue
                     self.set_input(variable, year, table[variable])
 


### PR DESCRIPTION
## Summary

Fixes the bug where two-child limit budgetary impact was incorrectly constant across projection years.

## Problem

The `birth_year` variable was being loaded from the dataset as a static value, preventing it from being recalculated based on the projection year. This caused:

- Birth years to remain constant (e.g., 2006-2023 range in both 2026 and 2029)
- Number of children exempt from two-child limit to stay constant
- **Cost of repealing the limit to be incorrectly flat across years**

With a consistent age distribution in the microdata:
- **2026**: 10-year-olds should represent children born in **2016** → exempt (< 2017)
- **2029**: 10-year-olds should represent children born in **2019** → NOT exempt (≥ 2017)

## Solution

Skip loading `birth_year` from the dataset in `simulation.py`, allowing the Variable formula (`period.year - age`) to calculate it fresh for each projection year.

```python
# Skip birth_year - it should be calculated from age and period
# to properly reflect the projection year in multi-year datasets
if variable == "birth_year":
    continue
```

## Results

### Population Demographics

**Before fix:**
- 2026: 14,870 children born <2017 (exempt), birth years 2006-2023
- 2029: 14,870 children born <2017 (exempt), birth years 2006-2023
- Same cost in both years ❌

**After fix:**
- 2026: 10,638 children born <2017 (exempt), birth years 2009-2026
- 2029: 6,504 children born <2017 (exempt), birth years 2012-2029  
- **4,134 more children subject to limit in 2029** ✓

### Budgetary Impact (Repeal Cost)

**With the fix applied:**
- **2026**: £3.28bn total (£0.00bn CTC, £3.28bn UC)
- **2029**: £3.76bn total (£0.00bn CTC, £3.76bn UC)
- **Change**: +£0.47bn (+14.4%)

The cost now correctly increases over time as more children born after April 2017 enter the population ✓

## Dependencies

- Companion PR in policyengine-uk-data: #198 (removes birth_year from dataset generation)

## Test Plan

- [x] Verified birth years now update correctly by projection year
- [x] Confirmed number of affected children increases over time
- [x] Ran microsimulation showing 14.4% cost increase from 2026 to 2029
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)