### PR TITLE
Fix hardcoded data_year in state pension calculations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
 - **Testing**: Write tests for all new functionality
 - **Documentation**: Document all public functions with docstrings
 - **Versioning**: Follow SemVer (increment patch for fixes, minor for features, major for breaking changes)
-- **Pull Requests**: Add entries to changelog_entry.yaml, run `make changelog`, and commit results
+- **Pull Requests**: Must include a changelog_entry.yaml file describing the changes (GitHub Actions will automatically run `make changelog` to update the changelog)
 
 ## Repository Structure
 - **parameters/**: YAML files that define tax rates, thresholds, and other policy parameters

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - Bug in state pension formulae causing issues when using datasets with year != 2023.

--- a/policyengine_uk/variables/gov/dwp/additional_state_pension.py
+++ b/policyengine_uk/variables/gov/dwp/additional_state_pension.py
@@ -12,8 +12,10 @@ class additional_state_pension(Variable):
         simulation = person.simulation
         if simulation.dataset is None:
             return 0
-
-        data_year = min(simulation.dataset.years)
+        try:
+            data_year = min(simulation.dataset.years)
+        except:
+            data_year = period.year
         reported = person("state_pension_reported", data_year) / WEEKS_IN_YEAR
         type = person("state_pension_type", data_year)
         maximum_basic_sp = parameters(

--- a/policyengine_uk/variables/gov/dwp/additional_state_pension.py
+++ b/policyengine_uk/variables/gov/dwp/additional_state_pension.py
@@ -13,7 +13,7 @@ class additional_state_pension(Variable):
         if simulation.dataset is None:
             return 0
 
-        data_year = 2023
+        data_year = min(simulation.dataset.years)
         reported = person("state_pension_reported", data_year) / WEEKS_IN_YEAR
         type = person("state_pension_type", data_year)
         maximum_basic_sp = parameters(

--- a/policyengine_uk/variables/gov/dwp/basic_state_pension.py
+++ b/policyengine_uk/variables/gov/dwp/basic_state_pension.py
@@ -13,7 +13,7 @@ class basic_state_pension(Variable):
         if simulation.dataset is None:
             return 0
 
-        data_year = 2023
+        data_year = min(simulation.dataset.years)
         reported = person("state_pension_reported", data_year) / WEEKS_IN_YEAR
         type = person("state_pension_type", period)
         maximum_basic_sp = parameters(

--- a/policyengine_uk/variables/gov/dwp/basic_state_pension.py
+++ b/policyengine_uk/variables/gov/dwp/basic_state_pension.py
@@ -12,8 +12,10 @@ class basic_state_pension(Variable):
         simulation = person.simulation
         if simulation.dataset is None:
             return 0
-
-        data_year = min(simulation.dataset.years)
+        try:
+            data_year = min(simulation.dataset.years)
+        except:
+            data_year = period.year
         reported = person("state_pension_reported", data_year) / WEEKS_IN_YEAR
         type = person("state_pension_type", period)
         maximum_basic_sp = parameters(


### PR DESCRIPTION
The data_year variable in additional_state_pension and basic_state_pension was hardcoded to 2023, which caused incorrect calculations when using datasets from other years. This changes it to use min(simulation.dataset.years) instead.

Fixes #1363