### PR TITLE
Use UK-average land intensity for Northern Ireland

### DIFF
--- a/policyengine_uk/parameters/household/wealth/land/intensity.yaml
+++ b/policyengine_uk/parameters/household/wealth/land/intensity.yaml
@@ -57,7 +57,7 @@ property_wealth_by_region:
       2023-01-01: 0.42
   NORTHERN_IRELAND:
     values:
-      2023-01-01: 0.44
+      2023-01-01: 0.673
   UNKNOWN:
     values:
       2023-01-01: 0.673

--- a/policyengine_uk/tests/policy/baseline/household/wealth/household_land_value.yaml
+++ b/policyengine_uk/tests/policy/baseline/household/wealth/household_land_value.yaml
@@ -86,4 +86,4 @@
     residential_property_value: 200000
     owned_land: 0
   output:
-    household_land_value: 88000
+    household_land_value: 134600


### PR DESCRIPTION
## Summary
- Northern Ireland's land intensity was interpolated at 0.44 from the nearest English region (MHCLG covers England only)
- This produced implausibly low household land values (~£91k vs £196k average house price, a 46% land/price ratio)
- Replace with UK-wide average (0.673) until NI-specific data becomes available, bringing the ratio to ~56%

## Test plan
- [ ] Verify NI average land value per household increases to a more plausible level
- [ ] Check that UK-wide aggregates are not materially distorted (NI is <3% of UK households)

🤖 Generated with [Claude Code](https://claude.com/claude-code)