### PR TITLE
feat: add Scottish Child Payment 2026-27 rate increase

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Scottish Child Payment increased to 28.20/week for 2026-27, per Scottish Budget 2026-27.

--- a/policyengine_uk/parameters/gov/social_security_scotland/scottish_child_payment/amount.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/scottish_child_payment/amount.yaml
@@ -6,6 +6,7 @@ values:
   2022-11-14: 25
   2024-04-01: 26.70
   2025-04-01: 27.15
+  2026-04-01: 28.20
 metadata:
   unit: currency-GBP
   period: week
@@ -15,3 +16,5 @@ metadata:
       href: https://www.legislation.gov.uk/ssi/2020/351/regulation/20
     - title: Scottish Government - Scottish Child Payment
       href: https://www.gov.scot/policies/social-security/scottish-child-payment/
+    - title: Scottish Budget 2026-27
+      href: https://www.gov.scot/news/a-budget-to-tackle-child-poverty/

--- a/policyengine_uk/tests/policy/baseline/gov/social_security_scotland/scottish_child_payment.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/social_security_scotland/scottish_child_payment.yaml
@@ -415,3 +415,27 @@
     # £27.15/week * 52 weeks = £1,411.80
     # [grandparent, child_1]
     scottish_child_payment: [0, 1412]
+
+# 2026-27 rate increase
+
+- name: SCP with 2026 amount (28.20/week)
+  period: 2026
+  absolute_error_margin: 10
+  input:
+    people:
+      parent:
+        age: 30
+      child_1:
+        age: 5
+    benunits:
+      benunit:
+        members: [parent, child_1]
+        universal_credit: 5000
+    households:
+      household:
+        members: [parent, child_1]
+        region: SCOTLAND
+  output:
+    # 28.20/week * 52 weeks = 1,466.40
+    # [parent, child_1]
+    scottish_child_payment: [0, 1466]


### PR DESCRIPTION
## Summary

Increases the Scottish Child Payment from £27.15/week to £28.20/week starting April 2026, in line with inflation.

## Source

> "The Scottish Child Payment for 2026-27 will increase to £28.20 per child per week, in line with inflation."

- [Scottish Government - A Budget to tackle child poverty](https://www.gov.scot/news/a-budget-to-tackle-child-poverty/)

## Changes

| File | Change |
|------|--------|
| `amount.yaml` | Added `2026-04-01: 28.20` |
| `scottish_child_payment.yaml` | Added test for 2026 rate |
| `changelog_entry.yaml` | Added changelog entry |

## Test plan
- [ ] Run `policyengine-core test policyengine_uk/tests/policy/baseline/gov/social_security_scotland -c policyengine_uk`
- [ ] Verify £28.20/week * 52 = £1,466.40/year for 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)