### PR TITLE
Fix uprate_rent StringArray lookup

### DIFF
--- a/changelog.d/uprate-rent-stringarray.fixed.md
+++ b/changelog.d/uprate-rent-stringarray.fixed.md
@@ -1,0 +1,1 @@
+- Ensure `uprate_rent` passes a NumPy array into vectorial parameter lookup for regional private rent growth.

--- a/policyengine_uk/data/economic_assumptions.py
+++ b/policyengine_uk/data/economic_assumptions.py
@@ -177,7 +177,7 @@ def uprate_rent(
     elif year < 2025:
         # We have regional growth rates for private rent.
         regional_growth_rate = growth.ons.private_rental_prices(year)[
-            region.values.astype(str)
+            np.array(region.values.astype(str))
         ]
         current_year.household["rent"] = np.where(
             is_private_rented,


### PR DESCRIPTION
## Summary
- ensure `uprate_rent` passes a NumPy array into the regional private rent parameter lookup
- add a changelog fragment for the compatibility fix
- supersede the stale conflicted branch from #1489

## Local verification
- `uv run pytest policyengine_uk/tests/core/test_pandas3_enum_encoding.py -q`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/consumption/rent -c policyengine_uk`