### PR TITLE
Fix changelog_entry.yaml encoding

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-      - November 2025 Autumn Budget parameter updates. Extends income tax threshold freeze (personal allowance £12,570, higher rate £50,270, additional rate £125,140) and NICs secondary threshold freeze (£96/week) to April 2031. Updates fuel duty schedule with freeze until September 2026, staggered 5p cut reversal, and RPI uprating from April 2027.
+      - November 2025 Autumn Budget parameter updates. Extends income tax threshold freeze (personal allowance GBP 12,570, higher rate GBP 50,270, additional rate GBP 125,140) and NICs secondary threshold freeze (GBP 96/week) to April 2031. Updates fuel duty schedule with freeze until September 2026, staggered 5p cut reversal, and RPI uprating from April 2027.


### PR DESCRIPTION
## Summary

The versioning workflow failed because `changelog_entry.yaml` contained £ symbols encoded in ISO-8859 (Latin-1) instead of UTF-8, causing a `UnicodeDecodeError`:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa3 in position 147: invalid start byte
```

This PR replaces the £ symbols with "GBP" to fix the encoding issue and allow the versioning workflow to complete.

## Test plan

- [ ] Versioning workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)