### PR TITLE
Update OBR economic forecasts to March 2026 EFO

### DIFF
--- a/changelog.d/update-obr-march-2026.changed.md
+++ b/changelog.d/update-obr-march-2026.changed.md
@@ -1,0 +1,1 @@
+Update OBR economic forecasts to March 2026 EFO.

--- a/policyengine_uk/parameters/gov/economic_assumptions/yoy_growth.yaml
+++ b/policyengine_uk/parameters/gov/economic_assumptions/yoy_growth.yaml
@@ -266,8 +266,8 @@ obr:
       unit: /1
       label: After housing costs consumer price index growth
       reference:
-        - title: OBR EFO March 2026
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+        - title: OBR EFO November 2025
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
         - title: ONS CPI weights
           href: https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflationupdatingweightsannexatablesw1tow3
         - title: ONS CPI series excluding housing costs
@@ -335,8 +335,8 @@ obr:
       unit: /1
       label: CPIH growth
       reference:
-        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
         - title: OBR long-run RPI-CPI wedge methodology (2031+ values derived from this)
           href: https://obr.uk/box/the-long-run-difference-between-rpi-and-cpi-inflation/
 
@@ -348,7 +348,7 @@ obr:
       2022-01-01: 0.0987
       2023-01-01: 0.1215
       2024-01-01: 0.0492
-      # Forecast (2025-2030) from OBR EFO March 2026, Table 1.12
+      # Forecast (2025-2030) from OBR EFO November 2025, Table 1.12
       2025-01-01: 0.0519
       2026-01-01: 0.0565
       2027-01-01: 0.0474
@@ -359,7 +359,7 @@ obr:
       unit: /1
       label: Non-labour income growth
       reference:
-        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.12)
+        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
           href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   council_tax:
@@ -369,7 +369,7 @@ obr:
         # Outturn (2023-2024)
         2023-01-01: 0.051
         2024-01-01: 0.051
-        # Forecast (2025-2030) from OBR EFO March 2026, Expenditure Table 4.1
+        # Forecast (2025-2030) from OBR EFO November 2025, Expenditure Table 4.1
         2025-01-01: 0.0781
         2026-01-01: 0.0530
         2027-01-01: 0.0579
@@ -379,7 +379,7 @@ obr:
       metadata:
         unit: /1
         reference:
-          - title: OBR EFO March 2026 (detailed forecast tables, expenditure, Table 4.1)
+          - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
             href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
     scotland:
       description: Growth in the level of council tax receipts in Scotland.
@@ -387,7 +387,7 @@ obr:
         # Outturn (2023-2024)
         2023-01-01: 0.052
         2024-01-01: 0.001
-        # Forecast (2025-2030) from OBR EFO March 2026, Expenditure Table 4.1
+        # Forecast (2025-2030) from OBR EFO November 2025, Expenditure Table 4.1
         2025-01-01: 0.0384
         2026-01-01: 0.0384
         2027-01-01: 0.0384
@@ -397,7 +397,7 @@ obr:
       metadata:
         unit: /1
         reference:
-          - title: OBR EFO March 2026 (detailed forecast tables, expenditure, Table 4.1)
+          - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
             href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
     wales:
       description: Growth in the level of council tax receipts in Wales.
@@ -405,7 +405,7 @@ obr:
         # Outturn (2023-2024)
         2023-01-01: 0.058
         2024-01-01: 0.077
-        # Forecast (2025-2030) from OBR EFO March 2026, Expenditure Table 4.1
+        # Forecast (2025-2030) from OBR EFO November 2025, Expenditure Table 4.1
         2025-01-01: 0.0581
         2026-01-01: 0.0581
         2027-01-01: 0.0581
@@ -415,7 +415,7 @@ obr:
       metadata:
         unit: /1
         reference:
-          - title: OBR EFO March 2026 (detailed forecast tables, expenditure, Table 4.1)
+          - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
             href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   per_capita:
@@ -438,7 +438,7 @@ obr:
         unit: /1
         label: Per capita GDP growth
         reference:
