### PR TITLE
Relax Python version requirement to >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "policyengine-core>=3.23.6",
     "microdf-python>=1.2.1",


### PR DESCRIPTION
## Summary
- Changes `requires-python` from `>=3.13,<3.14` to `>=3.10,<3.14`

Fixes #1493

## Context
The `>=3.13` requirement was unintentionally set when migrating from `setup.py` (which had `>=3.7`) to `pyproject.toml`. This aligns with policyengine-us which uses `>=3.10,<3.14`.

## Test plan
- [ ] CI passes on Python 3.10, 3.11, 3.12, 3.13