### PR TITLE
fix(scotland): add 2026-27 higher rate threshold freeze to baseline

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Add 2026-27 Scottish income tax threshold freeze to baseline (higher, advanced, and top rates) per Scottish Budget 2025-26.

--- a/policyengine_uk/parameters/gov/hmrc/fuel_duty/calculate_fuel_duty_rates.py
+++ b/policyengine_uk/parameters/gov/hmrc/fuel_duty/calculate_fuel_duty_rates.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 import yaml
 
-
 # Years to calculate rates for
 CALCULATION_YEARS = range(2026, 2031)
 

--- a/policyengine_uk/parameters/gov/hmrc/income_tax/rates/scotland/rates.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/rates/scotland/rates.yaml
@@ -45,6 +45,8 @@ brackets:
         2023-04-06: 31_092
         2024-04-06: 31_092
         2025-04-06: 31_092
+        # Scottish Budget 2025-26 announced freeze through 2026-27
+        2026-04-06: 31_092
       metadata:
         uprating: gov.economic_assumptions.indices.obr.consumer_price_index
     rate:
@@ -57,6 +59,8 @@ brackets:
         2023-04-06: 125_140
         2024-04-06: 62_430
         2025-04-06: 62_430
+        # Scottish Budget 2025-26 announced freeze through 2026-27
+        2026-04-06: 62_430
       metadata:
         uprating: gov.economic_assumptions.indices.obr.consumer_price_index
     rate:
@@ -69,6 +73,8 @@ brackets:
         2017-04-06: null
         2024-04-06: 125_140
         2025-04-06: 125_140
+        # Scottish Budget 2025-26 announced freeze through 2026-27
+        2026-04-06: 125_140
       metadata:
         uprating: gov.economic_assumptions.indices.obr.consumer_price_index
     rate:
@@ -81,3 +87,5 @@ metadata:
   reference:
     - title: GOV.UK
       href: https://www.gov.uk/government/publications/rates-and-allowances-income-tax/income-tax-rates-and-allowances-current-and-past
+    - title: Scottish Budget 2025-26 - Higher rate threshold freeze
+      href: https://www.gov.scot/publications/scottish-budget-2025-26/

--- a/policyengine_uk/tests/microsimulation/test_reform_impacts.py
+++ b/policyengine_uk/tests/microsimulation/test_reform_impacts.py
@@ -8,7 +8,6 @@ import yaml
 from pathlib import Path
 from policyengine_uk import Microsimulation
 
-
 # Load configuration from YAML file
 config_path = Path(__file__).parent / "reforms_config.yaml"
 with open(config_path, "r") as f:

--- a/policyengine_uk/tests/microsimulation/test_salary_sacrifice_cap_reform.py
+++ b/policyengine_uk/tests/microsimulation/test_salary_sacrifice_cap_reform.py
@@ -20,7 +20,6 @@ import numpy as np
 import pandas as pd
 from policyengine_uk import Microsimulation
 
-
 # Policy year when the salary sacrifice cap takes effect
 POLICY_YEAR = 2030  # Use 2030 to ensure cap is active (cap starts 2029-04-06)
 

--- a/policyengine_uk/tests/test_behavioral_responses.py
+++ b/policyengine_uk/tests/test_behavioral_responses.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from policyengine_uk import Microsimulation
 from policyengine_uk.model_api import Scenario
 
-
 # Check if HF token is available for data-dependent tests
 HF_TOKEN_AVAILABLE = bool(os.environ.get("HUGGING_FACE_TOKEN"))
 requires_hf_data = pytest.mark.skipif(

--- a/policyengine_uk/utils/dependencies.py
+++ b/policyengine_uk/utils/dependencies.py
@@ -179,14 +179,12 @@ def create_waterfall_change_chart(
 
 
 def add_fonts():
-    fonts = HTML(
-        """
+    fonts = HTML("""
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:ital,opsz,wght@0,8..144,100..900;1,8..144,100..900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap" rel="stylesheet">
-    """
-    )
+    """)
     return display_html(fonts)
 
 

--- a/policyengine_uk/variables/gov/hmrc/fuel_duty/fuel_duty.py
+++ b/policyengine_uk/variables/gov/hmrc/fuel_duty/fuel_duty.py
@@ -1,6 +1,5 @@
 from policyengine_uk.model_api import *
 
-
 STATUTORY_CONSUMER_INCIDENCE = 0.5
 ECONOMIC_CONSUMER_INCIDENCE = 1
 

--- a/policyengine_uk/variables/gov/hmrc/income_tax/reliefs/loss_relief.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/reliefs/loss_relief.py
@@ -1,6 +1,5 @@
 from policyengine_uk.model_api import *
 
-
 """
 The section detailing some tax reliefs applicable is section 24 of the Act, but others are described in the 2003 and 2005 Acts as deductions from the respective components.
 """


### PR DESCRIPTION
## Summary

Scottish Budget 2025-26 announced freezing higher, advanced, and top rate thresholds through 2026-27. This updates the baseline parameters to include these frozen values for 2026-04-06.

Without this fix, PolicyEngine's baseline incorrectly assumes CPI growth for 2026, leading to incorrect policy costings when comparing to SFC (Scottish Fiscal Commission) estimates.

### Thresholds frozen at:
- Higher rate: £31,092
- Advanced rate: £62,430
- Top rate: £125,140

### Evidence

From [SFC January 2026 Economic and Fiscal Forecasts](https://fiscalcommission.scot/publications/scotlands-economic-and-fiscal-forecasts-january-2026/), page 95 (Table A.1):

> The higher rate freeze for 2027-28 and 2028-29 shows **no costing for 2026-27** because it was already incorporated into the SFC baseline after Budget 2025-26 announced the freeze.

This means the 2026-27 freeze is NOT a new policy - it's already legislated and should be in the baseline.

## Test plan
- [ ] Verify higher rate threshold for 2026 is £31,092 (not CPI-inflated ~£31,863)
- [ ] Verify advanced rate threshold for 2026 is £62,430
- [ ] Verify top rate threshold for 2026 is £125,140

🤖 Generated with [Claude Code](https://claude.com/claude-code)