### PR TITLE
Fix property income tax not being included in total income tax

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,5 @@
-- bump: minor
+- bump: patch
   changes:
-    added:
-      - November 2025 Autumn Budget parameter updates. Extends income tax threshold freeze (personal allowance £12,570, higher rate £50,270, additional rate £125,140) and NICs secondary threshold freeze (£96/week) to April 2031. Updates fuel duty schedule with freeze until September 2026, staggered 5p cut reversal, and RPI uprating from April 2027.
+    fixed:
+    - Property income tax now properly included in total income tax calculation
+    - Property income excluded from earned taxable income to prevent double taxation

--- a/policyengine_uk/parameters/gov/hmrc/income_tax/earned_taxable_income_exclusions.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/earned_taxable_income_exclusions.yaml
@@ -3,6 +3,7 @@ values:
   0000-01-01:
     - taxable_savings_interest_income
     - taxable_dividend_income
+    - taxable_property_income
     - received_allowances_earned_income
     - marriage_allowance
     

--- a/policyengine_uk/parameters/gov/hmrc/income_tax/income_tax_additions.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/income_tax_additions.yaml
@@ -7,5 +7,6 @@ values:
   - earned_income_tax
   - savings_income_tax
   - dividend_income_tax
+  - property_income_tax
   - CB_HITC
   - personal_pension_contributions_tax

