### PR TITLE
Fix missing dataset attribute in Simulation class

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,2 @@
+- fixed:
+    - Fix missing dataset attribute in Simulation class

--- a/policyengine_uk/simulation.py
+++ b/policyengine_uk/simulation.py
@@ -43,6 +43,7 @@ class Simulation(CoreSimulation):
 
     calculated_periods: List[str] = []
     _variable_dependencies: Dict[str, List[str]] = None
+    dataset = None
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes #1366.

The Simulation class was missing an initialised `dataset` attribute, which could cause AttributeError when accessing `simulation.dataset` before it was set by one of the build methods. Fixed by adding `dataset = None` as a class attribute.