### PR TITLE
Fix state pension reforms having no budget impact

### DIFF
--- a/policyengine_uk/tests/microsimulation/test_state_pension_reform.py
+++ b/policyengine_uk/tests/microsimulation/test_state_pension_reform.py
@@ -1,0 +1,32 @@
+"""Test state pension parameter reforms affect microsimulation outputs."""
+
+import pytest
+
+from policyengine_uk import Microsimulation
+
+YEAR = 2025
+
+
+@pytest.fixture(scope="module")
+def baseline():
+    return Microsimulation()
+
+
+@pytest.fixture(scope="module")
+def reform_halved():
+    return Microsimulation(
+        reform={
+            "gov.dwp.state_pension.basic_state_pension.amount": {
+                "2025-01-01": 84.75,
+            }
+        }
+    )
+
+
+@pytest.mark.microsimulation
+def test_basic_state_pension_responds_to_reform(baseline, reform_halved):
+    baseline_total = baseline.calculate("basic_state_pension", YEAR).sum()
+    reform_total = reform_halved.calculate("basic_state_pension", YEAR).sum()
+
+    assert baseline_total > 0
+    assert reform_total < baseline_total * 0.9

--- a/policyengine_uk/variables/gov/dwp/additional_state_pension.py
+++ b/policyengine_uk/variables/gov/dwp/additional_state_pension.py
@@ -18,12 +18,17 @@ class additional_state_pension(Variable):
             data_year = period.start.year
         reported = person("state_pension_reported", data_year) / WEEKS_IN_YEAR
         type = person("state_pension_type", data_year)
-        maximum_basic_sp = parameters(
-            data_year
-        ).gov.dwp.state_pension.basic_state_pension.amount
+        sp_amount = parameters.gov.dwp.state_pension.basic_state_pension.amount
+        max_sp_data_year = sp_amount(data_year)
+        max_sp_period = sp_amount(period)
         amount_in_data_year = where(
             type == type.possible_values.BASIC,
-            max_(reported - maximum_basic_sp, 0),
+            max_(reported - max_sp_data_year, 0),
             0,
         )
-        return amount_in_data_year * WEEKS_IN_YEAR
+        uprating = where(
+            max_sp_data_year > 0,
+            max_sp_period / max_sp_data_year,
+            1,
+        )
+        return amount_in_data_year * uprating * WEEKS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/basic_state_pension.py
+++ b/policyengine_uk/variables/gov/dwp/basic_state_pension.py
@@ -23,23 +23,22 @@ class basic_state_pension(Variable):
 
         reported = person("state_pension_reported", data_year) / WEEKS_IN_YEAR
         pension_type = person("state_pension_type", period)
-        maximum_basic_sp = parameters(
-            data_year
-        ).gov.dwp.state_pension.basic_state_pension.amount
+        sp_amount = parameters.gov.dwp.state_pension.basic_state_pension.amount
+        max_sp_data_year = sp_amount(data_year)
+        max_sp_period = sp_amount(period)
 
-        # For BASIC pension type, cap at the maximum; otherwise return 0
-        amount_in_data_year = where(
-            pension_type == pension_type.possible_values.BASIC,
-            min_(reported, maximum_basic_sp),
+        # Compute the person's share of the data-year maximum so reforms can
+        # scale the current-period amount while preserving the original cap.
+        share = where(
+            max_sp_data_year > 0,
+            min_(reported, max_sp_data_year) / max_sp_data_year,
             0,
         )
-
-        # Apply triple lock uprating only when using dataset
-        # (i.e., when data year differs from simulation period)
-        if has_dataset:
-            triple_lock = parameters.gov.economic_assumptions.indices.triple_lock
-            uprating = triple_lock(period) / triple_lock(data_year)
-        else:
-            uprating = 1
-
-        return amount_in_data_year * uprating * WEEKS_IN_YEAR
+        return (
+            where(
+                pension_type == pension_type.possible_values.BASIC,
+                share * max_sp_period,
+                0,
+            )
+            * WEEKS_IN_YEAR
+        )


### PR DESCRIPTION
## Summary
- switch state pension formulas to leaf-level parameter access so simulation-year reforms are visible
- preserve the cap/share logic for basic state pension and scale additional pension consistently
- add a focused microsimulation regression test

## Context
- supersedes the stale conflicting branch in #1509 with a fresh re-cut on current `main`
- intentionally leaves out the stale `reforms_config.yaml` edits from the old PR

## Validation
- `uv run pytest policyengine_uk/tests/microsimulation/test_state_pension_reform.py -q`