-          - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.4)
+          - title: OBR EFO March 2026 (Table A.1, nominal GDP minus population growth)
             href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
     mixed_income:
@@ -449,7 +449,7 @@ obr:
         2022-01-01: 0.0296
         2023-01-01: -0.0060
         2024-01-01: 0.0273
-        # Forecast (2025-2030) from OBR EFO March 2026, Table 1.12 minus population growth
+        # Forecast (2025-2030) from OBR EFO November 2025, Table 1.12 minus population growth
         2025-01-01: 0.0024
         2026-01-01: 0.0362
         2027-01-01: 0.0374
@@ -460,7 +460,7 @@ obr:
         unit: /1
         label: Per capita mixed income growth
         reference:
-          - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.12)
+          - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
             href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
     non_labour_income:
@@ -471,7 +471,7 @@ obr:
         2022-01-01: 0.0894
         2023-01-01: 0.1084
         2024-01-01: 0.0385
-        # Forecast (2025-2030) from OBR EFO March 2026, Table 1.12 minus population growth
+        # Forecast (2025-2030) from OBR EFO November 2025, Table 1.12 minus population growth
         2025-01-01: 0.0447
         2026-01-01: 0.0527
         2027-01-01: 0.0437
@@ -482,7 +482,7 @@ obr:
         unit: /1
         label: Per capita non-labour income growth
         reference:
-          - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.12)
+          - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
             href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   house_prices:
@@ -526,8 +526,8 @@ obr:
       unit: /1
       label: Mortgage interest growth
       reference:
-        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 
   social_rent:
     description: Rent year-on-year growth (CPI+1%, one year lagged).
@@ -568,8 +568,8 @@ obr:
       unit: /1
       label: Rent growth
       reference:
-        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 
 ons:
   population:
@@ -657,7 +657,7 @@ ons:
       reference:
         - title: ONS National Accounts D.41g - Households interest received (HAXV series)
           href: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/haxv/ukea
-        - title: OBR EFO March 2026 - Non-labour income growth used as proxy for 2025+ (Table 1.12)
+        - title: OBR EFO November 2025 - Non-labour income growth used as proxy for 2025+ (Table 1.12)
           href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
   private_rental_prices:
     UNITED_KINGDOM:

--- a/policyengine_uk/parameters/gov/economic_assumptions/yoy_growth.yaml
+++ b/policyengine_uk/parameters/gov/economic_assumptions/yoy_growth.yaml
@@ -360,7 +360,7 @@ obr:
       label: Non-labour income growth
       reference:
         - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 
   council_tax:
     england:
@@ -380,7 +380,7 @@ obr:
         unit: /1
         reference:
           - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
     scotland:
       description: Growth in the level of council tax receipts in Scotland.
       values:
@@ -398,7 +398,7 @@ obr:
         unit: /1
         reference:
           - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
     wales:
       description: Growth in the level of council tax receipts in Wales.
       values:
@@ -416,7 +416,7 @@ obr:
         unit: /1
         reference:
           - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 
   per_capita:
     gdp:
@@ -461,7 +461,7 @@ obr:
         label: Per capita mixed income growth
         reference:
           - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 
     non_labour_income:
       description: Per capita non-labour income year-on-year growth.
@@ -483,7 +483,7 @@ obr:
         label: Per capita non-labour income growth
         reference:
           - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
 
   house_prices:
     description: House prices year-on-year growth.
@@ -658,7 +658,7 @@ ons:
         - title: ONS National Accounts D.41g - Households interest received (HAXV series)
           href: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/haxv/ukea
         - title: OBR EFO November 2025 - Non-labour income growth used as proxy for 2025+ (Table 1.12)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
   private_rental_prices:
     UNITED_KINGDOM:
       description: Private rental prices year-on-year growth in United Kingdom.

--- a/policyengine_uk/parameters/gov/economic_assumptions/yoy_growth.yaml
+++ b/policyengine_uk/parameters/gov/economic_assumptions/yoy_growth.yaml
@@ -2,7 +2,7 @@
 #
 # Data sources:
 # - 2009-2024: OBR outturn data from detailed forecast tables
