### PR TITLE
Clip negative earnings in labor supply responses

### DIFF
--- a/changelog.d/lsr-negative-earnings.fixed.md
+++ b/changelog.d/lsr-negative-earnings.fixed.md
@@ -1,2 +1,2 @@
-Prevent labor supply response formulas from flipping sign when baseline
-employment income is negative.
+Prevent labor supply response formulas and progression dynamics from
+flipping sign when baseline employment income is negative.

--- a/changelog.d/lsr-negative-earnings.fixed.md
+++ b/changelog.d/lsr-negative-earnings.fixed.md
@@ -1,0 +1,2 @@
+Prevent labor supply response formulas from flipping sign when baseline
+employment income is negative.

--- a/policyengine_uk/dynamics/progression.py
+++ b/policyengine_uk/dynamics/progression.py
@@ -347,23 +347,25 @@ def calculate_employment_income_change(
     Returns:
         Array of employment income changes due to labour supply responses
     """
+    earnings_base = np.maximum(employment_income, 0)
+
     # Calculate substitution effect: response to changes in marginal rates
     substitution_response = (
-        employment_income
+        earnings_base
         * derivative_changes["wage_rel_change"]
         * substitution_elasticities
     )
 
     # Calculate income effect: response to changes in unearned income
     income_response = (
-        employment_income * income_changes["income_rel_change"] * income_elasticities
+        earnings_base * income_changes["income_rel_change"] * income_elasticities
     )
 
     # Total labour supply response is sum of substitution and income effects
     total_response = substitution_response + income_response
 
-    # No response for people with zero employment income
-    total_response[employment_income == 0] = 0
+    # No response for people with non-positive employment income
+    total_response[earnings_base == 0] = 0
 
     df = pd.DataFrame(
         {

--- a/policyengine_uk/tests/test_labor_supply_response_formulas.py
+++ b/policyengine_uk/tests/test_labor_supply_response_formulas.py
@@ -1,7 +1,11 @@
 from types import SimpleNamespace
 
 import numpy as np
+import pandas as pd
 
+from policyengine_uk.dynamics.progression import (
+    calculate_employment_income_change,
+)
 from policyengine_uk.variables.gov.simulation.labor_supply_response.income_elasticity_lsr import (
     income_elasticity_lsr,
 )
@@ -61,3 +65,17 @@ def test_substitution_elasticity_lsr_clips_negative_earnings():
     )
 
     assert np.allclose(result, np.array([0.0, 0.0, 40.0]))
+
+
+def test_progression_labor_supply_response_clips_negative_earnings():
+    result = calculate_employment_income_change(
+        employment_income=np.array([-1_000.0, 0.0, 1_000.0]),
+        derivative_changes=pd.DataFrame({"wage_rel_change": [0.1, 0.1, 0.1]}),
+        income_changes=pd.DataFrame({"income_rel_change": [0.2, 0.2, 0.2]}),
+        substitution_elasticities=np.array([0.15, 0.15, 0.15]),
+        income_elasticities=np.array([-0.05, -0.05, -0.05]),
+    )
+
+    assert np.allclose(result["substitution_response"], [0.0, 0.0, 15.0])
+    assert np.allclose(result["income_response"], [0.0, 0.0, -10.0])
+    assert np.allclose(result["total_response"], [0.0, 0.0, 5.0])

--- a/policyengine_uk/tests/test_labor_supply_response_formulas.py
+++ b/policyengine_uk/tests/test_labor_supply_response_formulas.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from policyengine_uk.variables.gov.simulation.labor_supply_response.income_elasticity_lsr import (
+    income_elasticity_lsr,
+)
+from policyengine_uk.variables.gov.simulation.labor_supply_response.substitution_elasticity_lsr import (
+    substitution_elasticity_lsr,
+)
+
+
+class FakePerson:
+    def __init__(self, values):
+        self.values = values
+
+    def __call__(self, variable, period):
+        return np.array(self.values[variable])
+
+
+class FakeParameters:
+    def __init__(self, income_elasticity=0.1, substitution_elasticity=0.2):
+        self.gov = SimpleNamespace(
+            simulation=SimpleNamespace(
+                labor_supply_responses=SimpleNamespace(
+                    income_elasticity=income_elasticity,
+                    substitution_elasticity=substitution_elasticity,
+                )
+            )
+        )
+
+    def __call__(self, period):
+        return self
+
+
+def test_income_elasticity_lsr_clips_negative_earnings():
+    person = FakePerson(
+        {
+            "employment_income_before_lsr": [-1_000, 0, 1_000],
+            "relative_income_change": [0.1, 0.1, 0.1],
+        }
+    )
+
+    result = income_elasticity_lsr.formula(
+        person, 2025, FakeParameters(income_elasticity=0.1)
+    )
+
+    assert np.allclose(result, np.array([0.0, 0.0, 10.0]))
+
+
+def test_substitution_elasticity_lsr_clips_negative_earnings():
+    person = FakePerson(
+        {
+            "employment_income_before_lsr": [-1_000, 0, 1_000],
+            "relative_wage_change": [0.2, 0.2, 0.2],
+        }
+    )
+
+    result = substitution_elasticity_lsr.formula(
+        person, 2025, FakeParameters(substitution_elasticity=0.2)
+    )
+
+    assert np.allclose(result, np.array([0.0, 0.0, 40.0]))

--- a/policyengine_uk/variables/gov/simulation/labor_supply_response/income_elasticity_lsr.py
+++ b/policyengine_uk/variables/gov/simulation/labor_supply_response/income_elasticity_lsr.py
@@ -11,7 +11,7 @@ class income_elasticity_lsr(Variable):
 
     def formula(person, period, parameters):
         lsr = parameters(period).gov.simulation.labor_supply_responses
-        employment_income = person("employment_income_before_lsr", period)
+        employment_income = max_(person("employment_income_before_lsr", period), 0)
         income_change = person("relative_income_change", period)
 
         return employment_income * income_change * lsr.income_elasticity

--- a/policyengine_uk/variables/gov/simulation/labor_supply_response/substitution_elasticity_lsr.py
+++ b/policyengine_uk/variables/gov/simulation/labor_supply_response/substitution_elasticity_lsr.py
@@ -11,7 +11,7 @@ class substitution_elasticity_lsr(Variable):
 
     def formula(person, period, parameters):
         lsr = parameters(period).gov.simulation.labor_supply_responses
-        employment_income = person("employment_income_before_lsr", period)
+        employment_income = max_(person("employment_income_before_lsr", period), 0)
         wage_change = person("relative_wage_change", period)
 
         return employment_income * wage_change * lsr.substitution_elasticity


### PR DESCRIPTION
## Summary\n- clip negative baseline employment income to zero before applying labor supply elasticities\n- add direct regression tests for income and substitution elasticity formulas\n- add a changelog entry\n\nCloses #1135.\n\n## Testing\n- python3 -m pytest -q policyengine_uk/tests/test_labor_supply_response_formulas.py\n- uvx ruff check policyengine_uk/tests/test_labor_supply_response_formulas.py