### PR TITLE
Add November 2025 Autumn Budget parameter updates

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - November 2025 Autumn Budget parameter updates. Extends income tax threshold freeze (personal allowance £12,570, higher rate £50,270, additional rate £125,140) and NICs secondary threshold freeze (£96/week) to April 2031. Updates fuel duty schedule with freeze until September 2026, staggered 5p cut reversal, and RPI uprating from April 2027.

--- a/policyengine_uk/parameters/gov/hmrc/fuel_duty/petrol_and_diesel.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/fuel_duty/petrol_and_diesel.yaml
@@ -1,4 +1,4 @@
-description: Fuel duty rate per litre of petrol and diesel.
+description: The UK levies fuel duty on petrol and diesel at this rate per litre.
 values:
   2010-04-01: 0.5719
   2010-10-01: 0.5819
@@ -26,6 +26,8 @@ values:
       reference:
         - title: OBR Economic and Fiscal Outlook November 2025
           href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+  # November 2025 Autumn Budget: staggered 5p cut reversal (+1p Sep, +2p Dec, +2p Mar 2027)
+  # then RPI uprating from Apr 2027: 59.80p (4.1%), 61.54p (3.2%), 63.34p (2.9%)
   2026-09-01:
     value: 0.5395
     metadata:

--- a/policyengine_uk/parameters/gov/hmrc/fuel_duty/petrol_and_diesel.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/fuel_duty/petrol_and_diesel.yaml
@@ -21,11 +21,47 @@ values:
         - title: Costing Document - Spring Budget 2023 (page 25)
           href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1142824/Costing_Document_-_Spring_Budget_2023.pdf#page=25
   2026-03-22:
+    value: 0.5295
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+  2026-09-01:
+    value: 0.5395
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+  2026-12-01:
+    value: 0.5595
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+  2027-03-01:
     value: 0.5795
     metadata:
       reference:
-        - title: Costing Document - Spring Budget 2025 (page 46)
-          href: https://assets.publishing.service.gov.uk/media/67e562fc33afcd62e4ca4c9e/SS25_Published_Costing_Document.pdf#page=46
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+  2027-04-01:
+    value: 0.598
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+  2028-04-01:
+    value: 0.6154
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+  2029-04-01:
+    value: 0.6334
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 metadata:
   unit: currency-GBP
   name: fuel_duty_rate

--- a/policyengine_uk/parameters/gov/hmrc/income_tax/allowances/personal_allowance/amount.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/allowances/personal_allowance/amount.yaml
@@ -6,6 +6,12 @@ values:
   2019-04-06: 12_500
   2021-04-06: 12_570
   2027-04-06: 12_570
+  2030-04-06:
+    value: 12_570
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 metadata:
   period: year
   name: personal_allowance

--- a/policyengine_uk/parameters/gov/hmrc/income_tax/rates/uk.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/rates/uk.yaml
@@ -47,6 +47,12 @@ brackets:
       2020-04-01: 37500
       2021-04-01: 37700
       2027-04-01: 37700
+      2030-04-01:
+        value: 37700
+        metadata:
+          reference:
+            - title: OBR Economic and Fiscal Outlook November 2025
+              href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 - rate:
     description: The additional rate is the highest tax bracket, with no upper bound
     metadata:
@@ -71,11 +77,17 @@ brackets:
       unit: currency-GBP
     values:
       2015-04-05: 150_000
-      2023-01-01: 
-        value: 125_140 
+      2023-01-01:
+        value: 125_140
         reference:
           - title: Finance Act 2023 s. 6 (4)
             href: https://www.legislation.gov.uk/ukpga/2023/1/section/6/enacted
+      2030-04-01:
+        value: 125_140
+        metadata:
+          reference:
+            - title: OBR Economic and Fiscal Outlook November 2025
+              href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 - rate:
     description: An extra tax bracket.
     metadata:

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/class_1/thresholds/secondary_threshold.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/class_1/thresholds/secondary_threshold.yaml
@@ -28,8 +28,14 @@ values:
     reference:
       - title: National Insurance Contributions (Secondary Class 1 Contributions) Act 2025(2)
         href: https://www.legislation.gov.uk/ukpga/2025/11/section/2
-  2027-01-01: 
+  2027-01-01:
     value: 96
     reference:
       - title: National Insurance Contributions (Secondary Class 1 Contributions) Act 2025(2)
         href: https://www.legislation.gov.uk/ukpga/2025/11/section/2
+  2030-04-06:
+    value: 96
+    metadata:
+      reference:
+        - title: OBR Economic and Fiscal Outlook November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/

--- a/policyengine_uk/tests/microsimulation/reforms_config.yaml
+++ b/policyengine_uk/tests/microsimulation/reforms_config.yaml
@@ -4,11 +4,11 @@ reforms:
   parameters:
     gov.hmrc.income_tax.rates.uk[0].rate: 0.21
 - name: Raise higher rate by 1pp
-  expected_impact: 4.8
+  expected_impact: 5.3
   parameters:
     gov.hmrc.income_tax.rates.uk[1].rate: 0.42
 - name: Raise personal allowance by ~800GBP/year
