### PR TITLE
Clarify reform impact regression fixtures

### DIFF
--- a/policyengine_uk/tests/microsimulation/reforms_config.yaml
+++ b/policyengine_uk/tests/microsimulation/reforms_config.yaml
@@ -1,3 +1,7 @@
+# Regression fixtures for microsimulation reform impacts.
+# These expected impacts are derived from current model output and are used to
+# catch unintended behavior changes. They are not external fiscal estimates
+# unless a reform entry is explicitly annotated otherwise.
 reforms:
 - name: Raise basic rate by 1pp
   expected_impact: 7.8

--- a/policyengine_uk/tests/microsimulation/test_reform_impacts.py
+++ b/policyengine_uk/tests/microsimulation/test_reform_impacts.py
@@ -1,6 +1,8 @@
 """
 Test suite for PolicyEngine UK reform fiscal impacts.
 This file tests that model changes don't unexpectedly change reform impacts.
+Expected impacts come from the repo's current-model regression fixtures in
+reforms_config.yaml, not from external policy costings unless noted there.
 """
 
 import pytest
@@ -61,7 +63,7 @@ reform_names = [reform["name"] for reform in reforms_data]
 def test_reform_fiscal_impacts(
     baseline, reform, reform_name, expected_impact, tolerance
 ):
-    """Test that each reform produces the expected fiscal impact."""
+    """Test that each reform still matches its current-model regression target."""
     impact = get_fiscal_impact(baseline, reform)
 
     assert abs(impact - expected_impact) < tolerance, (


### PR DESCRIPTION
## Summary
- document that microsimulation reform expected impacts are regression fixtures derived from current model output
- clarify in the test module that these are not external policy costings unless explicitly noted

## Testing
- uv run pytest policyengine_uk/tests/microsimulation/test_reform_impacts.py -q