### PR TITLE
Skip redundant dataset copy in apply_uprating

### DIFF
--- a/changelog.d/fix-apply-uprating-redundant-copy.changed.md
+++ b/changelog.d/fix-apply-uprating-redundant-copy.changed.md
@@ -1,0 +1,1 @@
+Added `copy` parameter to `apply_uprating` (default `True`); `extend_single_year_dataset` now passes `copy=False` to skip the redundant deep copy of the multi-year dataset since each year is already copied individually.

--- a/policyengine_uk/data/economic_assumptions.py
+++ b/policyengine_uk/data/economic_assumptions.py
@@ -48,20 +48,22 @@ def extend_single_year_dataset(
     return apply_uprating(
         multi_year_dataset,
         tax_benefit_system_parameters=tax_benefit_system_parameters,
+        copy=False,
     )
 
 
 def apply_uprating(
     dataset: UKMultiYearDataset,
     tax_benefit_system_parameters: ParameterNode = None,
+    copy: bool = True,
 ):
     from policyengine_uk.system import system
 
-    # Apply uprating to the dataset.
-    dataset = dataset.copy()
-
     if not isinstance(dataset, UKMultiYearDataset):
         raise TypeError("dataset must be of type UKMultiYearDataset.")
+
+    if copy:
+        dataset = dataset.copy()
 
     for year in dataset.datasets.keys():
         if year == min(dataset.datasets.keys()):


### PR DESCRIPTION
## Summary

- Adds a `copy` parameter (default `True`) to `apply_uprating` so callers can opt out of the defensive deep copy of the full multi-year dataset
- `extend_single_year_dataset` now passes `copy=False` since it already copies each year individually via `dataset.copy()` — the second copy was redundant
- External callers of `apply_uprating` retain the existing safe-by-default behaviour

This is the proper upstream fix for the monkey-patch used in [policyengine.py#251](https://github.com/PolicyEngine/policyengine.py/pull/251) to avoid the redundant copy in the UK simulation run.

## Test plan

- [ ] Existing tests pass
- [ ] Benchmark in policyengine.py#251 confirms no change in output values after removing the monkey-patch