### PR TITLE
Handle missing HUGGING_FACE_TOKEN gracefully in CI

### DIFF
--- a/.github/workflows/code_changes.yaml
+++ b/.github/workflows/code_changes.yaml
@@ -50,9 +50,14 @@ jobs:
           - name: UV sync
             run: uv sync
           - name: Run tests with coverage
-            run: make test
+            run: |
+              # Only export token if non-empty (defensive against missing secrets)
+              if [ -n "$HF_TOKEN_VALUE" ]; then
+                export HUGGING_FACE_TOKEN="$HF_TOKEN_VALUE"
+              fi
+              make test
             env:
-              HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+              HF_TOKEN_VALUE: ${{ secrets.HUGGING_FACE_TOKEN }}
           - name: Upload coverage to Codecov
             uses: codecov/codecov-action@v4
             with:

--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -50,9 +50,14 @@ jobs:
           - name: UV sync
             run: uv sync
           - name: Run tests with coverage
-            run: make test
+            run: |
+              # Only export token if non-empty (avoids 'Bearer ' error for Dependabot PRs)
+              if [ -n "$HF_TOKEN_VALUE" ]; then
+                export HUGGING_FACE_TOKEN="$HF_TOKEN_VALUE"
+              fi
+              make test
             env:
-              HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+              HF_TOKEN_VALUE: ${{ secrets.HUGGING_FACE_TOKEN }}
           - name: Upload coverage to Codecov
             uses: codecov/codecov-action@v4
             with:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - CI workflows now handle missing HUGGING_FACE_TOKEN gracefully, allowing Dependabot PRs to run tests without failing on empty Bearer token errors.


### PR DESCRIPTION
## Summary
- CI workflows now handle missing `HUGGING_FACE_TOKEN` gracefully
- Fixes the `httpx.LocalProtocolError: Illegal header value b'Bearer '` error that occurs when Dependabot PRs run without access to secrets

## Problem
When Dependabot opens a PR, it doesn't have access to repository secrets. The `HUGGING_FACE_TOKEN` secret gets passed as an empty string, which causes:
1. `policyengine-core` to return `""` (empty string is not `None`)
2. `huggingface_hub` to create a `Bearer ` header (empty token)
3. `httpx` to fail with `Illegal header value`

## Solution
Pass the token through an intermediate env var (`HF_TOKEN_VALUE`) and only export it to `HUGGING_FACE_TOKEN` if non-empty:

```bash
if [ -n "$HF_TOKEN_VALUE" ]; then
  export HUGGING_FACE_TOKEN="$HF_TOKEN_VALUE"
fi
```

This allows tests that don't need microdata downloads to still pass.

## Test plan
- [ ] CI passes on this PR (won't have access to token either, ironically)
- [ ] After merge, verify Dependabot PRs can run tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)