### PR TITLE
Add abolish benefit cap scenario

### DIFF
--- a/changelog.d/abolish-benefit-cap-scenario.added.md
+++ b/changelog.d/abolish-benefit-cap-scenario.added.md
@@ -1,0 +1,1 @@
+Added an `abolish_benefit_cap` scenario for benefit-cap removal analysis.

--- a/docs/book/usage/scenarios.md
+++ b/docs/book/usage/scenarios.md
@@ -268,6 +268,18 @@ reformed_cap = reformed_sim.calculate("benefit_cap", 2026).mean()
 print(f"Benefit cap - frozen: £{baseline_cap:.0f}/year, indexed: £{reformed_cap:.0f}/year")
 ```
 
+If you want to remove the cap entirely for a poverty-analysis package, PolicyEngine
+UK also exposes a reusable scenario:
+
+```python
+from policyengine_uk import Simulation
+from policyengine_uk.scenarios import abolish_benefit_cap
+
+sim = Simulation(situation=benefit_cap_family, scenario=abolish_benefit_cap)
+benefit_cap_reduction = sim.calculate("benefit_cap_reduction", 2026).mean()
+print(f"Benefit cap reduction after abolition: £{benefit_cap_reduction:.0f}")
+```
+
 ## Advanced scenario techniques
 
 ### Time-varying parameters

--- a/policyengine_uk/scenarios/__init__.py
+++ b/policyengine_uk/scenarios/__init__.py
@@ -1,3 +1,4 @@
+from .abolish_benefit_cap import abolish_benefit_cap
 from .pip_reform import reform_pip_phase_in
 from .reindex_benefit_cap import reindex_benefit_cap
 from .repeal_two_child_limit import repeal_two_child_limit

--- a/policyengine_uk/scenarios/abolish_benefit_cap.py
+++ b/policyengine_uk/scenarios/abolish_benefit_cap.py
@@ -7,8 +7,6 @@ abolish_benefit_cap = Scenario(
         "gov.dwp.benefit_cap.single.in_london": {"year:2026:10": np.inf},
         "gov.dwp.benefit_cap.single.outside_london": {"year:2026:10": np.inf},
         "gov.dwp.benefit_cap.non_single.in_london": {"year:2026:10": np.inf},
-        "gov.dwp.benefit_cap.non_single.outside_london": {
-            "year:2026:10": np.inf
-        },
+        "gov.dwp.benefit_cap.non_single.outside_london": {"year:2026:10": np.inf},
     }
 )

--- a/policyengine_uk/scenarios/abolish_benefit_cap.py
+++ b/policyengine_uk/scenarios/abolish_benefit_cap.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from policyengine_uk.model_api import Scenario
+
+abolish_benefit_cap = Scenario(
+    parameter_changes={
+        "gov.dwp.benefit_cap.single.in_london": {"year:2026:10": np.inf},
+        "gov.dwp.benefit_cap.single.outside_london": {"year:2026:10": np.inf},
+        "gov.dwp.benefit_cap.non_single.in_london": {"year:2026:10": np.inf},
+        "gov.dwp.benefit_cap.non_single.outside_london": {
+            "year:2026:10": np.inf
+        },
+    }
+)

--- a/policyengine_uk/tests/test_abolish_benefit_cap_scenario.py
+++ b/policyengine_uk/tests/test_abolish_benefit_cap_scenario.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from policyengine_uk import Simulation
+from policyengine_uk.scenarios import abolish_benefit_cap
+
+BENEFIT_CAP_FAMILY = {
+    "people": {
+        "parent1": {"age": {2026: 30}, "employment_income": {2026: 0}},
+        "parent2": {"age": {2026: 28}, "employment_income": {2026: 0}},
+        "child1": {"age": {2026: 6}},
+        "child2": {"age": {2026: 3}},
+        "child3": {"age": {2026: 1}},
+    },
+    "benunits": {
+        "family": {
+            "members": ["parent1", "parent2", "child1", "child2", "child3"]
+        }
+    },
+    "households": {
+        "home": {
+            "members": ["parent1", "parent2", "child1", "child2", "child3"],
+            "rent": {2026: 24_000},
+        }
+    },
+}
+
+
+class TestAbolishBenefitCapScenario:
+    def test_removes_benefit_cap_reduction(self):
+        baseline = Simulation(situation=BENEFIT_CAP_FAMILY)
+        reformed = Simulation(
+            situation=BENEFIT_CAP_FAMILY, scenario=abolish_benefit_cap
+        )
+
+        baseline_reduction = baseline.calculate("benefit_cap_reduction", 2026)
+        baseline_uc = baseline.calculate("universal_credit", 2026)
+        reformed_cap = reformed.calculate("benefit_cap", 2026)
+        reformed_reduction = reformed.calculate("benefit_cap_reduction", 2026)
+        reformed_uc = reformed.calculate("universal_credit", 2026)
+        reformed_uc_pre_cap = reformed.calculate(
+            "universal_credit_pre_benefit_cap", 2026
+        )
+
+        assert baseline_reduction[0] > 0
+        assert np.isfinite(baseline.calculate("benefit_cap", 2026)[0])
+        assert np.isinf(reformed_cap[0])
+        assert reformed_reduction.tolist() == [0.0]
+        assert reformed_uc.tolist() == reformed_uc_pre_cap.tolist()
+        assert reformed_uc[0] > baseline_uc[0]

--- a/policyengine_uk/tests/test_abolish_benefit_cap_scenario.py
+++ b/policyengine_uk/tests/test_abolish_benefit_cap_scenario.py
@@ -12,9 +12,7 @@ BENEFIT_CAP_FAMILY = {
         "child3": {"age": {2026: 1}},
     },
     "benunits": {
-        "family": {
-            "members": ["parent1", "parent2", "child1", "child2", "child3"]
-        }
+        "family": {"members": ["parent1", "parent2", "child1", "child2", "child3"]}
     },
     "households": {
         "home": {


### PR DESCRIPTION
## Summary
- add a reusable `abolish_benefit_cap` scenario by setting each benefit cap rate to `np.inf`
- export the scenario and document it in the scenarios guide
- add a regression test showing the scenario removes `benefit_cap_reduction` and restores pre-cap UC awards

## Testing
- `/Users/maxghenis/worktrees/policyengine-uk-fix-private-default/.venv/bin/python -m pytest -q policyengine_uk/tests/test_abolish_benefit_cap_scenario.py`
- `/Users/maxghenis/worktrees/policyengine-uk-fix-private-default/.venv/bin/python -m ruff check policyengine_uk/scenarios/abolish_benefit_cap.py policyengine_uk/tests/test_abolish_benefit_cap_scenario.py`
- `cd docs/book && uvx --from 'jupyter-book>=2.0.0a0' jupyter book clean --all -y`
- `cd docs/book && uvx --from 'jupyter-book>=2.0.0a0' jupyter book build --html`

Closes #1397.