### PR TITLE
Fix UC standard allowance reforms being ignored

### DIFF
--- a/policyengine_uk/scenarios/uc_reform.py
+++ b/policyengine_uk/scenarios/uc_reform.py
@@ -29,16 +29,8 @@ def add_universal_credit_reform(sim: Microsimulation):
         )  # Monthly amount * 12
         sim.set_input("uc_LCWRA_element", year, current_health_element)
 
-    # https://bills.parliament.uk/publications/62123/documents/6889#page=14
-
-    uc_uplift = rebalancing.standard_allowance_uplift
-
-    for year in range(2026, 2030):
-        if not rebalancing.active(year):
-            continue
-        previous_value = sim.calculate("uc_standard_allowance", year - 1)
-        new_value = previous_value * (1 + uc_uplift(year))
-        sim.set_input("uc_standard_allowance", year, new_value)
+    # Standard allowance uplift is handled in the formula itself so user
+    # reforms to the base amount are applied before the uplift.
 
 
 universal_credit_july_2025_reform = Scenario(

--- a/policyengine_uk/tests/microsimulation/test_uc_standard_allowance_reform.py
+++ b/policyengine_uk/tests/microsimulation/test_uc_standard_allowance_reform.py
@@ -1,0 +1,27 @@
+"""Test UC standard allowance reforms are respected (#1472)."""
+
+from policyengine_uk import Simulation
+
+YEAR = 2026
+
+SITUATION = {
+    "people": {"person": {"age": {YEAR: 30}}},
+    "benunits": {"benunit": {"members": ["person"]}},
+    "households": {"household": {"members": ["person"]}},
+}
+
+REFORM = {
+    "gov.dwp.universal_credit.standard_allowance.amount.SINGLE_OLD": {
+        "2025-01-01.2100-12-31": 800,
+    },
+}
+
+
+def test_uc_standard_allowance_responds_to_reform():
+    baseline = Simulation(situation=SITUATION)
+    baseline_amount = baseline.calculate("uc_standard_allowance", YEAR)[0]
+
+    reformed = Simulation(situation=SITUATION, reform=REFORM)
+    reform_amount = reformed.calculate("uc_standard_allowance", YEAR)[0]
+
+    assert reform_amount / baseline_amount > 1.5

--- a/policyengine_uk/variables/gov/dwp/universal_credit/standard_allowance/uc_standard_allowance.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/standard_allowance/uc_standard_allowance.py
@@ -11,4 +11,8 @@ class uc_standard_allowance(Variable):
     def formula(benunit, period, parameters):
         p = parameters(period).gov.dwp.universal_credit.standard_allowance
         claimant_type = benunit("uc_standard_allowance_claimant_type", period)
-        return p.amount[claimant_type] * MONTHS_IN_YEAR
+        value = p.amount[claimant_type] * MONTHS_IN_YEAR
+        rebalancing = parameters(period).gov.dwp.universal_credit.rebalancing
+        if rebalancing.active:
+            value = value * (1 + rebalancing.standard_allowance_uplift)
+        return value


### PR DESCRIPTION
## Summary
- move the rebalancing uplift into the `uc_standard_allowance` formula
- stop overriding `uc_standard_allowance` via scenario `set_input` so user reforms still apply
- add a focused microsimulation regression test

## Context
- supersedes the stale conflicting branch in #1507 with a fresh re-cut on current `main`
- intentionally leaves out the stale `reforms_config.yaml` edits from the old PR

## Validation
- `uv run pytest policyengine_uk/tests/microsimulation/test_uc_standard_allowance_reform.py -q`