--- a/policyengine_uk/tests/test_property_income_tax.py
+++ b/policyengine_uk/tests/test_property_income_tax.py
@@ -1,0 +1,109 @@
+"""Test that property_income_tax is properly included in total income_tax."""
+
+from policyengine_uk import Microsimulation
+
+
+def test_property_income_tax_included_in_total_2027():
+    """Test that property income tax is included in total income tax for 2027."""
+    situation = {
+        "people": {"person": {"age": 30, "property_income": {2027: 20000}}},
+        "benunits": {"benunit": {"members": ["person"]}},
+        "households": {"household": {"members": ["person"]}},
+    }
+    sim = Microsimulation(situation=situation)
+
+    # Calculate values
+    property_income_tax = sim.calculate("property_income_tax", 2027).sum()
+    income_tax = sim.calculate("income_tax", 2027).sum()
+
+    # Property income tax should be non-zero
+    assert property_income_tax > 0, "property_income_tax should be calculated"
+
+    # Income tax should include property income tax (for person with only property income)
+    assert abs(income_tax - property_income_tax) < 10, (
+        f"income_tax (£{income_tax}) should equal property_income_tax (£{property_income_tax}) "
+        "for person with only property income"
+    )
+
+
+def test_property_income_tax_with_employment_2027():
+    """Test property income tax stacking on employment income."""
+    situation = {
+        "people": {
+            "person": {
+                "age": 30,
+                "employment_income": {2027: 30000},
+                "property_income": {2027: 20000},
+            }
+        },
+        "benunits": {"benunit": {"members": ["person"]}},
+        "households": {"household": {"members": ["person"]}},
+    }
+    sim = Microsimulation(situation=situation)
+
+    # Calculate values
+    earned_income_tax = sim.calculate("earned_income_tax", 2027).sum()
+    property_income_tax = sim.calculate("property_income_tax", 2027).sum()
+    income_tax = sim.calculate("income_tax", 2027).sum()
+
+    # Both should be non-zero
+    assert earned_income_tax > 0, "earned_income_tax should be calculated"
+    assert property_income_tax > 0, "property_income_tax should be calculated"
+
+    # Income tax should be sum of both components
+    expected_total = earned_income_tax + property_income_tax
+    assert abs(income_tax - expected_total) < 10, (
+        f"income_tax (£{income_tax}) should equal sum of "
+        f"earned_income_tax (£{earned_income_tax}) + "
+        f"property_income_tax (£{property_income_tax}) = £{expected_total}"
+    )
+
+
+def test_property_income_uses_standard_rates_before_2027():
+    """Test that property income uses standard rates before 2027."""
+    situation = {
+        "people": {"person": {"age": 30, "property_income": {2026: 20000}}},
+        "benunits": {"benunit": {"members": ["person"]}},
+        "households": {"household": {"members": ["person"]}},
+    }
+    sim = Microsimulation(situation=situation)
+
+    # Calculate values
+    property_income_tax = sim.calculate("property_income_tax", 2026).sum()
+    income_tax = sim.calculate("income_tax", 2026).sum()
+
+    # Property income tax should be non-zero
+    assert property_income_tax > 0, "property_income_tax should be calculated"
+
+    # Income tax should include property income tax
+    assert abs(income_tax - property_income_tax) < 10, (
+        f"income_tax (£{income_tax}) should equal property_income_tax (£{property_income_tax})"
+    )
+
+
+def test_property_income_uses_higher_rates_from_2027():
+    """Test that property income tax increases from 2026 to 2027 due to rate change."""
+    situation_2026 = {
+        "people": {"person": {"age": 30, "property_income": {2026: 20000}}},
+        "benunits": {"benunit": {"members": ["person"]}},
+        "households": {"household": {"members": ["person"]}},
+    }
+    situation_2027 = {
+        "people": {"person": {"age": 30, "property_income": {2027: 20000}}},
+        "benunits": {"benunit": {"members": ["person"]}},
+        "households": {"household": {"members": ["person"]}},
+    }
+
+    sim_2026 = Microsimulation(situation=situation_2026)
+    sim_2027 = Microsimulation(situation=situation_2027)
+
+    # Calculate values
+    property_tax_2026 = sim_2026.calculate("property_income_tax", 2026).sum()
+    property_tax_2027 = sim_2027.calculate("property_income_tax", 2027).sum()
+
+    # 2027 should be higher due to 2pp increase
+    # (Note: difference may be small due to parameter uprating between years)
+    assert property_tax_2027 > property_tax_2026, (
+        f"2027 property tax (£{property_tax_2027}) should be higher than "
+        f"2026 (£{property_tax_2026}) due to 2pp rate increase"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.47.4"
+version = "2.59.0"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary

Fixes a bug where property income tax was being calculated correctly but was not included in the main `income_tax` variable. This was causing `gov_balance` to show no impact from property tax reforms (e.g., the 2027 property income tax rate increase of +2pp).

## Root Cause

In commit 53c38d2 (PR #1396), the `property_income_tax` variable was added to calculate tax on property income using property-specific rates. However:

1. `property_income_tax` was **not added** to the `income_tax_additions.yaml` parameter file, so it was never summed into total income tax
2. `taxable_property_income` was **not excluded** from `earned_taxable_income_exclusions.yaml`, which would have caused double taxation if the first issue hadn't prevented it from being counted at all

## Changes Made

1. **Added `property_income_tax` to `income_tax_additions.yaml`** - This ensures property income tax is included when calculating total income tax
2. **Added `taxable_property_income` to `earned_taxable_income_exclusions.yaml`** - This prevents property income from being taxed twice (once via `earned_income_tax` and once via `property_income_tax`)

## Impact

Before this fix:
- Property income tax reforms showed £0 impact on government balance
- Property income was effectively untaxed in total calculations

After this fix:
- Property income tax is correctly included in total income tax
- Government balance shows proper impact of property tax reforms
- Property income is taxed exactly once at the correct rates

## Testing

Added comprehensive tests in `test_property_income_tax.py`:
- ✅ Property income tax is included in total income tax for person with only property income
- ✅ Property income tax correctly combines with employment income tax
- ✅ Property tax rates apply correctly before and after 2027
- ✅ All 4 tests pass

## Test Plan

- [x] Added unit tests that verify property_income_tax is included in income_tax
- [x] Tests confirm no double taxation (income_tax = sum of components)
- [x] Tests verify correct stacking with other income types
- [x] All new tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)