### PR TITLE
Fix Plan 2 student loan threshold for 2026-2029

### DIFF
--- a/policyengine_uk/parameters/gov/hmrc/student_loans/thresholds/plan_2.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/student_loans/thresholds/plan_2.yaml
@@ -21,26 +21,33 @@ values:
         - title: Student loan thresholds for April 2025
           href: https://www.gov.uk/government/publications/student-loan-and-postgraduate-loan-thresholds/student-loan-and-postgraduate-loan-thresholds-for-the-2025-to-2026-academic-year
   2026-04-06:
-    value: 28_470
+    value: 29_385
     metadata:
       uprating: none
       reference:
-        - title: Autumn Budget 2025 - Plan 2 threshold freeze
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: Student Loans Interest and Repayment Threshold Announcement for Plan 2 and Plan 3 loans
+          href: https://www.gov.uk/government/news/student-loans-interest-and-repayment-threshold-announcement-for-plan-2-and-plan-3-loans
   2027-04-06:
-    value: 28_470
+    value: 29_385
     metadata:
       uprating: none
       reference:
-        - title: Autumn Budget 2025 - Plan 2 threshold freeze
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: Budget 2025 - Plan 2 threshold freeze 2027-28 until 2029-30
+          href: https://www.gov.uk/government/publications/budget-2025-document/budget-2025-html
   2028-04-06:
-    value: 28_470
+    value: 29_385
     metadata:
       uprating: none
       reference:
-        - title: Autumn Budget 2025 - Plan 2 threshold freeze
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: Budget 2025 - Plan 2 threshold freeze 2027-28 until 2029-30
+          href: https://www.gov.uk/government/publications/budget-2025-document/budget-2025-html
+  2029-04-06:
+    value: 29_385
+    metadata:
+      uprating: none
+      reference:
+        - title: Budget 2025 - Plan 2 threshold freeze 2027-28 until 2029-30
+          href: https://www.gov.uk/government/publications/budget-2025-document/budget-2025-html
 metadata:
   label: Plan 2 threshold
   unit: currency-GBP

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_repayment.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_repayment.yaml
@@ -61,3 +61,70 @@
         student_loan_plan: NONE
   output:
     has_student_loan: false
+
+# Plan 2 threshold tests for Autumn Budget 2025 freeze
+# Per GOV.UK announcement: threshold rises to £29,385 from April 2026
+# Per Budget 2025: frozen at £29,385 from 2027-28 until 2029-30
+# Reference: https://www.gov.uk/government/news/student-loans-interest-and-repayment-threshold-announcement-for-plan-2-and-plan-3-loans
+#
+# Note: Calendar year tests use the parameter value at January 1 of that year.
+# The £29,385 threshold takes effect from April 6, 2026, so:
+# - 2026 calendar year (Jan 1): uses £28,470 (from April 2025)
+# - 2027+ calendar years: use £29,385 (from April 2026)
+# For tax year 2026-27 calculations, the threshold is £29,385.
+
+- name: Plan 2 - 2027 threshold is £29,385 (tax year 2026-27 rate)
+  period: 2027
+  input:
+    people:
+      person:
+        employment_income: 40_000
+        student_loan_plan: PLAN_2
+  output:
+    # 9% of (40,000 - 29,385) = 9% of 10,615 = 955.35
+    student_loan_repayment: 955.35
+
+- name: Plan 2 - 2028 threshold frozen at £29,385
+  period: 2028
+  input:
+    people:
+      person:
+        employment_income: 40_000
+        student_loan_plan: PLAN_2
+  output:
+    # 9% of (40,000 - 29,385) = 9% of 10,615 = 955.35
+    student_loan_repayment: 955.35
+
+- name: Plan 2 - 2029 threshold frozen at £29,385
+  period: 2029
+  input:
+    people:
+      person:
+        employment_income: 40_000
+        student_loan_plan: PLAN_2
+  output:
+    # 9% of (40,000 - 29,385) = 9% of 10,615 = 955.35
+    student_loan_repayment: 955.35
+
+- name: Plan 2 - 2030 threshold resumed RPI uprating
+  period: 2030
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        employment_income: 40_000
+        student_loan_plan: PLAN_2
+  output:
+    # Threshold resumes RPI uprating from 2030
+    # 9% of (40,000 - ~30,064) = 9% of ~9,936 = ~894.26
+    student_loan_repayment: 894.26
+
+- name: Plan 2 - Income just below 2027 threshold
+  period: 2027
+  input:
+    people:
+      person:
+        employment_income: 29_000
+        student_loan_plan: PLAN_2
+  output:
+    student_loan_repayment: 0


### PR DESCRIPTION
## Summary

Fixes the Plan 2 student loan repayment threshold to match official policy from the Autumn Budget 2025.

### Previous values (incorrect)

| Year | Threshold |
|------|-----------|
| 2025 | £28,470 |
| 2026 | £28,470 |
| 2027 | £28,470 |
| 2028 | £28,470 |
| 2029 | RPI (~£29,298) |

### Corrected values

| Year | Threshold | Source |
|------|-----------|--------|
| 2025 | £28,470 | Current |
| 2026 | **£29,385** | [GOV.UK announcement](https://www.gov.uk/government/news/student-loans-interest-and-repayment-threshold-announcement-for-plan-2-and-plan-3-loans) |
| 2027 | **£29,385** (frozen) | [Budget 2025](https://www.gov.uk/government/publications/budget-2025-document/budget-2025-html) |
| 2028 | **£29,385** (frozen) | Budget 2025 |
| 2029 | **£29,385** (frozen) | Budget 2025 |
| 2030 | RPI (~£30,064) | Resume uprating |

## Test plan

- [x] Added tests for 2027-2030 thresholds
- [x] Tests verify threshold is £29,385 for 2027-2029 (frozen)
- [x] Tests verify threshold resumes RPI uprating from 2030
- [x] All student loan tests pass

Fixes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)