### PR TITLE
Fix uprate_rent vector lookup input type

### DIFF
--- a/policyengine_uk/data/economic_assumptions.py
+++ b/policyengine_uk/data/economic_assumptions.py
@@ -177,7 +177,7 @@ def uprate_rent(
     elif year < 2025:
         # We have regional growth rates for private rent.
         regional_growth_rate = growth.ons.private_rental_prices(year)[
-            region.values.astype(str)
+            np.array(region.values.astype(str))
         ]
         current_year.household["rent"] = np.where(
             is_private_rented,


### PR DESCRIPTION
## Summary
- wrap the regional lookup input in `np.array(...)` before indexing `private_rental_prices`
- avoid stale branch/conflict state from #1489 by applying the same narrow fix on current `main`

## Context
- supersedes the old intent of #1489 with a fresh branch on current `main`

## Validation
- diff reviewed to confirm this is a one-line behavioral change