### PR TITLE
fix: skip student loan uprating if column doesn't exist

### DIFF
--- a/policyengine_uk/data/economic_assumptions.py
+++ b/policyengine_uk/data/economic_assumptions.py
@@ -245,6 +245,11 @@ def uprate_student_loan_plans(
     For (2) and (3), we use highest_education == TERTIARY as the signal
     for who is a graduate, then apply a flat take-up probability.
     """
+    # Skip if student_loan_plan column doesn't exist yet (e.g., during
+    # initial dataset creation before imputation runs)
+    if "student_loan_plan" not in current_year.person.columns:
+        return current_year
+
     year = int(current_year.time_period)
 
     person = current_year.person.copy()


### PR DESCRIPTION
## Summary

During initial dataset creation in policyengine-uk-data, the `student_loan_plan` column is added by imputation **after** the base FRS dataset is created. The uprating code runs before imputation, so we need to gracefully skip if the column doesn't exist yet.

Without this fix, policyengine-uk-data CI fails with `KeyError: 'student_loan_plan'` when trying to create datasets.

## Test plan

- [ ] policyengine-uk-data CI passes after this is merged and released