### PR TITLE
fix: update SCP baby bonus reform to use Person-level variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fixed Scottish Child Payment baby bonus reform to use Person-level variable structure, matching the refactored base variable. The reform now correctly uses parameterized baby bonus rates instead of hardcoded values.
+      - Fixed SCP baby bonus effective date to 2027-04-01 (fiscal year 2027-28) per Scottish Budget 2026-27.

--- a/policyengine_uk/parameters/gov/contrib/scotland/scottish_child_payment/baby_bonus.yaml
+++ b/policyengine_uk/parameters/gov/contrib/scotland/scottish_child_payment/baby_bonus.yaml
@@ -1,11 +1,12 @@
-description: Additional weekly amount for Scottish Child Payment based on child age.
+description: Additional weekly amount for Scottish Child Payment based on child age. Effective from 2027-28 fiscal year.
 brackets:
   - threshold:
       values:
         0001-01-01: 0
     amount:
       values:
-        0001-01-01: 12.85
+        0001-01-01: 0
+        2027-04-01: 12.85
   - threshold:
       values:
         0001-01-01: 1
@@ -19,5 +20,5 @@ metadata:
   period: week
   label: Scottish Child Payment baby bonus by age
   reference:
-    - title: Scottish Government - Scottish Child Payment
-      href: https://www.gov.scot/policies/social-security/scottish-child-payment/
+    - title: Scottish Budget 2026 to 2027
+      href: https://www.gov.scot/publications/scottish-budget-2026-2027/pages/6/

--- a/policyengine_uk/parameters/gov/contrib/scotland/scottish_child_payment/in_effect.yaml
+++ b/policyengine_uk/parameters/gov/contrib/scotland/scottish_child_payment/in_effect.yaml
@@ -1,7 +1,11 @@
 description: Whether the Scottish Child Payment baby bonus reform is in effect.
 values:
   0001-01-01: false
+  2027-04-01: true
 metadata:
   unit: bool
   period: year
   label: Scottish Child Payment baby bonus reform in effect
+  reference:
+    - title: Scottish Budget 2026 to 2027
+      href: https://www.gov.scot/publications/scottish-budget-2026-2027/pages/6/

