### PR TITLE
Fix verified_years in programs.yaml based on audit

### DIFF
--- a/changelog.d/fix-verified-years.fixed.md
+++ b/changelog.d/fix-verified-years.fixed.md
@@ -1,0 +1,1 @@
+Fix verified_years in programs.yaml based on parameter and test audit.

--- a/policyengine_uk/programs.yaml
+++ b/policyengine_uk/programs.yaml
@@ -14,7 +14,7 @@ programs:
     coverage: UK
     variable: income_tax
     parameter_prefix: gov.hmrc.income_tax
-    verified_years: "2019-2028"
+    verified_start_year: 2019
     notes: Includes Scottish rates via devolved tax bands
 
   - id: national_insurance
@@ -26,7 +26,7 @@ programs:
     coverage: UK
     variable: national_insurance
     parameter_prefix: gov.hmrc.national_insurance
-    verified_years: "2019-2028"
+    verified_start_year: 2019
     notes: Classes 1, 2, 3, and 4
 
   - id: capital_gains_tax
@@ -38,7 +38,7 @@ programs:
     coverage: UK
     variable: capital_gains_tax
     parameter_prefix: gov.hmrc.cgt
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: child_benefit
     name: Child Benefit
@@ -49,7 +49,7 @@ programs:
     coverage: UK
     variable: child_benefit
     parameter_prefix: gov.hmrc.child_benefit
-    verified_years: "2019-2028"
+    verified_start_year: 2019
     notes: Includes High Income Child Benefit Charge
 
   - id: stamp_duty_land_tax
@@ -61,7 +61,7 @@ programs:
     coverage: England and Northern Ireland
     variable: stamp_duty_land_tax
     parameter_prefix: gov.hmrc.stamp_duty
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: vat
     name: VAT
@@ -72,7 +72,7 @@ programs:
     coverage: UK
     variable: vat
     parameter_prefix: gov.hmrc.vat
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: fuel_duty
     name: Fuel duty
@@ -83,7 +83,7 @@ programs:
     coverage: UK
     variable: fuel_duty
     parameter_prefix: gov.hmrc.fuel_duty
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: student_loans
     name: Student loan repayments
@@ -94,7 +94,7 @@ programs:
     coverage: UK
     variable: student_loan_repayment
     parameter_prefix: gov.hmrc.student_loans
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: tax_free_childcare
     name: Tax-Free Childcare
@@ -105,6 +105,7 @@ programs:
     coverage: UK
     variable: tax_free_childcare
     parameter_prefix: gov.hmrc.tax_free_childcare
+    verified_start_year: 2022
 
   - id: pensions_allowance
     name: Pensions allowance
@@ -114,18 +115,20 @@ programs:
     status: complete
     coverage: UK
     parameter_prefix: gov.hmrc.pensions
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: business_rates
     name: Business rates
     full_name: Business Rates
     category: Taxes
     agency: HMRC
-    status: complete
+    status: partial
     coverage: UK
     variable: business_rates
     parameter_prefix: gov.hmrc.business_rates
-    verified_years: "2022-2028"
+    verified_start_year: 2019
+    verified_end_year: 2021
+    notes: Parameters need updating beyond 2021
 
   - id: minimum_wage
     name: National Minimum Wage
@@ -135,7 +138,7 @@ programs:
     status: complete
     coverage: UK
     parameter_prefix: gov.hmrc
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   # --- DWP programs ---
   - id: universal_credit
@@ -147,7 +150,7 @@ programs:
     coverage: UK
     variable: universal_credit
     parameter_prefix: gov.dwp.universal_credit
-    verified_years: "2019-2028"
+    verified_start_year: 2019
     notes: Includes standard allowance, child element, housing costs, work allowances, and taper
 
   - id: pension_credit
@@ -159,7 +162,7 @@ programs:
     coverage: UK
     variable: pension_credit
     parameter_prefix: gov.dwp.pension_credit
-    verified_years: "2022-2028"
+    verified_start_year: 2022
     notes: Guarantee Credit and Savings Credit
 
   - id: state_pension
@@ -171,7 +174,7 @@ programs:
     coverage: UK
     variable: state_pension
     parameter_prefix: gov.dwp.state_pension
-    verified_years: "2022-2028"
+    verified_start_year: 2022
     notes: New State Pension and basic State Pension
 
   - id: housing_benefit
@@ -183,7 +186,7 @@ programs:
     coverage: UK
     variable: housing_benefit
     parameter_prefix: gov.dwp.housing_benefit
-    verified_years: "2022-2028"
+    verified_start_year: 2022
     notes: Legacy benefit being replaced by Universal Credit
 
   - id: income_support
@@ -195,7 +198,7 @@ programs:
     coverage: UK
     variable: income_support
     parameter_prefix: gov.dwp.income_support
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: jsa
     name: JSA
@@ -206,7 +209,7 @@ programs:
     coverage: UK
     variable: JSA
     parameter_prefix: gov.dwp.JSA
-    verified_years: "2022-2028"
+    verified_start_year: 2022
     notes: Income-based and contribution-based
 
   - id: esa
@@ -218,7 +221,7 @@ programs:
     coverage: UK
     variable: ESA
     parameter_prefix: gov.dwp.ESA
