### PR TITLE
Update documentation build to use myst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ update-tests:
 	python policyengine_uk/tests/microsimulation/update_reform_impacts.py
 
 documentation:
-	cd docs/book && jupyter book clean --all -y
-	cd docs/book && jupyter book build --html
+	myst clean --all docs/book
+	myst build docs/book
 	python docs/book/add_plotly_to_book.py docs/book/_build
 
 docs: documentation

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Update documentation command to use myst instead of deprecated jb/jupyter book


### PR DESCRIPTION
This PR updates the documentation build commands in the Makefile to use `myst` instead of the deprecated `jupyter book` commands.

## Changes
- Replace `jupyter book clean --all -y` with `myst clean --all docs/book`
- Replace `jupyter book build --html` with `myst build docs/book`
- Remove `cd docs/book` from commands since `myst` can handle paths directly

This aligns with the project requirement to use Jupyter Book 2.0 (MyST-NB) and the `myst` CLI instead of the deprecated `jupyter book` command.

## Testing
The documentation build process should work the same way, but using the modern `myst` command instead of the deprecated `jupyter book` command.