### PR TITLE
Fix state pension relative reform path

### DIFF
--- a/changelog.d/state-pension-relative-reform.fixed.md
+++ b/changelog.d/state-pension-relative-reform.fixed.md
@@ -1,0 +1,1 @@
+Fixed `gov.contrib.cec.state_pension_increase` so state pension reforms affect microsimulation outputs and budget impacts.

--- a/policyengine_uk/tests/microsimulation/test_state_pension_reform.py
+++ b/policyengine_uk/tests/microsimulation/test_state_pension_reform.py
@@ -23,6 +23,11 @@ def reform_halved():
     )
 
 
+@pytest.fixture(scope="module")
+def reform_relative_cut():
+    return Microsimulation(reform={"gov.contrib.cec.state_pension_increase": -0.1})
+
+
 @pytest.mark.microsimulation
 def test_basic_state_pension_responds_to_reform(baseline, reform_halved):
     baseline_total = baseline.calculate("basic_state_pension", YEAR).sum()
@@ -30,3 +35,15 @@ def test_basic_state_pension_responds_to_reform(baseline, reform_halved):
 
     assert baseline_total > 0
     assert reform_total < baseline_total * 0.9
+
+
+@pytest.mark.microsimulation
+def test_relative_state_pension_reform_affects_budget(baseline, reform_relative_cut):
+    baseline_total = baseline.calculate("state_pension", YEAR).sum()
+    reform_total = reform_relative_cut.calculate("state_pension", YEAR).sum()
+    baseline_balance = baseline.calculate("gov_balance", YEAR).sum()
+    reform_balance = reform_relative_cut.calculate("gov_balance", YEAR).sum()
+
+    assert baseline_total > 0
+    assert reform_total < baseline_total * 0.95
+    assert reform_balance > baseline_balance

--- a/policyengine_uk/variables/input/state_pension.py
+++ b/policyengine_uk/variables/input/state_pension.py
@@ -12,20 +12,19 @@ class state_pension(Variable):
     uprating = "gov.economic_assumptions.indices.obr.consumer_price_index"
 
     def formula(person, period, parameters):
-        gov = parameters(period).gov
-        if gov.contrib.abolish_state_pension:
+        contrib = parameters.gov.contrib
+        if contrib.abolish_state_pension(period):
             return 0
-        relative_increase = gov.contrib.cec.state_pension_increase
-        uprating = 1 + relative_increase
-        sp = gov.dwp.state_pension
-        gender = person("gender", period).decode_to_str()
-        is_sp_age = person("is_SP_age", period)
-        return add(
-            person,
-            period,
-            [
-                "basic_state_pension",
-                "additional_state_pension",
-                "new_state_pension",
-            ],
+        uprating = 1 + contrib.cec.state_pension_increase(period)
+        return (
+            add(
+                person,
+                period,
+                [
+                    "basic_state_pension",
+                    "additional_state_pension",
+                    "new_state_pension",
+                ],
+            )
+            * uprating
         )


### PR DESCRIPTION
## Summary
- read state pension contribution reforms from the active parameter tree instead of the period snapshot that was ignoring 
- apply the relative state pension reform multiplier to the aggregated state pension amount
- add a microsimulation regression test and changelog entry

## Testing
- ..                                                                       [100%]
=============================== warnings summary ===============================
../policyengine-uk-fix-private-default/.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:323
  /Users/maxghenis/worktrees/policyengine-uk-fix-private-default/.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2 passed, 1 warning in 12.51s

Closes #1178.