### PR TITLE
Clarify salary sacrifice default comment

### DIFF
--- a/policyengine_uk/parameters/gov/contrib/behavioral_responses/employee_salary_sacrifice_reduction_rate.yaml
+++ b/policyengine_uk/parameters/gov/contrib/behavioral_responses/employee_salary_sacrifice_reduction_rate.yaml
@@ -5,7 +5,7 @@
 # Most employees would optimize their salary sacrifice to avoid NI charges by reducing it to the cap level.
 description: The percentage by which employees reduce their salary sacrifice pension contributions in response to the salary sacrifice pension cap.
 values:
-  2010-01-01: 0  # Default: full optimization (employees reduce to cap level)
+  2010-01-01: 0  # Default: no adjustment (employees keep high salary sacrifice)
 metadata:
   unit: /1
   label: Employee salary sacrifice reduction rate in response to cap


### PR DESCRIPTION
## Summary
- update the inline YAML comment for `employee_salary_sacrifice_reduction_rate` so it matches the actual default value
- document that the default `0` means no adjustment, not full optimization

Issue #1463 reported this default-behavior bug, but current `main` already has the correct value. This PR just removes the stale comment that still described the opposite behavior.

## Verification
- `python - <<'PY' ... yaml.safe_load(...) ... PY` on `policyengine_uk/parameters/gov/contrib/behavioral_responses/employee_salary_sacrifice_reduction_rate.yaml`