### PR TITLE
Fix changelog encoding - replace pound symbol with GBP

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     added:
-      - Salary sacrifice pension cap reform (£2,000 cap from April 2029) with broad-base employer response modeling.
+      - Salary sacrifice pension cap reform (GBP 2,000 cap from April 2029) with broad-base employer response modeling.


### PR DESCRIPTION
## Summary
- Fixes UTF-8 encoding error in changelog_entry.yaml
- Replaces `£` with `GBP` to avoid `UnicodeDecodeError` in yaml-changelog

The previous PR #1444 was merged before the fix was pushed, causing the versioning workflow to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)