### PR TITLE
Add 2026 Scottish income tax thresholds for starter and intermediate bands

### DIFF
--- a/policyengine_uk/parameters/gov/hmrc/income_tax/rates/scotland/rates.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/rates/scotland/rates.yaml
@@ -19,6 +19,7 @@ brackets:
         2023-04-06: 2_162
         2024-04-06: 2_306
         2025-04-06: 2_827
+        2026-04-06: 3_967
       metadata:
         uprating: gov.economic_assumptions.indices.obr.consumer_price_index
     rate:
@@ -32,6 +33,7 @@ brackets:
         2023-04-06: 13_118
         2024-04-06: 13_991
         2025-04-06: 14_921
+        2026-04-06: 16_956
       metadata:
         uprating: gov.economic_assumptions.indices.obr.consumer_price_index
     rate:

--- a/policyengine_uk/tests/test_scottish_income_tax_rates.py
+++ b/policyengine_uk/tests/test_scottish_income_tax_rates.py
@@ -1,0 +1,7 @@
+from policyengine_uk.system import system
+
+
+def test_scottish_income_tax_thresholds_updated_for_2026():
+    rates = system.parameters.gov.hmrc.income_tax.rates.scotland.rates("2026-04-06")
+
+    assert rates.thresholds == [0.0, 3967, 16956, 31092, 62430, 112570]


### PR DESCRIPTION
## Summary
- add explicit `2026-04-06` Scottish starter and intermediate thresholds
- keep the higher, advanced, and top thresholds unchanged
- add a regression test covering the full 2026 threshold vector

Closes #1550.

## Verification
- `pytest -q policyengine_uk/tests/test_scottish_income_tax_rates.py`