### PR TITLE
Fix randomness between runs caused by UC reform

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed randomness between runs caused by UC reform.

--- a/policyengine_uk/scenarios/uc_reform.py
+++ b/policyengine_uk/scenarios/uc_reform.py
@@ -8,7 +8,9 @@ def add_universal_credit_reform(sim: Microsimulation):
         sim.tax_benefit_system.parameters.gov.dwp.universal_credit.rebalancing
     )
 
-    uc_seed = np.random.random(len(sim.calculate("benunit_id")))
+    generator = np.random.default_rng(43)
+
+    uc_seed = generator.random(len(sim.calculate("benunit_id")))
     p_uc_post_2026_status = {
         2025: 0,
         2026: 0.11,

--- a/policyengine_uk/tests/microsimulation/reforms_config.yaml
+++ b/policyengine_uk/tests/microsimulation/reforms_config.yaml
@@ -1,10 +1,10 @@
 reforms:
 - name: Raise basic rate by 1pp
-  expected_impact: 8.0
+  expected_impact: 8.1
   parameters:
     gov.hmrc.income_tax.rates.uk[0].rate: 0.21
 - name: Raise higher rate by 1pp
-  expected_impact: 5.0
+  expected_impact: 4.9
   parameters:
     gov.hmrc.income_tax.rates.uk[1].rate: 0.42
 - name: Raise personal allowance by ~800GBP/year
@@ -12,22 +12,22 @@ reforms:
   parameters:
     gov.hmrc.income_tax.allowances.personal_allowance.amount: 13000
 - name: Raise child benefit by 25GBP/week per additional child
-  expected_impact: -1.5
+  expected_impact: -1.3
   parameters:
     gov.hmrc.child_benefit.amount.additional: 25
 - name: Reduce Universal Credit taper rate to 20%
-  expected_impact: -36.5
+  expected_impact: -36.0
   parameters:
     gov.dwp.universal_credit.means_test.reduction_rate: 0.2
 - name: Raise Class 1 main employee NICs rate to 10%
-  expected_impact: 12.4
+  expected_impact: 12.5
   parameters:
     gov.hmrc.national_insurance.class_1.rates.employee.main: 0.1
 - name: Raise VAT standard rate by 2pp
-  expected_impact: 21.2
+  expected_impact: 19.1
   parameters:
     gov.hmrc.vat.standard_rate: 0.22
 - name: Raise additional rate by 3pp
-  expected_impact: 5.4
+  expected_impact: 4.5
   parameters:
     gov.hmrc.income_tax.rates.uk[2].rate: 0.48


### PR DESCRIPTION
The UC reform logic was using numpy's global random state, which caused different results on each run. This changes it to use a seeded random number generator for reproducible outputs.

Closes #1358