### PR TITLE
fix: convert StringArray to numpy array in uprate_rent

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix TypeError in uprate_rent when region.values.astype(str) returns a pandas StringArray instead of numpy array.

--- a/policyengine_uk/data/economic_assumptions.py
+++ b/policyengine_uk/data/economic_assumptions.py
@@ -161,8 +161,9 @@ def uprate_rent(
         pass
     elif year < 2025:
         # We have regional growth rates for private rent.
+        # Convert to numpy array for vectorial parameter lookup
         regional_growth_rate = growth.ons.private_rental_prices(year)[
-            region.values.astype(str)
+            np.array(region.values.astype(str))
         ]
         current_year.household["rent"] = np.where(
             is_private_rented,


### PR DESCRIPTION
## Summary
- Fix TypeError in `uprate_rent` when `region.values.astype(str)` returns a pandas `StringArray` instead of a numpy array
- The `ParameterNodeAtInstant.__getitem__` expects a `numpy.ndarray` for vectorial lookup, but pandas StringArray is not hashable

## Problem
When running microsimulations, the following error occurs:
```
TypeError: unhashable type: 'StringArray'
```

This happens in `economic_assumptions.py` line 164-165 where `region.values.astype(str)` returns a pandas StringArray which cannot be used as a key in the parameter lookup.

## CI Test Failures (Unrelated to this PR)

The CI test failures are **NOT caused by this PR**. They are due to a dependency version conflict that occurred after the last successful main branch CI run.

**Evidence:**
- Main branch CI passed 21 hours ago (2026-01-21 11:55 UTC)
- This PR CI failed today (2026-01-22 09:16 UTC)
- All tests pass locally on both main branch and this PR branch

**Root cause:**
The CI workflow runs `uv pip install policyengine --system` which now pulls in:
- `pandas==3.0.0` (newly released)
- `microdf-python==1.1.2`

This combination is broken - `microdf 1.1.2` is incompatible with `pandas 3.0.0`:
```
AttributeError: 'Series' object has no attribute 'set_weights'
```