### PR TITLE
Add Autumn Budget 2025 reforms: two child limit and salary sacrifice cap

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: minor
+  changes:
+    added:
+      - Two child limit repeal from April 2026 (Autumn Budget 2025) - sets UC and Tax Credits child element limit to infinity
+      - Salary sacrifice pension cap of £2,000 from April 2029 (Autumn Budget 2025)

--- a/policyengine_uk/parameters/gov/dwp/tax_credits/child_tax_credit/limit/child_count.yaml
+++ b/policyengine_uk/parameters/gov/dwp/tax_credits/child_tax_credit/limit/child_count.yaml
@@ -5,8 +5,12 @@ values:
   2026-04-06: .inf
 metadata:
   unit: int
+  label: Child Tax Credit child element child limit
+  period: year
   reference:
     - title: Exceptions to the 2 child limit
       href: https://www.gov.uk/guidance/child-tax-credit-exceptions-to-the-2-child-limit
-    - title: Autumn Budget 2025 - Two child limit repeal
-      href: https://www.gov.uk/government/publications/autumn-budget-2025
+    - title: Budget 2025 (HTML)
+      href: https://www.gov.uk/government/publications/budget-2025-document/budget-2025-html
+    - title: Removing the two-child limit on Universal Credit
+      href: https://www.gov.uk/government/publications/poverty-impacts-of-social-security-changes-at-budget-2025/removing-the-two-child-limit-on-universal-credit-impact-on-low-income-poverty-levels-in-the-united-kingdom

--- a/policyengine_uk/parameters/gov/dwp/tax_credits/child_tax_credit/limit/child_count.yaml
+++ b/policyengine_uk/parameters/gov/dwp/tax_credits/child_tax_credit/limit/child_count.yaml
@@ -2,6 +2,11 @@ description: Limit on the number of children for which the Child Tax Credit chil
 values:
   0001-01-01: .inf
   2017-04-06: 2
+  2026-04-06: .inf
 metadata:
   unit: int
-  reference: https://www.gov.uk/guidance/child-tax-credit-exceptions-to-the-2-child-limit
+  reference:
+    - title: Exceptions to the 2 child limit
+      href: https://www.gov.uk/guidance/child-tax-credit-exceptions-to-the-2-child-limit
+    - title: Autumn Budget 2025 - Two child limit repeal
+      href: https://www.gov.uk/government/publications/autumn-budget-2025

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/elements/child/limit/child_count.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/elements/child/limit/child_count.yaml
@@ -10,5 +10,7 @@ metadata:
   reference:
     - title: The Universal Credit Regulations 2013 reg. 24A
       href: https://www.legislation.gov.uk/uksi/2013/376/data.pdf#page=31
-    - title: Autumn Budget 2025 - Two child limit repeal
-      href: https://www.gov.uk/government/publications/autumn-budget-2025
+    - title: Budget 2025 (HTML)
+      href: https://www.gov.uk/government/publications/budget-2025-document/budget-2025-html
+    - title: Removing the two-child limit on Universal Credit
+      href: https://www.gov.uk/government/publications/poverty-impacts-of-social-security-changes-at-budget-2025/removing-the-two-child-limit-on-universal-credit-impact-on-low-income-poverty-levels-in-the-united-kingdom

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/elements/child/limit/child_count.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/elements/child/limit/child_count.yaml
@@ -2,10 +2,13 @@ description: Limit on the number of children for which the Universal Credit chil
 values:
   0001-01-01: .inf
   2017-04-06: 2
+  2026-04-06: .inf
 metadata:
   unit: child
   label: Universal Credit child element child limit
   period: year
-  reference: 
+  reference:
     - title: The Universal Credit Regulations 2013 reg. 24A
       href: https://www.legislation.gov.uk/uksi/2013/376/data.pdf#page=31
+    - title: Autumn Budget 2025 - Two child limit repeal
+      href: https://www.gov.uk/government/publications/autumn-budget-2025

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/salary_sacrifice_pension_cap.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/salary_sacrifice_pension_cap.yaml
@@ -10,7 +10,7 @@ metadata:
   label: Salary sacrifice pension NI exemption cap
   period: year
   reference:
-    - title: "Cap on UK salary sacrifice benefits is 'short-term' choice, warn experts"
-      href: https://docs.google.com/document/d/1Rhrfrg7A_oZHudmA775otAn1EE4-YthgeyS9nL-PrE8/edit?tab=t.0
-    - title: Autumn Budget 2025 - Salary sacrifice pension cap
-      href: https://www.gov.uk/government/publications/autumn-budget-2025
+    - title: Changes to salary sacrifice for pensions from April 2029
+      href: https://www.gov.uk/government/publications/changes-to-salary-sacrifice-for-pensions-from-april-2029
+    - title: Budget 2025 (HTML)
+      href: https://www.gov.uk/government/publications/budget-2025-document/budget-2025-html

--- a/policyengine_uk/parameters/gov/hmrc/national_insurance/salary_sacrifice_pension_cap.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/national_insurance/salary_sacrifice_pension_cap.yaml
@@ -4,6 +4,7 @@
 description: The annual cap on salary sacrifice pension contributions that are exempt from employee and employer National Insurance contributions.
 values:
   2010-01-01: .inf  # Default: no cap (scheme inactive)
+  2029-04-06: 2000  # Autumn Budget 2025: £2,000 cap from April 2029
 metadata:
   unit: currency-GBP
   label: Salary sacrifice pension NI exemption cap
@@ -11,3 +12,5 @@ metadata:
   reference:
     - title: "Cap on UK salary sacrifice benefits is 'short-term' choice, warn experts"
       href: https://docs.google.com/document/d/1Rhrfrg7A_oZHudmA775otAn1EE4-YthgeyS9nL-PrE8/edit?tab=t.0
+    - title: Autumn Budget 2025 - Salary sacrifice pension cap
+      href: https://www.gov.uk/government/publications/autumn-budget-2025


### PR DESCRIPTION
## Summary

  Adds two Autumn Budget 2025 reforms to policyengine-uk as baseline parameters:

  ### 1. Two Child Limit Repeal (April 2026)
  - Sets `gov.dwp.universal_credit.elements.child.limit.child_count` to infinity from 2026-04-06
  - Sets `gov.dwp.tax_credits.child_tax_credit.limit.child_count` to infinity from 2026-04-06
  - OBR costing: £2.1-2.8bn annually (static)

  ### 2. Salary Sacrifice Pension Cap (April 2029)
  - Sets `gov.hmrc.national_insurance.salary_sacrifice_pension_cap` to £2,000 from 2029-04-06
  - Contributions above the cap become subject to employee and employer NICs
  - OBR costing: £4.9bn in 2029-30 (static)

  ### 3. Rail Fares Freeze - No changes needed
  The rail fares freeze is **already implemented** in policyengine-uk via `gov.dft.rail.fare_index` (frozen at
  1.217 in 2026). The `prior_law_fare_index` parameter provides the counterfactual (5.8% increase).

  ## Test plan
  - [ ] Verify parameter values load correctly for 2026+ (two child limit)
  - [ ] Verify parameter values load correctly for 2029+ (salary sacrifice cap)
  - [ ] Run existing tests to ensure no regressions
