### PR TITLE
Adjust inflation for AHC real income

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,4 +2,6 @@
   changes:
     added:
       - Two child limit repeal from April 2026 (Autumn Budget 2025) - sets UC and Tax Credits child element limit to infinity
-      - Salary sacrifice pension cap of £2,000 from April 2029 (Autumn Budget 2025)
+      - Salary sacrifice pension cap of ï¿½2,000 from April 2029 (Autumn Budget 2025)
+      - Move inflation adjustment AHC back to BHC inflation.
+

--- a/policyengine_uk/variables/household/income/hbai_household_net_income_ahc.py
+++ b/policyengine_uk/variables/household/income/hbai_household_net_income_ahc.py
@@ -28,5 +28,5 @@ class real_hbai_household_net_income_ahc(Variable):
 
     def formula(household, period, parameters):
         return household("hbai_household_net_income_ahc", period) * household(
-            "inflation_adjustment_ahc", period
+            "inflation_adjustment", period
         )


### PR DESCRIPTION
cc @janton10

Point of this is to avoid the current situation where real incomes AHC can be higher than BHC due to using different indices