-  expected_impact: 0.8
+  expected_impact: -4.2
   parameters:
     gov.hmrc.income_tax.allowances.personal_allowance.amount: 13000
 - name: Raise child benefit by 25GBP/week per additional child
@@ -16,18 +16,18 @@ reforms:
   parameters:
     gov.hmrc.child_benefit.amount.additional: 25
 - name: Reduce Universal Credit taper rate to 20%
-  expected_impact: -30.7
+  expected_impact: -30.2
   parameters:
     gov.dwp.universal_credit.means_test.reduction_rate: 0.2
 - name: Raise Class 1 main employee NICs rate to 10%
-  expected_impact: 12.9
+  expected_impact: 13.0
   parameters:
     gov.hmrc.national_insurance.class_1.rates.employee.main: 0.1
 - name: Raise VAT standard rate by 2pp
-  expected_impact: 18.9
+  expected_impact: 18.8
   parameters:
     gov.hmrc.vat.standard_rate: 0.22
 - name: Raise additional rate by 3pp
-  expected_impact: 5.2
+  expected_impact: 4.6
   parameters:
     gov.hmrc.income_tax.rates.uk[2].rate: 0.48

--- a/policyengine_uk/tests/policy/reforms/nov_2025_budget/income_tax_freeze.yaml
+++ b/policyengine_uk/tests/policy/reforms/nov_2025_budget/income_tax_freeze.yaml
@@ -1,0 +1,83 @@
+# Tests for November 2025 Autumn Budget income tax threshold freeze extension
+# The budget extends the freeze on personal allowance, higher rate threshold, and additional rate threshold
+# from April 2028 to April 2031 (covering tax years 2028-29, 2029-30, 2030-31)
+
+# Personal allowance freeze tests
+- name: Personal allowance frozen at 12570 in 2028-29
+  period: 2028
+  input:
+    employment_income: 50000
+  output:
+    personal_allowance: 12570
+
+- name: Personal allowance frozen at 12570 in 2029-30
+  period: 2029
+  input:
+    employment_income: 50000
+  output:
+    personal_allowance: 12570
+
+- name: Personal allowance frozen at 12570 in 2030-31
+  period: 2030
+  input:
+    employment_income: 50000
+  output:
+    personal_allowance: 12570
+
+# Higher rate threshold tests (PA + basic rate band = 12570 + 37700 = 50270)
+- name: Income at 50270 pays basic rate only in 2028-29
+  period: 2028
+  input:
+    employment_income: 50270
+  output:
+    higher_rate_earned_income: 0
+
+- name: Income at 50271 pays higher rate in 2028-29
+  period: 2028
+  input:
+    employment_income: 50271
+  output:
+    higher_rate_earned_income: 1
+
+- name: Income at 50270 pays basic rate only in 2030-31
+  period: 2030
+  input:
+    employment_income: 50270
+  output:
+    higher_rate_earned_income: 0
+
+- name: Income at 50271 pays higher rate in 2030-31
+  period: 2030
+  input:
+    employment_income: 50271
+  output:
+    higher_rate_earned_income: 1
+
+# Additional rate threshold tests (125140)
+- name: Income at 125140 pays higher rate only in 2028-29
+  period: 2028
+  input:
+    employment_income: 125140
+  output:
+    add_rate_earned_income: 0
+
+- name: Income at 125141 pays additional rate in 2028-29
+  period: 2028
+  input:
+    employment_income: 125141
+  output:
+    add_rate_earned_income: 1
+
+- name: Income at 125140 pays higher rate only in 2030-31
+  period: 2030
+  input:
+    employment_income: 125140
+  output:
+    add_rate_earned_income: 0
+
+- name: Income at 125141 pays additional rate in 2030-31
+  period: 2030
+  input:
+    employment_income: 125141
+  output:
+    add_rate_earned_income: 1


### PR DESCRIPTION
## Summary

Implements parameter updates from the November 2025 Autumn Budget (OBR Economic and Fiscal Outlook November 2025).

### Income Tax Threshold Freezes (to April 2031)
- Personal allowance: frozen at £12,570
- Higher rate threshold: frozen at £50,270 (basic rate band £37,700 + PA)
- Additional rate threshold: frozen at £125,140

Previously frozen until April 2028. Extension expected to raise £7.6bn by 2029-30.

### NICs Secondary Threshold Freeze (to April 2031)
- Employer NICs threshold: frozen at £96/week (£5,000/year)

### Fuel Duty Schedule Update
- Freeze at 52.95p/litre extended until September 2026
- Staggered 5p cut reversal:
  - Sep 2026: 53.95p
  - Dec 2026: 55.95p
  - Mar 2027: 57.95p
- RPI uprating from April 2027:
  - Apr 2027: 59.80p
  - Apr 2028: 61.54p
  - Apr 2029: 63.34p

Total cost of fuel duty freezes from 2010-11 to 2026-27: £120bn

## Test plan
- [x] 595 policy tests pass
- [x] 26 pytest tests pass
- [x] Added 11 new tests for income tax freeze extension
- [x] Reform impact test values updated

## References
- [OBR Economic and Fiscal Outlook November 2025](https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/)
- [PolicyEngine fuel duty freeze analysis](https://policyengine.org/uk/research/fuel-duty-freeze-2025)

Closes #1380, #1381, #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)