-    verified_years: "2022-2028"
+    verified_start_year: 2022
     notes: Income-related and contribution-based
 
   - id: attendance_allowance
@@ -230,7 +233,7 @@ programs:
     coverage: UK
     variable: attendance_allowance
     parameter_prefix: gov.dwp.attendance_allowance
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: carers_allowance
     name: Carer's Allowance
@@ -241,7 +244,7 @@ programs:
     coverage: UK
     variable: carers_allowance
     parameter_prefix: gov.dwp.carers_allowance
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: dla
     name: DLA
@@ -252,7 +255,7 @@ programs:
     coverage: UK
     variable: DLA
     parameter_prefix: gov.dwp.dla
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: pip
     name: PIP
@@ -263,7 +266,7 @@ programs:
     coverage: UK
     variable: pip
     parameter_prefix: gov.dwp.pip
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: benefit_cap
     name: Benefit cap
@@ -274,7 +277,7 @@ programs:
     coverage: UK
     variable: benefit_cap
     parameter_prefix: gov.dwp
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: tax_credits
     name: Tax credits
@@ -285,7 +288,7 @@ programs:
     coverage: UK
     variable: tax_credits
     parameter_prefix: gov.dwp.tax_credits
-    verified_years: "2022-2028"
+    verified_start_year: 2022
     notes: Legacy benefit being replaced by Universal Credit
 
   - id: sda
@@ -297,6 +300,7 @@ programs:
     coverage: UK
     variable: sda
     parameter_prefix: gov.dwp.sda
+    verified_start_year: 2022
 
   - id: winter_fuel_payment
     name: Winter Fuel Payment
@@ -307,7 +311,7 @@ programs:
     coverage: UK
     variable: winter_fuel_payment
     parameter_prefix: gov.dwp.winter_fuel_payment
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: ssmg
     name: Sure Start Maternity Grant
@@ -318,6 +322,7 @@ programs:
     coverage: UK
     variable: ssmg
     parameter_prefix: gov.dwp.ssmg
+    verified_start_year: 2022
 
   - id: maternity_allowance
     name: Maternity Allowance
@@ -328,6 +333,7 @@ programs:
     coverage: UK
     variable: maternity_allowance
     parameter_prefix: gov.dwp
+    verified_start_year: 2022
 
   # --- DfE programs ---
   - id: childcare_entitlements
@@ -338,7 +344,9 @@ programs:
     status: complete
     coverage: England
     parameter_prefix: gov.dfe
-    notes: Universal (15h), extended (30h), and targeted entitlements
+    verified_start_year: 2023
+    verified_end_year: 2025
+    notes: Universal (15h), extended (30h), and targeted entitlements; parameters need expansion for later years
 
   # --- DCMS programs ---
   - id: tv_licence
@@ -350,7 +358,7 @@ programs:
     coverage: UK
     variable: tv_licence
     parameter_prefix: gov.dcms.bbc
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   # --- Local programs ---
   - id: council_tax
@@ -361,7 +369,7 @@ programs:
     status: complete
     coverage: UK
     variable: council_tax
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   # --- Treasury programs ---
   - id: cost_of_living_support
@@ -372,6 +380,9 @@ programs:
     status: complete
     coverage: UK
     parameter_prefix: gov.treasury.cost_of_living_support
+    verified_start_year: 2022
+    verified_end_year: 2023
+    notes: Temporary program, ended 2023
 
   # --- Ofgem programs ---
   - id: energy_price_guarantee
@@ -382,6 +393,9 @@ programs:
     status: complete
     coverage: UK
     parameter_prefix: gov.ofgem
+    verified_start_year: 2022
+    verified_end_year: 2023
+    notes: Temporary program, ended October 2023
 
   # --- Scotland programs ---
   - id: scottish_income_tax
@@ -391,7 +405,7 @@ programs:
     agency: Revenue Scotland
     status: complete
     coverage: Scotland
-    verified_years: "2019-2028"
+    verified_start_year: 2019
     notes: Devolved tax bands applied via income tax system
 
   - id: lbtt
@@ -403,7 +417,7 @@ programs:
     coverage: Scotland
     variable: land_and_buildings_transaction_tax
     parameter_prefix: gov.revenue_scotland.lbtt
-    verified_years: "2022-2028"
+    verified_start_year: 2022
 
   - id: scottish_child_payment
     name: Scottish Child Payment
@@ -414,4 +428,4 @@ programs:
     coverage: Scotland
     variable: scottish_child_payment
     parameter_prefix: gov.social_security_scotland.scottish_child_payment
-    verified_years: "2022-2028"
+    verified_start_year: 2022


### PR DESCRIPTION
## Summary
- Replace `verified_years` string with structured `verified_start_year`/`verified_end_year` integers
- No end year for programs with uprating (valid indefinitely forward)
- End year only for ended programs (cost_of_living_support, energy_price_guarantee) or limited params (business_rates, childcare_entitlements)
- Add missing verified_start_year to 7 programs (tax_free_childcare, sda, ssmg, maternity_allowance, childcare_entitlements, cost_of_living_support, energy_price_guarantee)
- `business_rates`: narrow to 2019-2021 and mark partial (params end 2021)

## Test plan
- [x] YAML syntax valid
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)