### PR TITLE
Add 2026 Scottish income tax source references

### DIFF
--- a/policyengine_uk/parameters/gov/hmrc/income_tax/rates/scotland/rates.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/rates/scotland/rates.yaml
@@ -93,5 +93,9 @@ metadata:
       href: https://www.gov.uk/government/publications/rates-and-allowances-income-tax/income-tax-rates-and-allowances-current-and-past
     - title: Scottish Budget 2025-26 - Higher rate threshold freeze
       href: https://www.gov.scot/publications/scottish-budget-2025-26/
+    - title: Scottish Income Tax 2026 to 2027
+      href: https://www.gov.scot/publications/scottish-income-tax-rates-and-bands/pages/2026-to-2027/
+    - title: Scottish Budget 2026-27
+      href: https://www.gov.scot/publications/scottish-budget-2026-2027/pages/4/
     - title: Scottish Fiscal Commission - Scotland's Economic and Fiscal Forecasts January 2026
       href: https://fiscalcommission.scot/wp-content/uploads/2026/01/Scotlands-Economic-and-Fiscal-Forecasts-January-2026-revised-13-01-2026.pdf


### PR DESCRIPTION
## Summary
- add the missing Scottish 2026-27 source references to the Scottish income tax rates parameter metadata
- keep the existing threshold values unchanged
- make the YAML metadata match the values added in #1553

## Verification
- `pytest -q policyengine_uk/tests/test_scottish_income_tax_rates.py`