-# - 2025-2030: OBR forecast from latest Economic and Fiscal Outlook (EFO)
+# - 2025-2030: OBR forecast from latest Economic and Fiscal Outlook (EFO, March 2026)
 # - 2031+: OBR long-run equilibrium assumptions:
 #   - CPI: 2.0% (Bank of England target)
 #   - RPI/CPIH: ~2.4% (CPI + 0.4pp wedge, reflecting housing costs growth)
@@ -33,12 +33,12 @@ obr:
       2023-01-01: 0.0969
       2024-01-01: 0.0359
       # Forecast (2025-2030)
-      2025-01-01: 0.0433
-      2026-01-01: 0.0371
-      2027-01-01: 0.0313
-      2028-01-01: 0.0287
-      2029-01-01: 0.0291
-      2030-01-01: 0.0231
+      2025-01-01: 0.041
+      2026-01-01: 0.031
+      2027-01-01: 0.030
+      2028-01-01: 0.028
+      2029-01-01: 0.029
+      2030-01-01: 0.023
       # Long-run assumptions (2031+)
       2031-01-01: 0.0230
       2032-01-01: 0.0237
@@ -87,8 +87,8 @@ obr:
       unit: /1
       label: Retail price index growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (Table A.1)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
         - title: OBR long-run RPI-CPI wedge methodology (2031+ values derived from this)
           href: https://obr.uk/box/the-long-run-difference-between-rpi-and-cpi-inflation/
   average_earnings:
@@ -110,14 +110,14 @@ obr:
       2021-01-01: 0.059
       2022-01-01: 0.0614
       2023-01-01: 0.0622
-      2024-01-01: 0.0493
+      2024-01-01: 0.051
       # Forecast (2025-2030)
-      2025-01-01: 0.0517
-      2026-01-01: 0.0333
-      2027-01-01: 0.0225
-      2028-01-01: 0.0210
-      2029-01-01: 0.0221
-      2030-01-01: 0.0232
+      2025-01-01: 0.053
+      2026-01-01: 0.034
+      2027-01-01: 0.024
+      2028-01-01: 0.021
+      2029-01-01: 0.022
+      2030-01-01: 0.024
       # Long-run assumptions (2031+)
       2031-01-01: 0.0332
       2032-01-01: 0.0371
@@ -166,9 +166,9 @@ obr:
       unit: /1
       label: Average earnings growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.6)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
-        - title: OBR long-run economic methodology (2031+ values derived from this)
+        - title: OBR EFO March 2026 (Table A.1)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
+        - title: OBR long-run economic methodology (2031+ values derived from this, unchanged from November 2025)
           href: https://obr.uk/forecasts-in-depth/the-economy-forecast/potential-output-and-the-output-gap/
 
   consumer_price_index:
@@ -190,14 +190,14 @@ obr:
       2021-01-01: 0.04
       2022-01-01: 0.0907
       2023-01-01: 0.0730
-      2024-01-01: 0.0253
+      2024-01-01: 0.025
       # Forecast (2025-2030)
-      2025-01-01: 0.0345
-      2026-01-01: 0.0248
-      2027-01-01: 0.0202
-      2028-01-01: 0.0204
-      2029-01-01: 0.0204
-      2030-01-01: 0.0200
+      2025-01-01: 0.034
+      2026-01-01: 0.023
+      2027-01-01: 0.020
+      2028-01-01: 0.020
+      2029-01-01: 0.020
+      2030-01-01: 0.020
       # Long-run assumptions (2031+): Bank of England 2% target
       2031-01-01: 0.0200
       2032-01-01: 0.0200
@@ -246,8 +246,8 @@ obr:
       unit: /1
       label: Consumer price index growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (Table A.1)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
         - title: Bank of England inflation target (2031+ assumes 2% target)
           href: https://www.bankofengland.co.uk/monetary-policy/inflation
 
@@ -266,8 +266,8 @@ obr:
       unit: /1
       label: After housing costs consumer price index growth
       reference:
