### PR TITLE
Complete towncrier migration for versioning workflow

### DIFF
--- a/.github/publish-git-tag.sh
+++ b/.github/publish-git-tag.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
 
-git tag `python setup.py --version`
-git push --tags || true  # update the repository version
+VERSION=$(python -c "import re; print(re.search(r'version = \"(.+?)\"', open('pyproject.toml').read()).group(1))")
+git tag "$VERSION"
+git push --tags || true

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -7,29 +7,33 @@ on:
       - main
 
     paths:
-      - changelog_entry.yaml
-      - .github/**
+      - changelog.d/**
+      - pyproject.toml
   workflow_dispatch:
 
 jobs:
   Versioning:
-    if: (github.event.head_commit.message != 'Update package version')
     runs-on: ubuntu-latest
+    if: |
+      (!(github.event.head_commit.message == 'Update package version'))
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.POLICYENGINE_GITHUB }}
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Build changelog
-        run: pip install yaml-changelog && make changelog
-      - name: Preview changelog update
-        run: ".github/get-changelog-diff.sh"
+      - name: Install towncrier
+        run: uv pip install towncrier --system
+      - name: Bump version and build changelog
+        run: |
+          python .github/bump_version.py
+          towncrier build --yes --version $(python -c "import re; print(re.search(r'version = \"(.+?)\"', open('pyproject.toml').read()).group(1))")
       - name: Update changelog
         uses: EndBug/add-and-commit@v9
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,10 @@ dev = [
     "sphinx-argparse>=0.3.2,<1",
     "sphinx-math-dollar>=1.2.1,<2",
     "wheel",
-    "yaml-changelog>=0.1.7",
+    "towncrier>=24.8.0",
     "snowballstemmer>=2,<3",
     "jupyter-book>=2.0.0a0",
     "rich",
-    "towncrier>=24.8.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

The Makefile, pyproject.toml, and bump_version.py were already migrated to towncrier (fragments in `changelog.d/`), but the versioning workflow still triggered on `changelog_entry.yaml` and used `yaml-changelog`. This meant PRs with `changelog.d/` fragments (like #1521) never triggered version bumps or PyPI publishes.

Changes:
- Trigger on `changelog.d/**` and `pyproject.toml` instead of `changelog_entry.yaml`
- Use `towncrier build` instead of `yaml-changelog` in the Versioning job
- Read version from `pyproject.toml` instead of `setup.py` in `publish-git-tag.sh`
- Remove duplicate towncrier dep, drop yaml-changelog

Once merged, this should trigger a version bump and release covering all the pending `changelog.d/` fragments (including the electricity/gas variables from #1521).

## Test plan

- [ ] Versioning job triggers when this PR merges (contains `changelog.d/` changes via the workflow path trigger)
- [ ] `bump_version.py` correctly infers minor bump from existing fragments
- [ ] `towncrier build` consumes fragments and updates CHANGELOG.md
- [ ] Publish job fires on the resulting "Update package version" commit