### PR TITLE
Fix abolish council tax reform budget impact

### DIFF
--- a/policyengine_uk/tests/microsimulation/test_abolish_council_tax_reform.py
+++ b/policyengine_uk/tests/microsimulation/test_abolish_council_tax_reform.py
@@ -1,0 +1,39 @@
+"""Test abolishing council tax affects household and government balances."""
+
+import pytest
+
+from policyengine_uk import Microsimulation
+
+YEAR = 2025
+
+SITUATION = {
+    "people": {"person": {"age": {YEAR: 40}, "employment_income": {YEAR: 30000}}},
+    "benunits": {"benunit": {"members": ["person"]}},
+    "households": {
+        "household": {
+            "members": ["person"],
+            "council_tax": {YEAR: 2000},
+            "council_tax_band": {YEAR: "C"},
+        }
+    },
+}
+
+
+@pytest.mark.microsimulation
+def test_abolish_council_tax_removes_budget_impact():
+    baseline = Microsimulation(situation=SITUATION)
+    reform = Microsimulation(
+        situation=SITUATION,
+        reform={"gov.contrib.abolish_council_tax": True},
+    )
+
+    baseline_household_tax = baseline.calculate("household_tax", YEAR).sum()
+    reform_household_tax = reform.calculate("household_tax", YEAR).sum()
+    baseline_gov_balance = baseline.calculate("gov_balance", YEAR).sum()
+    reform_gov_balance = reform.calculate("gov_balance", YEAR).sum()
+    baseline_hbai = baseline.calculate("hbai_household_net_income", YEAR).sum()
+    reform_hbai = reform.calculate("hbai_household_net_income", YEAR).sum()
+
+    assert reform_household_tax == baseline_household_tax - 2000
+    assert reform_gov_balance == baseline_gov_balance - 2000
+    assert reform_hbai == baseline_hbai + 2000

--- a/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_tax.py
+++ b/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_tax.py
@@ -29,7 +29,8 @@ class pre_budget_change_household_tax(Variable):
     ]
 
     def formula(household, period, parameters):
-        if parameters(period).gov.contrib.abolish_council_tax:
+        abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
+        if abolish_council_tax:
             return add(
                 household,
                 period,

--- a/policyengine_uk/variables/gov/gov_tax.py
+++ b/policyengine_uk/variables/gov/gov_tax.py
@@ -35,7 +35,8 @@ class gov_tax(Variable):
 
     def formula(household, period, parameters):
         variables = list(gov_tax.adds)
-        if parameters(period).gov.contrib.abolish_council_tax:
+        abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
+        if abolish_council_tax:
             variables = [
                 variable for variable in variables if variable != "council_tax"
             ]

--- a/policyengine_uk/variables/gov/hmrc/household_tax.py
+++ b/policyengine_uk/variables/gov/hmrc/household_tax.py
@@ -35,7 +35,8 @@ class household_tax(Variable):
     ]
 
     def formula(household, period, parameters):
-        if parameters(period).gov.contrib.abolish_council_tax:
+        abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
+        if abolish_council_tax:
             return add(
                 household,
                 period,

--- a/policyengine_uk/variables/household/income/hbai_household_net_income.py
+++ b/policyengine_uk/variables/household/income/hbai_household_net_income.py
@@ -71,7 +71,8 @@ class hbai_household_net_income(Variable):
     ]
 
     def formula(household, period, parameters):
-        if parameters(period).gov.contrib.abolish_council_tax:
+        abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
+        if abolish_council_tax:
             return add(
                 household,
                 period,


### PR DESCRIPTION
## Summary
- fix the abolish-council-tax reform checks to read the active parameter value from the parameter tree
- make `household_tax`, `gov_tax`, `pre_budget_change_household_tax`, and `hbai_household_net_income` respond to the reform
- add a microsimulation regression test covering the expected budget and net-income changes

Fixes #1153.

## Verification
- `python -m pytest -q policyengine_uk/tests/microsimulation/test_abolish_council_tax_reform.py`