### PR TITLE
Stop defaulting Simulation() to a private dataset

### DIFF
--- a/policyengine_uk/simulation.py
+++ b/policyengine_uk/simulation.py
@@ -1,4 +1,5 @@
 # Standard library imports
+import os
 from typing import Dict, Optional, Union, Type, List
 
 # Third-party imports
@@ -27,7 +28,7 @@ from policyengine_uk.data.economic_assumptions import (
 from policyengine_uk.utils.dependencies import get_variable_dependencies
 from policyengine_uk.reforms import create_structural_reforms_from_parameters
 
-from .tax_benefit_system import CountryTaxBenefitSystem
+from .tax_benefit_system import CountryTaxBenefitSystem, DEFAULT_DATASET_ENV_VAR
 
 from microdf import MicroDataFrame
 
@@ -35,6 +36,16 @@ from microdf import MicroDataFrame
 # by URL. Avoids repeating HDF5 reading (0.84s), uprating (0.69s) and enum
 # encoding (0.67s) on every Simulation() call after the first.
 _url_dataset_cache: dict = {}
+
+
+def get_default_dataset_url() -> str:
+    dataset_url = os.environ.get(DEFAULT_DATASET_ENV_VAR)
+    if dataset_url:
+        return dataset_url
+    raise ValueError(
+        "Simulation() requires an explicit dataset when no situation is provided. "
+        f"Pass dataset=..., or set {DEFAULT_DATASET_ENV_VAR} to opt into a default dataset."
+    )
 
 
 def _pre_encode_enum_columns(
@@ -143,9 +154,7 @@ class Simulation(CoreSimulation):
         elif isinstance(dataset, UKMultiYearDataset):
             self.build_from_multi_year_dataset(dataset)
         elif dataset is None:
-            self.build_from_url(
-                "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5"
-            )
+            self.build_from_url(get_default_dataset_url())
         else:
             raise ValueError(f"Unsupported dataset type: {dataset.__class__}")
 

--- a/policyengine_uk/tax_benefit_system.py
+++ b/policyengine_uk/tax_benefit_system.py
@@ -37,7 +37,7 @@ from policyengine_uk.utils.parameters import (
 
 # Module constants
 COUNTRY_DIR = Path(__file__).parent
-ENHANCED_FRS = "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5"
+DEFAULT_DATASET_ENV_VAR = "POLICYENGINE_UK_DEFAULT_DATASET"
 
 # Cache for fully-processed parameter tree, so convert_to_fiscal_year_parameters
 # (22,538 param.update() calls) only runs once per process.

--- a/policyengine_uk/tests/conftest.py
+++ b/policyengine_uk/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+
+import pytest
+
+DEFAULT_TEST_DATASET_URL = (
+    "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@1.40.3"
+)
+
+if os.environ.get("HUGGING_FACE_TOKEN") and not os.environ.get(
+    "POLICYENGINE_UK_DEFAULT_DATASET"
+):
+    os.environ["POLICYENGINE_UK_DEFAULT_DATASET"] = DEFAULT_TEST_DATASET_URL
+
+
+def pytest_collection_modifyitems(config, items):
+    has_default_dataset = bool(os.environ.get("POLICYENGINE_UK_DEFAULT_DATASET"))
+    if has_default_dataset:
+        return
+
+    skip_microsimulation = pytest.mark.skip(
+        reason=(
+            "Requires POLICYENGINE_UK_DEFAULT_DATASET or HUGGING_FACE_TOKEN "
+            "for microsimulation dataset access"
+        )
+    )
+    for item in items:
+        if "microsimulation" in item.keywords:
+            item.add_marker(skip_microsimulation)

--- a/policyengine_uk/tests/test_behavioral_responses.py
+++ b/policyengine_uk/tests/test_behavioral_responses.py
@@ -16,8 +16,11 @@ from pathlib import Path
 from policyengine_uk import Microsimulation
 from policyengine_uk.model_api import Scenario
 
-# Check if HF token is available for data-dependent tests
-HF_TOKEN_AVAILABLE = bool(os.environ.get("HUGGING_FACE_TOKEN"))
+# Check if a default dataset is available for data-dependent tests
+HF_TOKEN_AVAILABLE = bool(
+    os.environ.get("HUGGING_FACE_TOKEN")
+    or os.environ.get("POLICYENGINE_UK_DEFAULT_DATASET")
+)
 requires_hf_data = pytest.mark.skipif(
     not HF_TOKEN_AVAILABLE,
     reason="Requires HUGGING_FACE_TOKEN for private data access",

--- a/policyengine_uk/tests/test_deterministic_variables.py
+++ b/policyengine_uk/tests/test_deterministic_variables.py
@@ -155,9 +155,15 @@ class TestExplicitOverrides:
 
 
 class TestDefaultDatasetUrl:
-    """Test that the default dataset URL points at the private HF repo."""
+    """Test explicit handling of the default dataset URL."""
 
-    def test_simulation_defaults_to_private_hf_repo(self, monkeypatch):
+    def test_simulation_requires_explicit_default_dataset(self, monkeypatch):
+        monkeypatch.delenv("POLICYENGINE_UK_DEFAULT_DATASET", raising=False)
+
+        with pytest.raises(ValueError, match="requires an explicit dataset"):
+            Simulation()
+
+    def test_simulation_uses_opt_in_default_dataset(self, monkeypatch):
         captured = {}
 
         class _StopDefaultDatasetLoad(Exception):
@@ -168,12 +174,16 @@ class TestDefaultDatasetUrl:
             raise _StopDefaultDatasetLoad
 
         monkeypatch.setattr(Simulation, "build_from_url", fake_build_from_url)
+        monkeypatch.setenv(
+            "POLICYENGINE_UK_DEFAULT_DATASET",
+            "hf://policyengine/policyengine-uk-data/enhanced_frs_2022_23.h5",
+        )
 
         with pytest.raises(_StopDefaultDatasetLoad):
             Simulation()
 
         assert captured["url"] == (
-            "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5"
+            "hf://policyengine/policyengine-uk-data/enhanced_frs_2022_23.h5"
         )
 
 


### PR DESCRIPTION
## Summary
- remove the hardcoded private Hugging Face dataset from bare `Simulation()` / `Microsimulation()` initialization
- require an explicit dataset when no situation is provided, unless `POLICYENGINE_UK_DEFAULT_DATASET` is explicitly set
- add regression tests covering both the explicit error path and the opt-in env-var path

This is a corrective follow-up to the merged default-dataset change. It avoids silently reaching into a private HF repo from the public package.

## Verification
- `pytest policyengine_uk/tests/test_deterministic_variables.py::TestDefaultDatasetUrl -q`