### PR TITLE
Block Python 3.14 due to policyengine-core compatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.14"
 dependencies = [
     "policyengine-core>=3.19.3",
     "microdf-python>=1.0.2",


### PR DESCRIPTION
## Summary

Blocks Python 3.14 installation until policyengine-core fixes a compatibility issue.

## Problem

The `person()` accessor in policyengine-core returns **unweighted** values instead of **weighted** values when running with Python 3.14. This causes all microsimulation-based tax calculations to return incorrect (near-zero) results.

Example:
```python
from policyengine_uk import Microsimulation
sim = Microsimulation()
# Python 3.13: ~£86.7bn (correct)
# Python 3.14: ~£0.11bn (wrong)
print(sim.calculate("taxed_dividend_income", 2027).sum() / 1e9)
```

## Fix

Changes `requires-python` from `>=3.13` to `>=3.13,<3.14`.

## Related

- Root cause: https://github.com/PolicyEngine/policyengine-core/issues/407

🤖 Generated with [Claude Code](https://claude.com/claude-code)