### PR TITLE
Bump policyengine-core to 3.23.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Bump policyengine-core to 3.23.0 (adds strict enum validation).

--- a/policyengine_uk/__init__.py
+++ b/policyengine_uk/__init__.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import os
+from pathlib import Path
+
+from policyengine_core.taxbenefitsystems import TaxBenefitSystem
+
 from policyengine_uk import entities
 from policyengine_uk.system import (
     CountryTaxBenefitSystem,
@@ -10,10 +14,6 @@ from policyengine_uk.system import (
     parameters,
     variables,
 )
-from pathlib import Path
-import os
 from .model_api import *
-from policyengine_core.taxbenefitsystems import TaxBenefitSystem
 
 REPO = Path(__file__).parent
-

--- a/policyengine_uk/__init__.py
+++ b/policyengine_uk/__init__.py
@@ -16,3 +16,4 @@ from .model_api import *
 from policyengine_core.taxbenefitsystems import TaxBenefitSystem
 
 REPO = Path(__file__).parent
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "policyengine-core>=3.19.3",
+    "policyengine-core>=3.23.0",
     "microdf-python>=1.0.2",
     "pydantic>=2.11.7",
     "tables>=3.10.2",


### PR DESCRIPTION
## Summary

Updates policyengine-core from >=3.19.3 to >=3.23.0.

## Why

policyengine-core 3.23.0 adds strict enum validation - invalid enum values now raise `ValueError` instead of silently converting to index 0 (which caused silent data corruption).

This PR tests that all enum values in our test files are valid. If CI fails, it means we have invalid enum values that need to be fixed.

## Related

- policyengine-core#411 - The fix for silent enum data corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)