### PR TITLE
Bump version for salary sacrifice cap reform

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Salary sacrifice pension cap reform (£2,000 cap from April 2029) with broad-base employer response modeling.


### PR DESCRIPTION
## Summary
- Triggers version bump to 2.65.3 to release salary sacrifice cap reform changes from PR #1441

This will publish the new package to PyPI with:
- Salary sacrifice pension cap (£2,000 from April 2029)
- Broad-base employer response modeling
- Employee and employer NI on excess contributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)