### PR TITLE
Fix invalid secrets reference in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -79,7 +79,11 @@ jobs:
           password: ${{ secrets.PYPI }}
           skip_existing: true
       - name: Update API
-        if: ${{ secrets.POLICYENGINE_GITHUB != '' }}
-        run: python .github/update_api.py
+        run: |
+          if [ -n "$CROSS_REPO_TOKEN" ]; then
+            GITHUB_TOKEN="$CROSS_REPO_TOKEN" python .github/update_api.py
+          else
+            echo "Skipping cross-repo API update (POLICYENGINE_GITHUB secret not set)"
+          fi
         env:
-          GITHUB_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          CROSS_REPO_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}

--- a/changelog.d/fix-versioning-secrets-syntax.fixed.md
+++ b/changelog.d/fix-versioning-secrets-syntax.fixed.md
@@ -1,0 +1,1 @@
+Fixed invalid `secrets` reference in versioning workflow step condition that prevented the workflow from running.


### PR DESCRIPTION
## Summary
- Fixed `if: ${{ secrets.POLICYENGINE_GITHUB != '' }}` which is invalid — GitHub Actions doesn't allow `secrets` in step-level `if` expressions
- Replaced with a shell conditional that checks via an env var instead

## Context
PR #1530 introduced this bug. The versioning workflow fails instantly with:
> `Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.POLICYENGINE_GITHUB != ''`

## Test plan
- [x] Changelog entry included to trigger versioning on merge
- [ ] Verify versioning workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)