### PR TITLE
Add deploy hook to rebuild model site on release

### DIFF
--- a/.github/workflows/rebuild-model-site.yml
+++ b/.github/workflows/rebuild-model-site.yml
@@ -1,0 +1,20 @@
+# Trigger a rebuild of the policyengine-model site when a new release is published.
+# The model site pre-fetches metadata at build time for instant page loads.
+# Requires MODEL_SITE_DEPLOY_HOOK secret (Vercel Deploy Hook URL).
+name: Rebuild model site
+on:
+  release:
+    types: [published]
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel deploy
+        env:
+          DEPLOY_HOOK: ${{ secrets.MODEL_SITE_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$DEPLOY_HOOK" ]; then
+            echo "MODEL_SITE_DEPLOY_HOOK secret not set, skipping"
+            exit 0
+          fi
+          curl -X POST "$DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- add the release workflow from #1527 on top of current `main`
- trigger the policyengine-model Vercel deploy hook when a release is published
- no-op cleanly when `MODEL_SITE_DEPLOY_HOOK` is unset

## Context
- supersedes the stale draft in #1527 so this can get fresh CI on current `main`
- repository secret `MODEL_SITE_DEPLOY_HOOK` is still not configured in this repo, so the workflow will currently skip at runtime until that secret is added

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`