### PR TITLE
Replace personal PAT with GITHUB_TOKEN in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -1,4 +1,6 @@
 # Workflow that runs on versioning metadata updates.
+# Uses GITHUB_TOKEN (not a personal PAT) for same-repo operations.
+# Cross-repo API updates require POLICYENGINE_GITHUB secret (org-level PAT).
 
 name: Versioning updates
 on:
@@ -11,16 +13,20 @@ on:
       - pyproject.toml
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   Versioning:
     runs-on: ubuntu-latest
     if: |
       (!(github.event.head_commit.message == 'Update package version'))
+    outputs:
+      committed: ${{ steps.commit.outputs.committed }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
           fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -35,18 +41,20 @@ jobs:
           python .github/bump_version.py
           towncrier build --yes --version $(python -c "import re; print(re.search(r'version = \"(.+?)\"', open('pyproject.toml').read()).group(1))")
       - name: Update changelog
+        id: commit
         uses: EndBug/add-and-commit@v9
         with:
           add: "."
           message: Update package version
   Publish:
     runs-on: ubuntu-latest
-    if: (github.event.head_commit.message == 'Update package version')
-    env:
-      GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+    needs: Versioning
+    if: needs.Versioning.outputs.committed == 'true'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          ref: main
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
@@ -71,6 +79,7 @@ jobs:
           password: ${{ secrets.PYPI }}
           skip_existing: true
       - name: Update API
+        if: ${{ secrets.POLICYENGINE_GITHUB != '' }}
         run: python .github/update_api.py
         env:
           GITHUB_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}

--- a/changelog.d/fix-versioning-workflow.changed.md
+++ b/changelog.d/fix-versioning-workflow.changed.md
@@ -1,0 +1,1 @@
+Replaced personal PAT with `GITHUB_TOKEN` in versioning workflow. Publish now runs as a sequential job instead of requiring a re-triggered workflow, removing the dependency on a personal access token for same-repo operations.


### PR DESCRIPTION
## Summary
- Replaced `secrets.POLICYENGINE_GITHUB` (expired personal PAT) with `GITHUB_TOKEN` for same-repo checkout and push in the Versioning job
- Restructured Publish as a sequential job (`needs: Versioning`) instead of relying on a re-triggered push event, since `GITHUB_TOKEN` pushes don't trigger new workflow runs
- Made the cross-repo `update_api.py` step conditional on `POLICYENGINE_GITHUB` secret availability so core versioning + PyPI publish works without any PAT

## Context
The versioning workflow was failing because `secrets.POLICYENGINE_GITHUB` (a personal PAT) expired. The old design required the PAT to push a commit that re-triggered the workflow for the Publish job. This redesign eliminates that dependency for same-repo operations.

**Note:** Cross-repo API updates (`update_api.py` which bumps policyengine-api and policyengine-household-api) still need a token with cross-repo access. Consider creating an org-scoped fine-grained PAT or GitHub App for this.

## Test plan
- [x] Changelog entry included to trigger versioning on merge
- [ ] Verify Versioning job succeeds with `GITHUB_TOKEN` after merge
- [ ] Verify Publish job runs sequentially and publishes to PyPI

Closes the versioning failure from https://github.com/PolicyEngine/policyengine-uk/actions/runs/23208707049

🤖 Generated with [Claude Code](https://claude.com/claude-code)