-        - title: OBR EFO November 2025
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
         - title: ONS CPI weights
           href: https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflationupdatingweightsannexatablesw1tow3
         - title: ONS CPI series excluding housing costs
@@ -335,8 +335,8 @@ obr:
       unit: /1
       label: CPIH growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.7)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
         - title: OBR long-run RPI-CPI wedge methodology (2031+ values derived from this)
           href: https://obr.uk/box/the-long-run-difference-between-rpi-and-cpi-inflation/
 
@@ -348,7 +348,7 @@ obr:
       2022-01-01: 0.0987
       2023-01-01: 0.1215
       2024-01-01: 0.0492
-      # Forecast (2025-2030) from OBR EFO November 2025, Table 1.12
+      # Forecast (2025-2030) from OBR EFO March 2026, Table 1.12
       2025-01-01: 0.0519
       2026-01-01: 0.0565
       2027-01-01: 0.0474
@@ -359,8 +359,8 @@ obr:
       unit: /1
       label: Non-labour income growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.12)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   council_tax:
     england:
@@ -369,7 +369,7 @@ obr:
         # Outturn (2023-2024)
         2023-01-01: 0.051
         2024-01-01: 0.051
-        # Forecast (2025-2030) from OBR EFO November 2025, Expenditure Table 4.1
+        # Forecast (2025-2030) from OBR EFO March 2026, Expenditure Table 4.1
         2025-01-01: 0.0781
         2026-01-01: 0.0530
         2027-01-01: 0.0579
@@ -379,15 +379,15 @@ obr:
       metadata:
         unit: /1
         reference:
-          - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+          - title: OBR EFO March 2026 (detailed forecast tables, expenditure, Table 4.1)
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
     scotland:
       description: Growth in the level of council tax receipts in Scotland.
       values:
         # Outturn (2023-2024)
         2023-01-01: 0.052
         2024-01-01: 0.001
-        # Forecast (2025-2030) from OBR EFO November 2025, Expenditure Table 4.1
+        # Forecast (2025-2030) from OBR EFO March 2026, Expenditure Table 4.1
         2025-01-01: 0.0384
         2026-01-01: 0.0384
         2027-01-01: 0.0384
@@ -397,15 +397,15 @@ obr:
       metadata:
         unit: /1
         reference:
-          - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+          - title: OBR EFO March 2026 (detailed forecast tables, expenditure, Table 4.1)
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
     wales:
       description: Growth in the level of council tax receipts in Wales.
       values:
         # Outturn (2023-2024)
         2023-01-01: 0.058
         2024-01-01: 0.077
-        # Forecast (2025-2030) from OBR EFO November 2025, Expenditure Table 4.1
+        # Forecast (2025-2030) from OBR EFO March 2026, Expenditure Table 4.1
         2025-01-01: 0.0581
         2026-01-01: 0.0581
         2027-01-01: 0.0581
@@ -415,8 +415,8 @@ obr:
       metadata:
         unit: /1
         reference:
-          - title: OBR EFO November 2025 (detailed forecast tables, expenditure, Table 4.1)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+          - title: OBR EFO March 2026 (detailed forecast tables, expenditure, Table 4.1)
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   per_capita:
     gdp:
@@ -427,19 +427,19 @@ obr:
         2022-01-01: 0.1019
         2023-01-01: 0.0532
         2024-01-01: 0.0372
-        # Forecast (2025-2030) from OBR EFO November 2025, Table 1.4 minus population growth
-        2025-01-01: 0.0418
-        2026-01-01: 0.0327
-        2027-01-01: 0.0326
-        2028-01-01: 0.0302
-        2029-01-01: 0.0294
-        2030-01-01: 0.0306
+        # Forecast (2025-2030) from OBR EFO March 2026, Table A.1 nominal GDP minus population growth
+        2025-01-01: 0.0438
+        2026-01-01: 0.0292
+        2027-01-01: 0.0323
+        2028-01-01: 0.0310
+        2029-01-01: 0.0296
+        2030-01-01: 0.0315
       metadata:
         unit: /1
         label: Per capita GDP growth
         reference:
