### PR TITLE
Fix default enhanced FRS Hugging Face repo URL

### DIFF
--- a/policyengine_uk/simulation.py
+++ b/policyengine_uk/simulation.py
@@ -144,7 +144,7 @@ class Simulation(CoreSimulation):
             self.build_from_multi_year_dataset(dataset)
         elif dataset is None:
             self.build_from_url(
-                "hf://policyengine/policyengine-uk-data/enhanced_frs_2023_24.h5"
+                "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5"
             )
         else:
             raise ValueError(f"Unsupported dataset type: {dataset.__class__}")

--- a/policyengine_uk/tax_benefit_system.py
+++ b/policyengine_uk/tax_benefit_system.py
@@ -37,7 +37,7 @@ from policyengine_uk.utils.parameters import (
 
 # Module constants
 COUNTRY_DIR = Path(__file__).parent
-ENHANCED_FRS = "hf://policyengine/policyengine-uk-data/enhanced_frs_2023_24.h5"
+ENHANCED_FRS = "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5"
 
 # Cache for fully-processed parameter tree, so convert_to_fiscal_year_parameters
 # (22,538 param.update() calls) only runs once per process.

--- a/policyengine_uk/tests/test_deterministic_variables.py
+++ b/policyengine_uk/tests/test_deterministic_variables.py
@@ -154,6 +154,29 @@ class TestExplicitOverrides:
         assert result[0] == False
 
 
+class TestDefaultDatasetUrl:
+    """Test that the default dataset URL points at the private HF repo."""
+
+    def test_simulation_defaults_to_private_hf_repo(self, monkeypatch):
+        captured = {}
+
+        class _StopDefaultDatasetLoad(Exception):
+            pass
+
+        def fake_build_from_url(self, url):
+            captured["url"] = url
+            raise _StopDefaultDatasetLoad
+
+        monkeypatch.setattr(Simulation, "build_from_url", fake_build_from_url)
+
+        with pytest.raises(_StopDefaultDatasetLoad):
+            Simulation()
+
+        assert captured["url"] == (
+            "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5"
+        )
+
+
 class TestIsHigherEarner:
     """Test deterministic tie-breaking for is_higher_earner."""
 


### PR DESCRIPTION
## Summary
- point the default enhanced FRS dataset URL at `policyengine/policyengine-uk-data-private`
- update the shared `ENHANCED_FRS` constant to the same repo
- add a regression test covering the default `Simulation()` dataset URL

Closes #1533.

## Verification
- `pytest policyengine_uk/tests/test_deterministic_variables.py::TestDefaultDatasetUrl::test_simulation_defaults_to_private_hf_repo -q`