--- a/policyengine_uk/reforms/scotland/scottish_child_payment_reform.py
+++ b/policyengine_uk/reforms/scotland/scottish_child_payment_reform.py
@@ -4,14 +4,11 @@ from policyengine_core.periods import period as period_
 
 def create_scottish_child_payment_baby_bonus_reform() -> Reform:
     """
-    Reform that implements SCP Premium for under-ones.
+    Reform that implements SCP baby bonus for children under 1.
 
-    Policy: Children under 1 receive a FIXED £40/week total payment.
-    Children 1+ receive the standard SCP rate (inflates with inflation).
-
-    This is NOT a fixed bonus added to the base - it's a fixed total amount.
-    As the base SCP rate inflates, the "bonus" for under-1s effectively
-    decreases to maintain the £40 total.
+    Policy: Children under 1 receive an additional weekly bonus on top of
+    the standard SCP rate. The bonus amount is parameterized at
+    gov.contrib.scotland.scottish_child_payment.baby_bonus.
 
     Source: Scottish Budget 2026-27
     https://www.gov.scot/publications/scottish-budget-2026-2027-finance-secretarys-statement-13-january-2026-2/
@@ -20,125 +17,42 @@ def create_scottish_child_payment_baby_bonus_reform() -> Reform:
     class scottish_child_payment(Variable):
         label = "Scottish Child Payment"
         documentation = (
-            "Scottish Child Payment provides financial support to low-income "
-            "families in Scotland. It is paid per eligible child to families "
-            "receiving qualifying benefits such as Universal Credit."
+            "Scottish Child Payment amount for this child. "
+            "Paid to eligible children in families receiving qualifying benefits. "
+            "When baby bonus reform is active, children under 1 receive additional payment."
         )
-        entity = BenUnit
+        entity = Person
         definition_period = YEAR
         value_type = float
         unit = GBP
+        defined_for = "is_scp_eligible"
         reference = [
+            "https://www.legislation.gov.uk/ssi/2020/351/contents",
             "https://www.gov.scot/policies/social-security/scottish-child-payment/",
-            "https://www.socialsecurity.gov.scot/",
         ]
 
-        def formula(benunit, period, parameters):
-            # Check if household is in Scotland
-            in_scotland = (
-                benunit.household("country", period).decode_to_str()
-                == "SCOTLAND"
-            )
-
+        def formula(person, period, parameters):
             # Get SCP parameters
             p = parameters(
                 period
             ).gov.social_security_scotland.scottish_child_payment
             weekly_amount = p.amount
 
-            # SCP only available when amount > 0 (i.e., after Feb 2021)
-            scp_available = weekly_amount > 0
+            # Get baby bonus parameter (age-bracketed)
+            baby_bonus_params = parameters(
+                period
+            ).gov.contrib.scotland.scottish_child_payment.baby_bonus
+            age = person("age", period)
+            baby_bonus = baby_bonus_params.calc(age)
 
-            # Count eligible children in the benefit unit
-            is_eligible_child = benunit.members(
-                "is_scp_eligible_child", period
-            )
-            eligible_children = benunit.sum(is_eligible_child)
+            # Total weekly amount = base + baby bonus
+            total_weekly = weekly_amount + baby_bonus
 
-            # Get ages for baby bonus calculation
-            age = benunit.members("age", period)
-
-            # Count children under 6 and 6+ for takeup rate calculation
-            is_child = benunit.members("is_child", period)
-            children_6_and_over = benunit.sum(
-                is_child & (age >= 6) & (age < 16)
-            )
-
-            # Check if receiving a qualifying benefit
-            qb = p.qualifying_benefits
-
-            receives_uc = (
-                benunit("universal_credit", period) > 0
-            ) & qb.universal_credit
-            receives_ctc = (
-                benunit("child_tax_credit", period) > 0
-            ) & qb.child_tax_credit
-            receives_wtc = (
-                benunit("working_tax_credit", period) > 0
-            ) & qb.working_tax_credit
-            receives_income_support = (
-                benunit("income_support", period) > 0
-            ) & qb.income_support
-            receives_jsa_income = (
-                benunit("jsa_income", period) > 0
-            ) & qb.jsa_income
-            receives_esa_income = (
-                benunit("esa_income", period) > 0
-            ) & qb.esa_income
-            receives_pension_credit = (
-                benunit("pension_credit", period) > 0
-            ) & qb.pension_credit
-
-            receives_qualifying_benefit = (
-                receives_uc
-                | receives_ctc
-                | receives_wtc
-                | receives_income_support
-                | receives_jsa_income
-                | receives_esa_income
-                | receives_pension_credit
-            )
-
-            # SCP Premium for under-ones: Fixed £40/week total (not base + bonus)
-            # Policy: Children under 1 get £40/week, children 1+ get standard rate
-            PREMIUM_RATE_UNDER_ONE = 40.0  # £40/week fixed total
-
-            # Calculate per-child weekly amount based on age
-            per_child_weekly = where(
-                age < 1,
-                PREMIUM_RATE_UNDER_ONE,  # £40/week for under-1s (TOTAL, not bonus)
-                weekly_amount,  # Standard SCP rate for 1+ (inflates with inflation)
-            )
-
-            # Calculate total weekly payment for all eligible children
-            total_weekly = benunit.sum(per_child_weekly * is_eligible_child)
+            # Child-level take-up (generated stochastically in dataset)
+            would_claim = person("would_claim_scp", period)
 
             # Convert to annual amount
-            annual_amount = total_weekly * WEEKS_IN_YEAR
-
-            # Apply age-specific take-up rates in microsimulation
-            takeup_under_6 = p.takeup_rate.under_6
-            takeup_6_and_over = p.takeup_rate.age_6_and_over
-
-            has_children_6_and_over = children_6_and_over > 0
-            takeup_rate = where(
-                has_children_6_and_over, takeup_6_and_over, takeup_under_6
-            )
-
-            takes_up = random(benunit) < takeup_rate
-            is_in_microsimulation = benunit.simulation.dataset is not None
-            if is_in_microsimulation:
-                receives_payment = takes_up
-            else:
-                receives_payment = True
-
-            return (
-                in_scotland
-                * scp_available
-                * receives_qualifying_benefit
-                * receives_payment
-                * annual_amount
-            )
+            return total_weekly * WEEKS_IN_YEAR * would_claim
 
     class reform(Reform):
         def apply(self):

--- a/policyengine_uk/tests/policy/reforms/scp_baby_bonus/scottish_child_payment_baby_bonus.yaml
+++ b/policyengine_uk/tests/policy/reforms/scp_baby_bonus/scottish_child_payment_baby_bonus.yaml
@@ -1,0 +1,130 @@
+# Scottish Child Payment Baby Bonus Reform tests
+# Tests that the SCP baby bonus reform correctly applies additional
+# payment for children under 1 year old.
+# Policy effective from 2027-28 fiscal year (April 2027).
+# Reform adds £12.85/week bonus for under-1s on top of standard rate.
+
+- name: SCP baby bonus for child under 1 (2028)
+  period: 2028
+  absolute_error_margin: 10
+  reforms:
+    - policyengine_uk.reforms.scotland.scottish_child_payment_reform.scottish_child_payment_reform
+  input:
+    people:
+      parent:
+        age: 30
+      baby:
+        age: 0
+    benunits:
+      benunit:
+        members: [parent, baby]
+        universal_credit: 5000
+    households:
+      household:
+        members: [parent, baby]
+        region: SCOTLAND
+  output:
+    # Base: £27.15/week + Bonus: £12.85/week = £40/week total
+    # £40/week * 52 weeks = £2,080 per year
+    # [parent, baby]
+    scottish_child_payment: [0, 2080]
+
+- name: SCP baby bonus - child over 1 gets standard rate (2028)
+  period: 2028
+  absolute_error_margin: 10
+  reforms:
+    - policyengine_uk.reforms.scotland.scottish_child_payment_reform.scottish_child_payment_reform
+  input:
+    people:
+      parent:
+        age: 30
+      toddler:
+        age: 2
+    benunits:
+      benunit:
+        members: [parent, toddler]
+        universal_credit: 5000
+    households:
+      household:
+        members: [parent, toddler]
+        region: SCOTLAND
+  output:
+    # Standard rate only: £27.15/week * 52 = £1,411.80
+    # [parent, toddler]
+    scottish_child_payment: [0, 1412]
+
+- name: SCP baby bonus - mixed ages (2028)
+  period: 2028
+  absolute_error_margin: 10
+  reforms:
+    - policyengine_uk.reforms.scotland.scottish_child_payment_reform.scottish_child_payment_reform
+  input:
+    people:
+      parent:
+        age: 30
+      baby:
+        age: 0
+      older_child:
+        age: 5
+    benunits:
+      benunit:
+        members: [parent, baby, older_child]
+        universal_credit: 5000
+    households:
+      household:
+        members: [parent, baby, older_child]
+        region: SCOTLAND
+  output:
+    # Baby (age 0): £40/week * 52 = £2,080
+    # Older child (age 5): £27.15/week * 52 = £1,411.80
+    # [parent, baby, older_child]
+    scottish_child_payment: [0, 2080, 1412]
+
+- name: SCP baby bonus - not in Scotland (2028)
+  period: 2028
+  absolute_error_margin: 1
+  reforms:
+    - policyengine_uk.reforms.scotland.scottish_child_payment_reform.scottish_child_payment_reform
+  input:
+    people:
+      parent:
+        age: 30
+      baby:
+        age: 0
+    benunits:
+      benunit:
+        members: [parent, baby]
+        universal_credit: 5000
+    households:
+      household:
+        members: [parent, baby]
+        region: NORTH_EAST
+  output:
+    # Not in Scotland - no SCP
+    # [parent, baby]
+    scottish_child_payment: [0, 0]
+
+- name: SCP baby bonus - before effective date (2025)
+  period: 2025
+  absolute_error_margin: 10
+  reforms:
+    - policyengine_uk.reforms.scotland.scottish_child_payment_reform.scottish_child_payment_reform
+  input:
+    people:
+      parent:
+        age: 30
+      baby:
+        age: 0
+    benunits:
+      benunit:
+        members: [parent, baby]
+        universal_credit: 5000
+    households:
+      household:
+        members: [parent, baby]
+        region: SCOTLAND
+  output:
+    # Before 2027-04-01 - baby bonus is £0, so standard rate only
+    # £27.15/week * 52 = £1,411.80
+    # [parent, baby]
+    scottish_child_payment: [0, 1412]


### PR DESCRIPTION
## Summary of Changes

| File | Change |
|------|--------|
| `scottish_child_payment_reform.py` | Updated to use Person entity (matching base variable) |
| `in_effect.yaml` | Now `true` starting `2027-04-01` (was `false` forever) |
| `baby_bonus.yaml` | Bonus is £0 before 2027-04-01, £12.85 after |
| `scottish_child_payment_baby_bonus.yaml` | Tests updated to use 2028, added test for pre-effective date |
| `changelog_entry.yaml` | Added note about effective date fix |

## Key Fixes

1. **Structural reform pattern**: Reform now properly uses Person-level variable with `is_scp_eligible` and `would_claim_scp` (was incorrectly using BenUnit entity). Reform entity type must match base variable entity type - verified against other reforms (`CB_HITC`, `marriage_allowance`) which all follow this pattern.

2. **Effective date**: Policy only takes effect from fiscal year 2027-28 (April 2027) per the [Scottish Budget 2026-27](https://www.gov.scot/publications/scottish-budget-2026-2027/pages/6/):
   > We will begin work in 2026-27 to introduce an additional payment for children under 1... which will be paid in 2027-28.

## Test plan
- [ ] Run `policyengine-core test policyengine_uk/tests/policy/reforms/scp_baby_bonus -c policyengine_uk`
- [ ] Verify reform correctly applies £12.85/week bonus for under-1s (2028+)
- [ ] Verify pre-2027 periods get standard rate only

🤖 Generated with [Claude Code](https://claude.com/claude-code)