### PR TITLE
Update HH net income calculation to subtract employee pension contrib

### DIFF
--- a/policyengine_uk/variables/household/income/household_net_income.py
+++ b/policyengine_uk/variables/household/income/household_net_income.py
@@ -16,11 +16,14 @@ class household_net_income(Variable):
     ]
     subtracts = [
         "household_tax",
-        "employee_pension_contributions",
+        "pension_contributions",
     ]
 
     def formula(household, period, parameters):
         market_income = household("household_market_income", period)
         benefits = household("household_benefits", period)
         tax = household("household_tax", period)
-        return np.round(market_income + benefits - tax)
+        pension_contributions = add(
+            household, period, ["pension_contributions"]
+        )
+        return np.round(market_income + benefits - tax - pension_contributions)

--- a/uv.lock
+++ b/uv.lock
@@ -1197,7 +1197,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.60.0"
+version = "2.61.1"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
Fixes #1411

## Summary

Updates `household_net_income` to subtract employee pension contributions, aligning with HBAI methodology.

## Changes

- Added `employee_pension_contributions` to the `subtracts` list in `household_net_income`