### PR TITLE
Add income decile regression coverage

### DIFF
--- a/changelog.d/income-decile-regression.fixed.md
+++ b/changelog.d/income-decile-regression.fixed.md
@@ -1,0 +1,1 @@
+Add regression coverage to keep income decile outputs in `-1` or `1..10`.

--- a/policyengine_uk/tests/test_household_income_decile.py
+++ b/policyengine_uk/tests/test_household_income_decile.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from policyengine_uk.variables.contrib.policyengine.pre_budget_change_ons_household_income_decile import (
+    pre_budget_change_ons_household_income_decile,
+)
+from policyengine_uk.variables.household.income.household_income_decile import (
+    household_income_decile,
+)
+
+
+class FakeHousehold:
+    def __init__(self, values, dataset=None):
+        self.values = values
+        self.simulation = type("FakeSimulation", (), {"dataset": dataset})()
+
+    def __call__(self, variable, period):
+        return np.array(self.values[variable])
+
+
+def test_household_income_decile_caps_at_ten():
+    household = FakeHousehold(
+        {
+            "equiv_hbai_household_net_income": np.arange(11, dtype=float),
+            "household_count_people": np.ones(11),
+            "household_weight": np.ones(11),
+        }
+    )
+
+    result = household_income_decile.formula(household, 2025, None)
+
+    assert np.all(result <= 10)
+    assert result.max() == 10
+
+
+def test_household_income_decile_keeps_negative_incomes_outside_deciles():
+    household = FakeHousehold(
+        {
+            "equiv_hbai_household_net_income": np.array([-5, 0, 10], dtype=float),
+            "household_count_people": np.ones(3),
+            "household_weight": np.ones(3),
+        }
+    )
+
+    result = household_income_decile.formula(household, 2025, None)
+
+    assert result[0] == -1
+    assert np.all(result[1:] >= 1)
+    assert np.all(result[1:] <= 10)
+
+
+def test_pre_budget_change_income_decile_domain_is_negative_or_one_to_ten():
+    household = FakeHousehold(
+        {
+            "pre_budget_change_household_net_income": np.array(
+                [-5, 16_000, 70_000], dtype=float
+            ),
+            "household_equivalisation_bhc": np.ones(3),
+        }
+    )
+
+    result = pre_budget_change_ons_household_income_decile.formula(
+        household, 2025, None
+    )
+
+    assert result.tolist() == [-1, 1, 10]


### PR DESCRIPTION
## Summary\n- add regression tests proving household income decile outputs stay within -1 or 1..10\n- cover both household deciles and the pre-budget ONS-matched decile variable\n- add a changelog entry\n\nReferences #944.\n\n## Testing\n- python3 -m pytest -q policyengine_uk/tests/test_household_income_decile.py\n- uvx ruff check policyengine_uk/tests/test_household_income_decile.py