### PR TITLE
Add Claude Code plugin configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "marketplaces": [
+      "PolicyEngine/policyengine-claude"
+    ],
+    "auto_install": [
+      "country-models@policyengine-claude"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds **policyengine-claude plugin configuration** to enable automated installation of agents, commands, and skills for PolicyEngine development.

## Changes

- ✅ Add plugin auto-install configuration in `.claude/settings.json`
- ✅ Configure auto-install of `country-models` plugin from `PolicyEngine/policyengine-claude`

## Benefits

### For Developers
- ✅ **Access to 15 specialized agents** - rules-engineer, test-creator, document-collector, validators, optimizers, CI fixer
- ✅ **3 slash commands** - /encode-policy, /review-pr, /fix-pr
- ✅ **2 skills** - policyengine-us-skill (simulation patterns), policyengine-standards-skill (code quality)
- ✅ **Automatic installation** - When you trust this repo, plugin auto-installs

### For Teams
- ✅ **Standardization** - All team members get same agents/commands/skills
- ✅ **Easy updates** - Plugin manager handles updates
- ✅ **No Git complexity** - No submodule management needed

## What's Included

The `country-models` plugin provides:

- **rules-engineer** - Implements variables/parameters with zero hard-coded values
- **test-creator** - Creates tests from documentation (isolated development)
- **document-collector** - Gathers authoritative sources
- **Validators** - policy-domain, reference, cross-program, implementation
- **Optimizers** - Performance optimization suggestions
- **CI tools** - Automated CI fixing
- **/encode-policy** - Full implementation workflow orchestration
- **/review-pr** - Comprehensive PR review
- **/fix-pr** - Automated PR fixes

## Installation

### Automatic (Recommended)
When you trust this repo in Claude Code, the plugin auto-installs!

### Manual (Optional)
```bash
/plugin marketplace add PolicyEngine/policyengine-claude
/plugin install country-models@policyengine-claude
```

## Testing

After merging:
1. Team members trust the repo in Claude Code
2. Plugin auto-installs from marketplace
3. Agents, commands, and skills are immediately available
4. Test with: `/encode-policy [program]` or invoke agents directly

## Related

- Plugin Repository: https://github.com/PolicyEngine/policyengine-claude
- See also: PolicyEngine/policyengine-us#6692 (similar PR for policyengine-us)

## Changelog

Included in `changelog_entry.yaml`:
- Added: Claude Code plugin configuration for automated agent installation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>