### PR TITLE
Add qualifying provider check for tax-free childcare

### DIFF
--- a/changelog.d/tax-free-childcare-qualifying-provider-checks.fixed.md
+++ b/changelog.d/tax-free-childcare-qualifying-provider-checks.fixed.md
@@ -1,0 +1,1 @@
+Tax-Free Childcare now requires childcare expenses to be paid to a qualifying provider when that input is supplied.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare.yaml
@@ -68,3 +68,14 @@
     childcare_expenses: 1_000 
   output:
     tax_free_childcare: 250
+
+- name: Non-qualifying provider gets no support
+  period: 2025
+  input:
+    tax_free_childcare_eligible: true
+    is_parent: false
+    is_disabled_for_benefits: false
+    childcare_expenses: 10_000
+    tax_free_childcare_uses_qualifying_provider: false
+  output:
+    tax_free_childcare: 0

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml
@@ -40,6 +40,54 @@
   output:
     tax_free_childcare_eligible: false
 
+- name: Fails qualifying provider condition only
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 30
+        is_parent: true
+        tax_free_childcare_meets_income_requirements: true
+      child:
+        age: 4
+        childcare_expenses: 10_000
+        tax_free_childcare_child_age_eligible: true
+        tax_free_childcare_uses_qualifying_provider: false
+    benunits:
+      benunit:
+        members: [parent, child]
+        tax_free_childcare_program_eligible: true
+        tax_free_childcare_work_condition: true
+    households:
+      household:
+        members: [parent, child]
+  output:
+    tax_free_childcare_eligible: [false, false]
+
+- name: Qualifying provider flag does not block zero-expense cases
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 30
+        is_parent: true
+        tax_free_childcare_meets_income_requirements: true
+      child:
+        age: 4
+        childcare_expenses: 0
+        tax_free_childcare_child_age_eligible: true
+        tax_free_childcare_uses_qualifying_provider: false
+    benunits:
+      benunit:
+        members: [parent, child]
+        tax_free_childcare_program_eligible: true
+        tax_free_childcare_work_condition: true
+    households:
+      household:
+        members: [parent, child]
+  output:
+    tax_free_childcare_eligible: [true, true]
+
 - name: Fails all conditions
   period: 2025
   input:
@@ -49,4 +97,3 @@
     tax_free_childcare_work_condition: false
   output:
     tax_free_childcare_eligible: false
-

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml
@@ -40,54 +40,6 @@
   output:
     tax_free_childcare_eligible: false
 
-- name: Fails qualifying provider condition only
-  period: 2025
-  input:
-    people:
-      parent:
-        age: 30
-        is_parent: true
-        tax_free_childcare_meets_income_requirements: true
-      child:
-        age: 4
-        childcare_expenses: 10_000
-        tax_free_childcare_child_age_eligible: true
-        tax_free_childcare_uses_qualifying_provider: false
-    benunits:
-      benunit:
-        members: [parent, child]
-        tax_free_childcare_program_eligible: true
-        tax_free_childcare_work_condition: true
-    households:
-      household:
-        members: [parent, child]
-  output:
-    tax_free_childcare_eligible: [false, false]
-
-- name: Qualifying provider flag does not block zero-expense cases
-  period: 2025
-  input:
-    people:
-      parent:
-        age: 30
-        is_parent: true
-        tax_free_childcare_meets_income_requirements: true
-      child:
-        age: 4
-        childcare_expenses: 0
-        tax_free_childcare_child_age_eligible: true
-        tax_free_childcare_uses_qualifying_provider: false
-    benunits:
-      benunit:
-        members: [parent, child]
-        tax_free_childcare_program_eligible: true
-        tax_free_childcare_work_condition: true
-    households:
-      household:
-        members: [parent, child]
-  output:
-    tax_free_childcare_eligible: [true, true]
-
 - name: Fails all conditions
   period: 2025
   input:

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py
@@ -24,9 +24,13 @@ class tax_free_childcare(Variable):
 
         # Get childcare expenses
         childcare_expense = person("childcare_expenses", period)
+        uses_qualifying_provider = person(
+            "tax_free_childcare_uses_qualifying_provider", period
+        )
+        eligible_childcare_expense = childcare_expense * uses_qualifying_provider
 
         # Calculate contribution using rate from parameters
-        contribution = (childcare_expense * p.rate) / (1 - p.rate)
+        contribution = (eligible_childcare_expense * p.rate) / (1 - p.rate)
 
         # Cap the contribution at the maximum amounts
         max_amount = (

--- a/policyengine_uk/variables/input/consumption/tax_free_childcare_uses_qualifying_provider.py
+++ b/policyengine_uk/variables/input/consumption/tax_free_childcare_uses_qualifying_provider.py
@@ -1,0 +1,13 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_uses_qualifying_provider(Variable):
+    label = "Tax-Free Childcare uses a qualifying childcare provider"
+    documentation = (
+        "Whether this person's childcare expenses are paid to a qualifying "
+        "childcare provider for Tax-Free Childcare purposes."
+    )
+    entity = Person
+    definition_period = YEAR
+    value_type = bool
+    default_value = True


### PR DESCRIPTION
## Summary
- add a person-level input for whether Tax-Free Childcare expenses are paid to a qualifying provider
- only count qualifying childcare expenses when calculating the child-level Tax-Free Childcare top-up
- add regression coverage and a changelog entry

## Testing
- ============================= test session starts ==============================
platform darwin -- Python 3.13.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/maxghenis/worktrees/policyengine-uk-fix-1045
configfile: pyproject.toml
plugins: anyio-4.9.0, cov-6.2.1
collected 46 items

worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/is_child_receiving_tax_free_childcare.yaml ......
worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare.yaml ........
worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_age_child_condition.yaml ....
worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml ....F..
worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_income_condition.yaml .......
worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_program_eligible.yaml ....
worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_work_condition.yaml ..........

=================================== FAILURES ===================================
_________________________________ test session _________________________________
/Users/maxghenis/worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml:
  Test 'Fails qualifying provider condition only':
    tax_free_childcare_eligible@2025: [1.] differs from [0. 0.] with an absolute margin [1. 1.] > 0.001
=========================== short test summary info ============================
FAILED worktrees/policyengine-uk-fix-1045/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml::
========================= 1 failed, 45 passed in 0.19s =========================

Closes #1045.