### PR TITLE
Bump policyengine-core to 3.23.5 for pandas 3.0 compatibility

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Bumped policyengine-core minimum version to 3.23.5 for pandas 3.0 compatibility

--- a/policyengine_uk/tests/core/test_pandas3_enum_encoding.py
+++ b/policyengine_uk/tests/core/test_pandas3_enum_encoding.py
@@ -1,0 +1,43 @@
+"""Test pandas 3.0 compatibility with enum encoding.
+
+This test verifies that policyengine-core 3.23.5+ correctly handles
+pandas Series with StringDtype index when encoding enums.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from policyengine_core.enums import Enum
+
+
+class SampleEnum(Enum):
+    VALUE_A = "value_a"
+    VALUE_B = "value_b"
+
+
+def test_enum_encode_with_pandas_series():
+    """Test that Enum.encode works with pandas Series containing enum items.
+    
+    In pandas 3.0, Series with StringDtype use label-based indexing by default.
+    This test verifies the fix in policyengine-core 3.23.5 that uses .iloc[0]
+    for positional access instead of array[0].
+    """
+    enum_items = [SampleEnum.VALUE_A, SampleEnum.VALUE_B, SampleEnum.VALUE_A]
+    series = pd.Series(enum_items)
+    
+    # This would fail with KeyError: 0 before the fix
+    encoded = SampleEnum.encode(series)
+    
+    assert len(encoded) == 3
+    assert list(encoded) == [0, 1, 0]
+
+
+def test_enum_encode_with_string_index():
+    """Test enum encoding with explicitly string-indexed Series."""
+    enum_items = [SampleEnum.VALUE_A, SampleEnum.VALUE_B]
+    series = pd.Series(enum_items, index=["a", "b"])
+    
+    encoded = SampleEnum.encode(series)
+    
+    assert len(encoded) == 2
+    assert list(encoded) == [0, 1]

--- a/policyengine_uk/tests/core/test_pandas3_enum_encoding.py
+++ b/policyengine_uk/tests/core/test_pandas3_enum_encoding.py
@@ -3,6 +3,7 @@
 This test verifies that policyengine-core 3.23.5+ correctly handles
 pandas Series with StringDtype index when encoding enums.
 """
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -17,17 +18,17 @@ class SampleEnum(Enum):
 
 def test_enum_encode_with_pandas_series():
     """Test that Enum.encode works with pandas Series containing enum items.
-    
+
     In pandas 3.0, Series with StringDtype use label-based indexing by default.
     This test verifies the fix in policyengine-core 3.23.5 that uses .iloc[0]
     for positional access instead of array[0].
     """
     enum_items = [SampleEnum.VALUE_A, SampleEnum.VALUE_B, SampleEnum.VALUE_A]
     series = pd.Series(enum_items)
-    
+
     # This would fail with KeyError: 0 before the fix
     encoded = SampleEnum.encode(series)
-    
+
     assert len(encoded) == 3
     assert list(encoded) == [0, 1, 0]
 
@@ -36,8 +37,8 @@ def test_enum_encode_with_string_index():
     """Test enum encoding with explicitly string-indexed Series."""
     enum_items = [SampleEnum.VALUE_A, SampleEnum.VALUE_B]
     series = pd.Series(enum_items, index=["a", "b"])
-    
+
     encoded = SampleEnum.encode(series)
-    
+
     assert len(encoded) == 2
     assert list(encoded) == [0, 1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "policyengine-core>=3.23.5",
+    "policyengine-core>=3.23.6",
     "microdf-python>=1.2.1",
     "pydantic>=2.11.7",
     "tables>=3.10.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "policyengine-core>=3.23.0",
+    "policyengine-core>=3.23.5",
     "microdf-python>=1.0.2",
     "pydantic>=2.11.7",
     "tables>=3.10.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "policyengine-core>=3.23.5",
+    "policyengine-core==3.23.4",
     "microdf-python>=1.0.2",
     "pydantic>=2.11.7",
     "tables>=3.10.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "policyengine-core==3.23.4",
+    "policyengine-core>=3.23.5",
     "microdf-python>=1.0.2",
     "pydantic>=2.11.7",
     "tables>=3.10.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "policyengine-core>=3.23.5",
-    "microdf-python>=1.0.2",
+    "microdf-python>=1.2.1",
     "pydantic>=2.11.7",
     "tables>=3.10.2",
 ]


### PR DESCRIPTION
## Summary
- Bumped policyengine-core minimum version from 3.23.0 to 3.23.5 for pandas 3.0 compatibility

## Test plan
- [ ] CI passes with updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)