-          - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.4)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+          - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.4)
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
     mixed_income:
       description: Per capita mixed income year-on-year growth.
@@ -449,7 +449,7 @@ obr:
         2022-01-01: 0.0296
         2023-01-01: -0.0060
         2024-01-01: 0.0273
-        # Forecast (2025-2030) from OBR EFO November 2025, Table 1.12 minus population growth
+        # Forecast (2025-2030) from OBR EFO March 2026, Table 1.12 minus population growth
         2025-01-01: 0.0024
         2026-01-01: 0.0362
         2027-01-01: 0.0374
@@ -460,8 +460,8 @@ obr:
         unit: /1
         label: Per capita mixed income growth
         reference:
-          - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+          - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.12)
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
     non_labour_income:
       description: Per capita non-labour income year-on-year growth.
@@ -471,7 +471,7 @@ obr:
         2022-01-01: 0.0894
         2023-01-01: 0.1084
         2024-01-01: 0.0385
-        # Forecast (2025-2030) from OBR EFO November 2025, Table 1.12 minus population growth
+        # Forecast (2025-2030) from OBR EFO March 2026, Table 1.12 minus population growth
         2025-01-01: 0.0447
         2026-01-01: 0.0527
         2027-01-01: 0.0437
@@ -482,8 +482,8 @@ obr:
         unit: /1
         label: Per capita non-labour income growth
         reference:
-          - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.12)
-            href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+          - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.12)
+            href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   house_prices:
     description: House prices year-on-year growth.
@@ -492,20 +492,20 @@ obr:
       2021-01-01: 0.082
       2022-01-01: 0.0926
       2023-01-01: 0.0036
-      2024-01-01: 0.0083
+      2024-01-01: 0.007
       # Forecast (2025-2030)
-      2025-01-01: 0.0294
-      2026-01-01: 0.0222
-      2027-01-01: 0.0279
-      2028-01-01: 0.0272
-      2029-01-01: 0.0257
-      2030-01-01: 0.0242
+      2025-01-01: 0.028
+      2026-01-01: 0.024
+      2027-01-01: 0.029
+      2028-01-01: 0.027
+      2029-01-01: 0.026
+      2030-01-01: 0.024
     metadata:
       unit: /1
       label: House prices growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.16)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (Table A.1)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   mortgage_interest:
     description: Mortgage interest year-on-year growth.
@@ -526,8 +526,8 @@ obr:
       unit: /1
       label: Mortgage interest growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.7)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
   social_rent:
     description: Rent year-on-year growth (CPI+1%, one year lagged).
@@ -538,8 +538,8 @@ obr:
       2024-01-01: 0.083
       # Forecast (2025-2030): Derived from CPI+1%, one year lagged
       2025-01-01: 0.035
-      2026-01-01: 0.045
-      2027-01-01: 0.035
+      2026-01-01: 0.044
+      2027-01-01: 0.033
       2028-01-01: 0.030
       2029-01-01: 0.030
       2030-01-01: 0.030
@@ -547,8 +547,8 @@ obr:
       unit: /1
       label: Social rent growth
       reference:
-        - title: OBR EFO November 2025 (derived from CPI+1%, one year lagged)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (derived from CPI+1%, one year lagged)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
   rent:
     description: Rent year-on-year growth, private and social (ONS series D7GQ).
     values:
@@ -568,8 +568,8 @@ obr:
       unit: /1
       label: Rent growth
       reference:
-        - title: OBR EFO November 2025 (detailed forecast tables, economy, Table 1.7)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 (detailed forecast tables, economy, Table 1.7)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
 
 ons:
   population:
@@ -657,8 +657,8 @@ ons:
       reference:
         - title: ONS National Accounts D.41g - Households interest received (HAXV series)
           href: https://www.ons.gov.uk/economy/grossdomesticproductgdp/timeseries/haxv/ukea
