### PR TITLE
Add Python 3.14 support, drop Python 3.10

### DIFF
--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -42,7 +42,7 @@ jobs:
             with:
               workload_identity_provider: "projects/322898545428/locations/global/workloadIdentityPools/policyengine-research-id-pool/providers/prod-github-provider"
               service_account: "policyengine-research@policyengine-research.iam.gserviceaccount.com"
-              
+
           - name: Install package
             run: uv pip install -e .[dev] --system
           - name: Install policyengine

--- a/changelog.d/upgrade-python-3.14.changed.md
+++ b/changelog.d/upgrade-python-3.14.changed.md
@@ -1,0 +1,1 @@
+Add Python 3.14 classifier and remove upper bound on requires-python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,13 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: POSIX",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.13"
 dependencies = [
     "policyengine-core>=3.23.6",
     "microdf-python>=1.2.1",
@@ -67,8 +67,8 @@ dev = [
     "snowballstemmer>=2,<3",
     "jupyter-book>=2.0.0a0",
     "linecheck",
-    "rich",    "towncrier>=24.8.0",
-
+    "rich",
+    "towncrier>=24.8.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- Add Python 3.14 to classifiers in pyproject.toml
- Drop Python 3.10 classifier
- Update `requires-python` from `>=3.13,<3.14` to `>=3.13` (removes upper bound, allows 3.14+)
- Update uv.lock to support Python 3.14 resolution markers

## Context

- policyengine-core merged Python 3.14 support in PR #435
- PyTables 3.11.0 has abi3 wheels for 3.14; the existing `tables>=3.10.2` constraint allows pip to select it when installing on 3.14

## Test results

Lint, documentation: passing. The 3 test failures (`test_reform_fiscal_impacts`, `test_dynamics_no_crash_simple`, `test_basic_behavioral_response_enabled`) are **pre-existing on main** and not caused by this PR. Verified by opening a separate PR with zero code changes from main ([PR #1510](https://github.com/PolicyEngine/policyengine-uk/pull/1510)) which showed the exact same failures. These tests pass in the push-to-main workflow but fail in the PR workflow.