### PR TITLE
Clarify fast setup instructions only on Linux/macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ PolicyEngine UK enhances this dataset by fusing it to other surveys and reweight
 [^1]: Department for Work and Pensions, Office for National Statistics, NatCen Social Research. (2021). Family Resources Survey, 2019-2020. [data collection]. UK Data Service. SN: 8802, http://doi.org/10.5255/UKDA-SN-8802-1
 
 
-## Fast setup instructions
+## Fast setup instructions (Linux / macOS)
 
 1. Run `pip install policyengine-uk`
 
 2. Run `policyengine-uk` and go through the prompt to setup microdata.
-
 
 ## Contact
 


### PR DESCRIPTION
The README previously instructed users to run `policyengine-uk` for setup.
This command doesn't seem to work on Windows. I assume it does work on Linux/macOS.
This PR updates the README to clarify platform differences and avoid confusion.