-        - title: OBR EFO November 2025 - Non-labour income growth used as proxy for 2025+ (Table 1.12)
-          href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/
+        - title: OBR EFO March 2026 - Non-labour income growth used as proxy for 2025+ (Table 1.12)
+          href: https://obr.uk/efo/economic-and-fiscal-outlook-march-2026/
   private_rental_prices:
     UNITED_KINGDOM:
       description: Private rental prices year-on-year growth in United Kingdom.

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/extended_childcare_entitlement/extended_childcare_entitlement.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/extended_childcare_entitlement/extended_childcare_entitlement.yaml
@@ -203,7 +203,7 @@
         members: [child1]
         extended_childcare_entitlement_eligible: true
   output:
-    extended_childcare_entitlement: 10011.897
+    extended_childcare_entitlement: 10004.133
 
 - name: Eligible for 30 hours - Family with multiple 2-year-olds after expansion
   period: 2026
@@ -219,4 +219,4 @@
         members: [child1, child2]
         extended_childcare_entitlement_eligible: true
   output:
-    extended_childcare_entitlement: 17121.797
+    extended_childcare_entitlement: 17108.518

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_interest_rate.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_interest_rate.yaml
@@ -148,6 +148,6 @@
         employment_income: 30_000
         student_loan_plan: POSTGRADUATE
   output:
-    # Postgraduate threshold ~£21,909 (uprated from £21,000)
-    # 6% of (30,000 - 21,909) = 6% of 8,091 = ~485
-    student_loan_repayment: 485
+    # Postgraduate threshold ~£21,861 (uprated from £21,000 by RPI)
+    # 6% of (30,000 - 21,861) = 6% of 8,139 = ~488.34
+    student_loan_repayment: 488.339

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_repayment.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_repayment.yaml
@@ -116,8 +116,8 @@
         student_loan_plan: PLAN_2
   output:
     # Threshold resumes RPI uprating from 2030
-    # 9% of (40,000 - ~30,064) = 9% of ~9,936 = ~894.26
-    student_loan_repayment: 894.26
+    # 9% of (40,000 - ~30,061) = 9% of ~9,939 = ~894.52
+    student_loan_repayment: 894.522
 
 - name: Plan 2 - Income just below 2027 threshold
   period: 2027

--- a/policyengine_uk/tests/policy/baseline/gov/social_security_scotland/two_child_limit_payment.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/social_security_scotland/two_child_limit_payment.yaml
@@ -347,4 +347,4 @@
         region: SCOTLAND
   output:
     # Payment continues as two-child limit still in effect
-    two_child_limit_payment: 3635
+    two_child_limit_payment: 3633.188


### PR DESCRIPTION
## Summary
- Update CPI, RPI, average earnings, house prices, per capita GDP, and social rent forecasts from the [March 2026 Economic and Fiscal Outlook](https://assets.publishing.service.gov.uk/media/69a6d7b62e1f4fbda4252208/economic-and-fiscal-outlook-march-2026-web-accessible.pdf) (Table A.1)
- Update all metadata references from November 2025 to March 2026
- Social rent derived from CPI+1% lagged formula
- Per capita GDP derived from nominal GDP minus population growth

### Variables updated from Table A.1
| Variable | Source |
|---|---|
| CPI | Table A.1 |
| RPI | Table A.1 |
| Average earnings | Table A.1 |
| House prices | Table A.1 |
| Per capita GDP | Derived (nominal GDP - population) |
| Social rent | Derived (CPI+1%, lagged) |

### Variables pending detailed tables
The following retain November 2025 forecast values. The OBR detailed forecast table spreadsheets (with Tables 1.7, 1.12, 1.16, 4.1) have not yet been published — OBR said they'll be available by end of day March 3. A follow-up PR should update:
- CPIH, mortgage interest, rent (Table 1.7)
- Non-labour income, mixed income (Table 1.12)
- Council tax by country (Expenditure Table 4.1)
- Consumer price index AHC
- Household interest income (uses non-labour income as proxy)

## Test plan
- [ ] CI passes
- [ ] Verify forecast values match Table A.1 of the March 2026 EFO PDF
- [ ] Follow up with detailed table updates when OBR publishes spreadsheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)