### PR TITLE
Add deploy hook to rebuild model site on release

### DIFF
--- a/.github/workflows/rebuild-model-site.yml
+++ b/.github/workflows/rebuild-model-site.yml
@@ -1,0 +1,20 @@
+# Trigger a rebuild of the policyengine-model site when a new release is published.
+# The model site pre-fetches metadata at build time for instant page loads.
+# Requires MODEL_SITE_DEPLOY_HOOK secret (Vercel Deploy Hook URL).
+name: Rebuild model site
+on:
+  release:
+    types: [published]
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel deploy
+        env:
+          DEPLOY_HOOK: ${{ secrets.MODEL_SITE_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$DEPLOY_HOOK" ]; then
+            echo "MODEL_SITE_DEPLOY_HOOK secret not set, skipping"
+            exit 0
+          fi
+          curl -X POST "$DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers a Vercel rebuild of the [policyengine-model](https://github.com/PolicyEngine/policyengine-model) site whenever a new release is published
- The model site pre-fetches metadata from the PE API at build time so pages load in ~1-2s instead of ~67s
- Requires a `MODEL_SITE_DEPLOY_HOOK` repository secret with the Vercel Deploy Hook URL (created in the policyengine-model Vercel project settings)

## Setup needed
1. In [Vercel project settings for policyengine-model](https://vercel.com/policyengine/policyengine-model/settings/git), create a Deploy Hook for the `master` branch
2. Add the hook URL as a repository secret named `MODEL_SITE_DEPLOY_HOOK` in this repo's Settings → Secrets

## Test plan
- [ ] Verify workflow file is valid YAML
- [ ] After adding the secret, publish a test release and confirm the model site rebuilds

Generated with [Claude Code](https://claude.com/claude-code)