### PR TITLE
Add Universal Credit capital limits

### DIFF
--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/lower_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/lower_threshold.yaml
@@ -6,7 +6,5 @@ metadata:
   period: year
   unit: currency-GBP
   reference:
-    - title: Universal Credit money, savings and investments
-      href: https://www.gov.uk/guidance/universal-credit-money-savings-and-investments
-    - title: Benefit and pension rates 2025 to 2026
-      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf
+    - title: The Universal Credit Regulations 2013 reg. 72
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/72

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/lower_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/lower_threshold.yaml
@@ -1,0 +1,12 @@
+description: Universal Credit lower capital threshold.
+values:
+  2013-04-29: 6_000
+metadata:
+  label: Universal Credit lower capital threshold
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: Universal Credit money, savings and investments
+      href: https://www.gov.uk/guidance/universal-credit-money-savings-and-investments
+    - title: Benefit and pension rates 2025 to 2026
+      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/sources.yaml
@@ -1,22 +1,36 @@
 description: >
-  Household asset variables currently counted towards Universal Credit capital.
-  Regulation 46 takes all capital into account unless it is treated as income or
-  disregarded under regulation 48 and Schedule 10. These household-level sources
-  are used directly when a household contains a single benefit unit. For
-  multi-benunit households, the model falls back to the household-head benunit's
-  household-level capital proxy unless a benunit-specific `uc_reported_capital`
-  override is provided.
+  Model variables currently mapped to countable Universal Credit capital.
+  Regulation 46 takes the whole of a person's capital into account unless it is
+  treated as income or disregarded under regulation 48 and Schedule 10. The
+  current mappings are `savings` for liquid capital,
+  `other_residential_property_value` for residential property other than the
+  home, `non_residential_property_value` for other land and premises, and
+  `corporate_wealth` for shares and similar investment assets. `main_residence_value`
+  is excluded because Schedule 10 paragraph 1 disregards premises occupied as
+  the person's home. Other Schedule 10 disregards within these broad asset
+  classes are not yet split out separately. Where only household-level capital
+  is available for a multi-benunit household, the model uses a household-wide
+  adult-share proxy for residual capital because the dataset does not identify
+  which adults hold the beneficial interest in each capital asset. The
+  denominator is all unreported adults in the household, including adults in
+  benunits that are not themselves UC claimants. That proxy is a data
+  approximation, not a legislated allocation rule. Regulation 47 is cited only
+  as related context on jointly held capital. If some benunits provide
+  `uc_reported_capital`, the proxy is applied only to the residual household
+  capital for benunits that remain unreported.
 metadata:
   label: Universal Credit countable capital sources
   period: year
   unit: list
   reference:
-    - title: The Universal Credit Regulations 2013 reg. 46
-      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/46
-    - title: The Universal Credit Regulations 2013 reg. 48
-      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/48
-    - title: The Universal Credit Regulations 2013 Schedule 10
-      href: https://www.legislation.gov.uk/uksi/2013/376/schedule/10
+    - title: The Universal Credit Regulations 2013 reg. 46(1)
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/46/1
+    - title: The Universal Credit Regulations 2013 reg. 47
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/47
+    - title: The Universal Credit Regulations 2013 reg. 48(1)
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/48/1
+    - title: The Universal Credit Regulations 2013 Schedule 10 para. 1
+      href: https://www.legislation.gov.uk/uksi/2013/376/schedule/10/paragraph/1
 values:
   2013-04-29:
     - savings

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/sources.yaml
@@ -1,8 +1,11 @@
 description: >
   Household asset variables currently counted towards Universal Credit capital.
   Regulation 46 takes all capital into account unless it is treated as income or
-  disregarded under regulation 48 and Schedule 10. The current modelled proxy is
-  limited to liquid savings.
+  disregarded under regulation 48 and Schedule 10. These household-level sources
+  are used directly when a household contains a single benefit unit. For
+  multi-benunit households, the model falls back to the household-head benunit's
+  household-level capital proxy unless a benunit-specific `uc_reported_capital`
+  override is provided.
 metadata:
   label: Universal Credit countable capital sources
   period: year
@@ -17,3 +20,6 @@ metadata:
 values:
   2013-04-29:
     - savings
+    - other_residential_property_value
+    - non_residential_property_value
+    - corporate_wealth

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/sources.yaml
@@ -1,0 +1,19 @@
+description: >
+  Household asset variables currently counted towards Universal Credit capital.
+  Regulation 46 takes all capital into account unless it is treated as income or
+  disregarded under regulation 48 and Schedule 10. The current modelled proxy is
+  limited to liquid savings.
+metadata:
+  label: Universal Credit countable capital sources
+  period: year
+  unit: list
+  reference:
+    - title: The Universal Credit Regulations 2013 reg. 46
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/46
+    - title: The Universal Credit Regulations 2013 reg. 48
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/48
+    - title: The Universal Credit Regulations 2013 Schedule 10
+      href: https://www.legislation.gov.uk/uksi/2013/376/schedule/10
+values:
+  2013-04-29:
+    - savings

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/amount.yaml
@@ -1,0 +1,12 @@
+description: Universal Credit monthly tariff income for each capital step above the lower threshold.
+values:
+  2013-04-29: 4.35
+metadata:
+  label: Universal Credit monthly tariff income per capital step
+  period: month
+  unit: currency-GBP
+  reference:
+    - title: Universal Credit money, savings and investments
+      href: https://www.gov.uk/guidance/universal-credit-money-savings-and-investments
+    - title: Benefit and pension rates 2025 to 2026
+      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/amount.yaml
@@ -6,7 +6,5 @@ metadata:
   period: month
   unit: currency-GBP
   reference:
-    - title: Universal Credit money, savings and investments
-      href: https://www.gov.uk/guidance/universal-credit-money-savings-and-investments
-    - title: Benefit and pension rates 2025 to 2026
-      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf
+    - title: The Universal Credit Regulations 2013 reg. 72
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/72

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/step.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/step.yaml
@@ -1,0 +1,12 @@
+description: Capital step used to calculate Universal Credit tariff income.
+values:
+  2013-04-29: 250
+metadata:
+  label: Universal Credit capital step for tariff income
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: Universal Credit money, savings and investments
+      href: https://www.gov.uk/guidance/universal-credit-money-savings-and-investments
+    - title: Benefit and pension rates 2025 to 2026
+      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/step.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/tariff_income/step.yaml
@@ -6,7 +6,5 @@ metadata:
   period: year
   unit: currency-GBP
   reference:
-    - title: Universal Credit money, savings and investments
-      href: https://www.gov.uk/guidance/universal-credit-money-savings-and-investments
-    - title: Benefit and pension rates 2025 to 2026
-      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf
+    - title: The Universal Credit Regulations 2013 reg. 72
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/72

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/upper_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/upper_threshold.yaml
@@ -6,7 +6,5 @@ metadata:
   period: year
   unit: currency-GBP
   reference:
-    - title: Universal Credit Eligibility
-      href: https://www.gov.uk/universal-credit/eligibility
-    - title: Benefit and pension rates 2025 to 2026
-      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf
+    - title: The Universal Credit Regulations 2013 reg. 18
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/18

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/upper_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/capital/upper_threshold.yaml
@@ -1,0 +1,12 @@
+description: Universal Credit upper capital threshold.
+values:
+  2013-04-29: 16_000
+metadata:
+  label: Universal Credit upper capital threshold
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: Universal Credit Eligibility
+      href: https://www.gov.uk/universal-credit/eligibility
+    - title: Benefit and pension rates 2025 to 2026
+      href: https://assets.publishing.service.gov.uk/media/67efe453cb0feef57df7e571/benefit_and_pension_rates_2025_to_2026.pdf

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/capital_derived.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/capital_derived.yaml
@@ -1,0 +1,17 @@
+description: >
+  Universal Credit unearned income sources that derive from capital currently
+  represented in the model's capital base. When tariff income applies under
+  regulation 72, these actual returns are folded into capital instead of being
+  counted separately as unearned income.
+metadata:
+  economy: false
+  label: Universal Credit capital-derived unearned income sources
+  propagate_metadata_to_children: true
+  period: year
+  unit: list
+  reference:
+    - title: The Universal Credit Regulations 2013 reg. 72
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/72
+values:
+  2013-04-29:
+    - savings_interest_income

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/capital_derived.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/capital_derived.yaml
@@ -1,8 +1,19 @@
 description: >
-  Universal Credit unearned income sources that derive from capital currently
-  represented in the model's capital base. Regulation 72(3) treats income
-  derived from capital that is yielding tariff income as part of capital rather
-  than a separate unearned-income reduction.
+  Model income variables treated as capital-derived income for Universal Credit
+  when tariff income applies. Regulation 72(3) covers actual income derived
+  from capital, for example rental, interest or dividends. In the current
+  model, those map to `property_income` when countable property capital is
+  present, `savings_interest_income` when savings are present, and
+  `dividend_income` when corporate wealth is present. Those linked income
+  streams are removed from `uc_unearned_income` once `uc_tariff_income`
+  applies to avoid double counting the same capital. The model does not add
+  annual income flows back into `uc_assessable_capital`, because the dataset
+  does not identify whether those receipts are retained as capital within the
+  assessment year. When benunit-level `uc_reported_capital` is provided, the
+  model treats that as sufficient evidence of countable capital for all listed
+  capital-derived income variables, so `savings_interest_income`,
+  `dividend_income`, and `property_income` are all suppressed once tariff
+  income applies.
 metadata:
   economy: false
   label: Universal Credit capital-derived unearned income sources
@@ -10,8 +21,8 @@ metadata:
   period: year
   unit: list
   reference:
-    - title: The Universal Credit Regulations 2013 reg. 72
-      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/72
+    - title: The Universal Credit Regulations 2013 reg. 72(3)
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/72/3
 values:
   2013-04-29:
     - savings_interest_income

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/capital_derived.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/capital_derived.yaml
@@ -1,8 +1,8 @@
 description: >
   Universal Credit unearned income sources that derive from capital currently
-  represented in the model's capital base. When tariff income applies under
-  regulation 72, these actual returns are folded into capital instead of being
-  counted separately as unearned income.
+  represented in the model's capital base. Regulation 72(3) treats income
+  derived from capital that is yielding tariff income as part of capital rather
+  than a separate unearned-income reduction.
 metadata:
   economy: false
   label: Universal Credit capital-derived unearned income sources
@@ -15,3 +15,5 @@ metadata:
 values:
   2013-04-29:
     - savings_interest_income
+    - dividend_income
+    - property_income

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/unearned.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/unearned.yaml
@@ -11,10 +11,11 @@ metadata:
 
 
 values:
-  2010-01-01:
+  2013-04-29:
   - carers_allowance
   - jsa_contrib
   - private_pension_income
+  - uc_tariff_income
   - savings_interest_income
   - dividend_income
   - property_income

--- a/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/unearned.yaml
+++ b/policyengine_uk/parameters/gov/dwp/universal_credit/means_test/income_definitions/unearned.yaml
@@ -6,8 +6,10 @@ metadata:
   period: year
   unit: list
   reference:
-    - title: The Universal Credit Regulations 2013 sec. 66.
-      href: https://www.legislation.gov.uk/uksi/2013/376/data.pdf#page=64
+    - title: The Universal Credit Regulations 2013 reg. 66
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/66
+    - title: The Universal Credit Regulations 2013 reg. 72
+      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/72
 
 
 values:

--- a/policyengine_uk/tests/microsimulation/reforms_config.yaml
+++ b/policyengine_uk/tests/microsimulation/reforms_config.yaml
@@ -20,7 +20,7 @@ reforms:
   parameters:
     gov.hmrc.child_benefit.amount.additional: 25
 - name: Reduce Universal Credit taper rate to 20%
-  expected_impact: -41.9
+  expected_impact: -18.1
   tolerance: 3.0
   parameters:
     gov.dwp.universal_credit.means_test.reduction_rate: 0.2

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_income_reduction.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_income_reduction.yaml
@@ -38,7 +38,6 @@
     benunits:
       benunit:
         uc_earned_income: 0
-        uc_unearned_income: 0
         uc_maximum_amount: 5_000
         members: person
     households:

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_income_reduction.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_income_reduction.yaml
@@ -27,3 +27,23 @@
     uc_maximum_amount: 5_000
   output:
     uc_income_reduction: 950
+
+- name: Capital tariff income reduces Universal Credit
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        uc_earned_income: 0
+        uc_unearned_income: 0
+        uc_maximum_amount: 5_000
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_300
+  output:
+    uc_income_reduction: 8.70 * 12

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_tariff_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_tariff_income.yaml
@@ -1,0 +1,50 @@
+- name: No tariff income below the lower capital threshold
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_000
+  output:
+    uc_tariff_income: 0
+
+- name: Tariff income rounds capital up to the next step
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+  output:
+    uc_tariff_income: 4.35 * 12
+
+- name: Tariff income applies through the upper capital limit
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 16_000
+  output:
+    uc_tariff_income: 40 * 4.35 * 12

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_unearned_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_unearned_income.yaml
@@ -46,6 +46,124 @@
     uc_tariff_income: 4.35 * 12
     uc_unearned_income: 4.35 * 12
 
+- name: Dividend income is folded into capital when tariff income applies
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        dividend_income: 120
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+        corporate_wealth: 1
+  output:
+    uc_tariff_income: 4.35 * 12
+    uc_unearned_income: 4.35 * 12
+
+- name: Property income is folded into capital when tariff income applies
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        property_income: 120
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+        other_residential_property_value: 1
+  output:
+    uc_tariff_income: 4.35 * 12
+    uc_unearned_income: 4.35 * 12
+
+- name: Non-residential property income is folded into capital when tariff income applies
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        property_income: 120
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+        non_residential_property_value: 1
+  output:
+    uc_tariff_income: 4.35 * 12
+    uc_unearned_income: 4.35 * 12
+
+- name: Dividend income stays in unearned income without corporate wealth
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        dividend_income: 120
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+  output:
+    uc_tariff_income: 4.35 * 12
+    uc_unearned_income: 120 + 4.35 * 12
+
+- name: Property income stays in unearned income without countable property capital
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        property_income: 120
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+  output:
+    uc_tariff_income: 4.35 * 12
+    uc_unearned_income: 120 + 4.35 * 12
+
+- name: Main residence value alone does not suppress property income
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        property_income: 120
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+        main_residence_value: 1_000_000
+  output:
+    uc_tariff_income: 4.35 * 12
+    uc_unearned_income: 120 + 4.35 * 12
+
 - name: Reported capital drives tariff income for multi-benunit households
   period: 2025
   absolute_error_margin: 0.01
@@ -53,6 +171,7 @@
     people:
       person_1:
         age: 30
+        savings_interest_income: 120
       person_2:
         age: 32
     benunits:
@@ -68,3 +187,43 @@
   output:
     uc_tariff_income: [52.2, 0]
     uc_unearned_income: [52.2, 0]
+
+- name: Reported capital suppresses dividend income without household asset detail
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        dividend_income: 120
+    benunits:
+      benunit:
+        members: person
+        uc_reported_capital: 6_001
+    households:
+      household:
+        members: person
+        savings: 0
+  output:
+    uc_tariff_income: 52.2
+    uc_unearned_income: 52.2
+
+- name: Reported capital suppresses property income without household asset detail
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        property_income: 120
+    benunits:
+      benunit:
+        members: person
+        uc_reported_capital: 6_001
+    households:
+      household:
+        members: person
+        savings: 0
+  output:
+    uc_tariff_income: 52.2
+    uc_unearned_income: 52.2

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_unearned_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_unearned_income.yaml
@@ -45,3 +45,26 @@
   output:
     uc_tariff_income: 4.35 * 12
     uc_unearned_income: 4.35 * 12
+
+- name: Reported capital drives tariff income for multi-benunit households
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person_1:
+        age: 30
+      person_2:
+        age: 32
+    benunits:
+      benunit_1:
+        members: person_1
+        uc_reported_capital: 6_001
+      benunit_2:
+        members: person_2
+    households:
+      household:
+        members: [person_1, person_2]
+        savings: 0
+  output:
+    uc_tariff_income: [52.2, 0]
+    uc_unearned_income: [52.2, 0]

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_unearned_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_unearned_income.yaml
@@ -9,3 +9,39 @@
     dividend_income: 1
   output:
     uc_unearned_income: 11_111
+
+- name: Tariff income is exposed in unearned income
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+  output:
+    uc_unearned_income: 4.35 * 12
+
+- name: Savings interest is folded into capital when tariff income applies
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 30
+        savings_interest_income: 120
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 6_001
+  output:
+    uc_tariff_income: 4.35 * 12
+    uc_unearned_income: 4.35 * 12

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
@@ -62,6 +62,25 @@
   output:
     is_uc_eligible: false
 
+- name: Capital-derived income alone does not change the UC capital limit test
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        savings_interest_income: 20
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 15_990
+  output:
+    uc_assessable_capital: 15_990
+    is_uc_eligible: true
+
 - name: Multi-benunit households use benunit-reported capital
   period: 2025
   absolute_error_margin: 0
@@ -86,7 +105,7 @@
     uc_assessable_capital: [10_000, 10_000]
     is_uc_eligible: [true, true]
 
-- name: Multi-benunit households default household capital to the head benunit
+- name: Multi-benunit households split proxy capital equally across adults
   period: 2025
   absolute_error_margin: 0
   input:
@@ -105,8 +124,8 @@
         members: [person_1, person_2]
         savings: 20_000
   output:
-    uc_assessable_capital: [20_000, 0]
-    is_uc_eligible: [false, true]
+    uc_assessable_capital: [10_000, 10_000]
+    is_uc_eligible: [true, true]
 
 - name: Reported capital can still exceed the upper threshold
   period: 2025
@@ -132,26 +151,136 @@
     uc_assessable_capital: [20_000, 20_000]
     is_uc_eligible: [false, false]
 
-- name: Savings interest can push capital over the upper threshold
+- name: Mixed reported and unreported benunits use residual household capital
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person_1:
+        age: 32
+      person_2:
+        age: 30
+    benunits:
+      benunit_1:
+        members: person_1
+        uc_reported_capital: 12_000
+      benunit_2:
+        members: person_2
+    households:
+      household:
+        members: [person_1, person_2]
+        savings: 20_000
+  output:
+    uc_assessable_capital: [12_000, 8_000]
+    is_uc_eligible: [true, true]
+
+- name: Multi-benunit proxy capital is weighted by adults in each benunit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person_1:
+        age: 40
+      person_2:
+        age: 38
+      person_3:
+        age: 30
+    benunits:
+      benunit_1:
+        members: [person_1, person_2]
+      benunit_2:
+        members: person_3
+    households:
+      household:
+        members: [person_1, person_2, person_3]
+        savings: 30_000
+  output:
+    uc_assessable_capital: [20_000, 10_000]
+    is_uc_eligible: [false, true]
+
+- name: Mixed claimant and pensioner benunits share the residual household proxy
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      claimant:
+        age: 30
+      pensioner:
+        age: 70
+    benunits:
+      claimant_benunit:
+        members: claimant
+      pensioner_benunit:
+        members: pensioner
+    households:
+      household:
+        members: [claimant, pensioner]
+        savings: 20_000
+  output:
+    uc_assessable_capital: [10_000, 10_000]
+    is_uc_eligible: [true, false]
+
+- name: Reported zero capital overrides the household proxy
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person_1:
+        age: 32
+      person_2:
+        age: 30
+    benunits:
+      benunit_1:
+        members: person_1
+        uc_reported_capital: 0
+      benunit_2:
+        members: person_2
+        uc_reported_capital: 20_000
+    households:
+      household:
+        members: [person_1, person_2]
+        savings: 20_000
+  output:
+    uc_assessable_capital: [0, 20_000]
+    is_uc_eligible: [true, false]
+
+- name: Countable other residential property can push capital over the upper threshold
   period: 2025
   absolute_error_margin: 0
   input:
     people:
       person:
         age: 30
-        savings_interest_income: 20
     benunits:
       benunit:
         members: person
     households:
       household:
         members: person
-        savings: 15_990
+        other_residential_property_value: 50_000
   output:
-    uc_assessable_capital: 16_010
+    uc_assessable_capital: 50_000
     is_uc_eligible: false
 
-- name: Corporate wealth can push capital over the upper threshold
+- name: Countable non-residential property can push capital over the upper threshold
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        non_residential_property_value: 50_000
+  output:
+    uc_assessable_capital: 50_000
+    is_uc_eligible: false
+
+- name: Countable corporate wealth can push capital over the upper threshold
   period: 2025
   absolute_error_margin: 0
   input:
@@ -168,3 +297,21 @@
   output:
     uc_assessable_capital: 50_000
     is_uc_eligible: false
+
+- name: Main residence value is excluded from Universal Credit capital
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        main_residence_value: 1_000_000
+  output:
+    uc_assessable_capital: 0
+    is_uc_eligible: true

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
@@ -62,7 +62,7 @@
   output:
     is_uc_eligible: false
 
-- name: Household capital is apportioned across benunits
+- name: Multi-benunit households use benunit-reported capital
   period: 2025
   absolute_error_margin: 0
   input:
@@ -71,6 +71,30 @@
         age: 30
       person_2:
         age: 32
+    benunits:
+      benunit_1:
+        members: person_1
+        uc_reported_capital: 10_000
+      benunit_2:
+        members: person_2
+        uc_reported_capital: 10_000
+    households:
+      household:
+        members: [person_1, person_2]
+        savings: 20_000
+  output:
+    uc_assessable_capital: [10_000, 10_000]
+    is_uc_eligible: [true, true]
+
+- name: Multi-benunit households default household capital to the head benunit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person_1:
+        age: 32
+      person_2:
+        age: 30
     benunits:
       benunit_1:
         members: person_1
@@ -81,23 +105,25 @@
         members: [person_1, person_2]
         savings: 20_000
   output:
-    uc_assessable_capital: [10_000, 10_000]
-    is_uc_eligible: [true, true]
+    uc_assessable_capital: [20_000, 0]
+    is_uc_eligible: [false, true]
 
-- name: Apportioned capital can still exceed the upper threshold
+- name: Reported capital can still exceed the upper threshold
   period: 2025
   absolute_error_margin: 0
   input:
     people:
       person_1:
-        age: 30
-      person_2:
         age: 32
+      person_2:
+        age: 30
     benunits:
       benunit_1:
         members: person_1
+        uc_reported_capital: 20_000
       benunit_2:
         members: person_2
+        uc_reported_capital: 20_000
     households:
       household:
         members: [person_1, person_2]
@@ -105,3 +131,40 @@
   output:
     uc_assessable_capital: [20_000, 20_000]
     is_uc_eligible: [false, false]
+
+- name: Savings interest can push capital over the upper threshold
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        savings_interest_income: 20
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 15_990
+  output:
+    uc_assessable_capital: 16_010
+    is_uc_eligible: false
+
+- name: Corporate wealth can push capital over the upper threshold
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        corporate_wealth: 50_000
+  output:
+    uc_assessable_capital: 50_000
+    is_uc_eligible: false

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
@@ -61,3 +61,47 @@
         savings: 16_001
   output:
     is_uc_eligible: false
+
+- name: Household capital is apportioned across benunits
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person_1:
+        age: 30
+      person_2:
+        age: 32
+    benunits:
+      benunit_1:
+        members: person_1
+      benunit_2:
+        members: person_2
+    households:
+      household:
+        members: [person_1, person_2]
+        savings: 20_000
+  output:
+    uc_assessable_capital: [10_000, 10_000]
+    is_uc_eligible: [true, true]
+
+- name: Apportioned capital can still exceed the upper threshold
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person_1:
+        age: 30
+      person_2:
+        age: 32
+    benunits:
+      benunit_1:
+        members: person_1
+      benunit_2:
+        members: person_2
+    households:
+      household:
+        members: [person_1, person_2]
+        savings: 40_000
+  output:
+    uc_assessable_capital: [20_000, 20_000]
+    is_uc_eligible: [false, false]

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml
@@ -27,3 +27,37 @@
         members: [person_1, person_2]
   output:
     is_uc_eligible: true
+
+- name: Working-age adult remains eligible at the upper capital limit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 16_000
+  output:
+    is_uc_eligible: true
+
+- name: Working-age adult is ineligible above the upper capital limit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 16_001
+  output:
+    is_uc_eligible: false

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/universal_credit.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/universal_credit.yaml
@@ -8,3 +8,21 @@
     is_uc_eligible: true
   output:
     universal_credit: 1000 - 100
+
+- name: Capital above the upper limit removes Universal Credit entitlement
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 16_001
+  output:
+    universal_credit_pre_benefit_cap: 0
+    universal_credit: 0

--- a/policyengine_uk/variables/gov/dwp/universal_credit/household_uc_reported_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/household_uc_reported_capital.py
@@ -1,0 +1,18 @@
+from policyengine_uk.model_api import *
+
+
+class household_uc_reported_capital(Variable):
+    value_type = float
+    entity = Household
+    label = "Household Universal Credit capital explicitly reported by benunits"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(household, period, parameters):
+        person = household.members
+        reported_capital = person.benunit("uc_reported_capital", period)
+        has_reported_capital = reported_capital >= 0
+        is_benunit_head = person("is_benunit_head", period)
+        return household.sum(
+            reported_capital * has_reported_capital * is_benunit_head
+        )

--- a/policyengine_uk/variables/gov/dwp/universal_credit/household_uc_reported_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/household_uc_reported_capital.py
@@ -13,6 +13,4 @@ class household_uc_reported_capital(Variable):
         reported_capital = person.benunit("uc_reported_capital", period)
         has_reported_capital = reported_capital >= 0
         is_benunit_head = person("is_benunit_head", period)
-        return household.sum(
-            reported_capital * has_reported_capital * is_benunit_head
-        )
+        return household.sum(reported_capital * has_reported_capital * is_benunit_head)

--- a/policyengine_uk/variables/gov/dwp/universal_credit/household_uc_unreported_adults.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/household_uc_unreported_adults.py
@@ -1,0 +1,21 @@
+from policyengine_uk.model_api import *
+
+
+class household_uc_unreported_adults(Variable):
+    value_type = int
+    entity = Household
+    label = "Number of adults in benunits without reported UC capital"
+    documentation = (
+        "Adults counted in the residual household-capital proxy for Universal "
+        "Credit, including adults in non-claimant benunits when capital "
+        "ownership cannot be identified."
+    )
+    definition_period = YEAR
+    unit = "adult"
+
+    def formula(household, period, parameters):
+        person = household.members
+        reported_capital = person.benunit("uc_reported_capital", period)
+        has_reported_capital = reported_capital >= 0
+        is_adult = person("is_adult", period)
+        return household.sum(is_adult * ~has_reported_capital)

--- a/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_income_reduction.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_income_reduction.py
@@ -14,11 +14,8 @@ class uc_income_reduction(Variable):
         earned_income = benunit("uc_earned_income", period)
         earned_income_reduction = p.reduction_rate * earned_income
         unearned_income_reduction = benunit("uc_unearned_income", period)
-        capital_tariff_income = benunit("uc_tariff_income", period)
         maximum_credit = benunit("uc_maximum_amount", period)
-        total_reduction = (
-            earned_income_reduction + unearned_income_reduction + capital_tariff_income
-        )
+        total_reduction = earned_income_reduction + unearned_income_reduction
         return min_(
             maximum_credit,
             total_reduction,

--- a/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_income_reduction.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_income_reduction.py
@@ -14,8 +14,11 @@ class uc_income_reduction(Variable):
         earned_income = benunit("uc_earned_income", period)
         earned_income_reduction = p.reduction_rate * earned_income
         unearned_income_reduction = benunit("uc_unearned_income", period)
+        capital_tariff_income = benunit("uc_tariff_income", period)
         maximum_credit = benunit("uc_maximum_amount", period)
-        total_reduction = earned_income_reduction + unearned_income_reduction
+        total_reduction = (
+            earned_income_reduction + unearned_income_reduction + capital_tariff_income
+        )
         return min_(
             maximum_credit,
             total_reduction,

--- a/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_tariff_income.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_tariff_income.py
@@ -1,0 +1,18 @@
+from policyengine_uk.model_api import *
+
+
+class uc_tariff_income(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Universal Credit tariff income from capital"
+    documentation = "Monthly tariff income from capital annualised to the model period."
+    definition_period = YEAR
+    unit = GBP
+    defined_for = "is_uc_eligible"
+
+    def formula(benunit, period, parameters):
+        capital = benunit("uc_assessable_capital", period)
+        p = parameters(period).gov.dwp.universal_credit.means_test.capital
+        excess_capital = max_(0, capital - p.lower_threshold)
+        steps = np.ceil(excess_capital / p.tariff_income.step)
+        return steps * p.tariff_income.amount * MONTHS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_unearned_income.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_unearned_income.py
@@ -10,9 +10,20 @@ class uc_unearned_income(Variable):
 
     def formula(benunit, period, parameters):
         p = parameters(period).gov.dwp.universal_credit.means_test
+        household = benunit.household
         total = add(benunit, period, p.income_definitions.unearned)
         tariff_income_applies = benunit("uc_tariff_income", period) > 0
-        capital_derived_income = add(
-            benunit, period, p.income_definitions.capital_derived
+        reported_capital = benunit("uc_reported_capital", period)
+        has_reported_capital = reported_capital >= 0
+        property_capital = household(
+            "other_residential_property_value", period
+        ) + household("non_residential_property_value", period)
+        capital_derived_income = (
+            ((household("savings", period) > 0) | has_reported_capital)
+            * benunit("savings_interest_income", period)
+            + ((household("corporate_wealth", period) > 0) | has_reported_capital)
+            * benunit("dividend_income", period)
+            + ((property_capital > 0) | has_reported_capital)
+            * benunit("property_income", period)
         )
         return total - tariff_income_applies * capital_derived_income

--- a/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_unearned_income.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/income/uc_unearned_income.py
@@ -8,4 +8,11 @@ class uc_unearned_income(Variable):
     definition_period = YEAR
     unit = GBP
 
-    adds = "gov.dwp.universal_credit.means_test.income_definitions.unearned"
+    def formula(benunit, period, parameters):
+        p = parameters(period).gov.dwp.universal_credit.means_test
+        total = add(benunit, period, p.income_definitions.unearned)
+        tariff_income_applies = benunit("uc_tariff_income", period) > 0
+        capital_derived_income = add(
+            benunit, period, p.income_definitions.capital_derived
+        )
+        return total - tariff_income_applies * capital_derived_income

--- a/policyengine_uk/variables/gov/dwp/universal_credit/is_uc_eligible.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/is_uc_eligible.py
@@ -9,4 +9,9 @@ class is_uc_eligible(Variable):
     definition_period = YEAR
 
     def formula(benunit, period, parameters):
-        return benunit.any(benunit.members("is_WA_adult", period))
+        capital = benunit("uc_assessable_capital", period)
+        upper_threshold = parameters(
+            period
+        ).gov.dwp.universal_credit.means_test.capital.upper_threshold
+        has_working_age_adult = benunit.any(benunit.members("is_WA_adult", period))
+        return has_working_age_adult & (capital <= upper_threshold)

--- a/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
@@ -6,11 +6,15 @@ class uc_assessable_capital(Variable):
     entity = BenUnit
     label = "Universal Credit assessable capital"
     documentation = (
-        "PolicyEngine UK's current proxy for Universal Credit assessable capital, "
-        "using household liquid savings."
+        "Universal Credit capital counted from the configured household asset "
+        "sources under the current model."
     )
     definition_period = YEAR
     unit = GBP
 
     def formula(benunit, period, parameters):
-        return max_(0, benunit.household("savings", period))
+        household = benunit.household
+        sources = parameters(period).gov.dwp.universal_credit.means_test.capital.sources
+        total_capital = add(household, period, sources)
+        num_benunits = max_(1, household("household_num_benunits", period))
+        return max_(0, total_capital / num_benunits)

--- a/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
@@ -1,0 +1,16 @@
+from policyengine_uk.model_api import *
+
+
+class uc_assessable_capital(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Universal Credit assessable capital"
+    documentation = (
+        "PolicyEngine UK's current proxy for Universal Credit assessable capital, "
+        "using household liquid savings."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        return max_(0, benunit.household("savings", period))

--- a/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
@@ -17,9 +17,7 @@ class uc_assessable_capital(Variable):
         p = parameters(period).gov.dwp.universal_credit.means_test
         household_capital = add(household, period, p.capital.sources)
         benunit_adults = add(benunit, period, ["is_adult"])
-        household_reported_capital = household(
-            "household_uc_reported_capital", period
-        )
+        household_reported_capital = household("household_uc_reported_capital", period)
         household_unreported_adults = household(
             "household_uc_unreported_adults", period
         )

--- a/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
@@ -14,7 +14,28 @@ class uc_assessable_capital(Variable):
 
     def formula(benunit, period, parameters):
         household = benunit.household
-        sources = parameters(period).gov.dwp.universal_credit.means_test.capital.sources
-        total_capital = add(household, period, sources)
-        num_benunits = max_(1, household("household_num_benunits", period))
-        return max_(0, total_capital / num_benunits)
+        p = parameters(period).gov.dwp.universal_credit.means_test
+        sources = p.capital.sources
+        capital_derived_income = add(
+            benunit,
+            period,
+            p.income_definitions.capital_derived,
+        )
+        household_capital = add(household, period, sources)
+        single_benunit_household = household("household_num_benunits", period) == 1
+        household_head_benunit = benunit.any(
+            benunit.members("is_household_head", period)
+        )
+        reported_capital = benunit("uc_reported_capital", period)
+        use_reported_capital = reported_capital > 0
+        household_capital_proxy = household_capital + capital_derived_income
+        assessed_capital = where(
+            use_reported_capital,
+            reported_capital,
+            where(
+                single_benunit_household | household_head_benunit,
+                household_capital_proxy,
+                0,
+            ),
+        )
+        return max_(0, assessed_capital)

--- a/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/uc_assessable_capital.py
@@ -6,8 +6,8 @@ class uc_assessable_capital(Variable):
     entity = BenUnit
     label = "Universal Credit assessable capital"
     documentation = (
-        "Universal Credit capital counted from the configured household asset "
-        "sources under the current model."
+        "Universal Credit capital counted from the configured capital sources, "
+        "with benunit-reported overrides when available."
     )
     definition_period = YEAR
     unit = GBP
@@ -15,27 +15,28 @@ class uc_assessable_capital(Variable):
     def formula(benunit, period, parameters):
         household = benunit.household
         p = parameters(period).gov.dwp.universal_credit.means_test
-        sources = p.capital.sources
-        capital_derived_income = add(
-            benunit,
-            period,
-            p.income_definitions.capital_derived,
+        household_capital = add(household, period, p.capital.sources)
+        benunit_adults = add(benunit, period, ["is_adult"])
+        household_reported_capital = household(
+            "household_uc_reported_capital", period
         )
-        household_capital = add(household, period, sources)
-        single_benunit_household = household("household_num_benunits", period) == 1
-        household_head_benunit = benunit.any(
-            benunit.members("is_household_head", period)
+        household_unreported_adults = household(
+            "household_uc_unreported_adults", period
         )
+        adult_divisor = max_(1, household_unreported_adults)
         reported_capital = benunit("uc_reported_capital", period)
-        use_reported_capital = reported_capital > 0
-        household_capital_proxy = household_capital + capital_derived_income
+        use_reported_capital = reported_capital >= 0
+        residual_household_capital = max_(
+            0, household_capital - household_reported_capital
+        )
+        household_capital_proxy = where(
+            household_unreported_adults > 0,
+            residual_household_capital * benunit_adults / adult_divisor,
+            0,
+        )
         assessed_capital = where(
             use_reported_capital,
             reported_capital,
-            where(
-                single_benunit_household | household_head_benunit,
-                household_capital_proxy,
-                0,
-            ),
+            household_capital_proxy,
         )
         return max_(0, assessed_capital)

--- a/policyengine_uk/variables/gov/dwp/universal_credit/uc_reported_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/uc_reported_capital.py
@@ -1,0 +1,13 @@
+from policyengine_uk.model_api import *
+
+
+class uc_reported_capital(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "reported Universal Credit capital"
+    documentation = (
+        "Claimant-level capital for Universal Credit when household-level asset "
+        "data cannot be attributed across multiple benefit units."
+    )
+    definition_period = YEAR
+    unit = GBP

--- a/policyengine_uk/variables/gov/dwp/universal_credit/uc_reported_capital.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/uc_reported_capital.py
@@ -7,7 +7,9 @@ class uc_reported_capital(Variable):
     label = "reported Universal Credit capital"
     documentation = (
         "Claimant-level capital for Universal Credit when household-level asset "
-        "data cannot be attributed across multiple benefit units."
+        "data cannot be attributed across multiple benefit units. Set to 0 to "
+        "explicitly override the household proxy with zero assessable capital."
     )
     definition_period = YEAR
     unit = GBP
+    default_value = -1

--- a/policyengine_uk/variables/input/main_residence_value.py
+++ b/policyengine_uk/variables/input/main_residence_value.py
@@ -3,7 +3,10 @@ from policyengine_uk.model_api import *
 
 class main_residence_value(Variable):
     label = "main residence value"
-    documentation = "Total value of the main residence"
+    documentation = (
+        "Total value of the main residence, which is excluded from Universal "
+        "Credit capital under Schedule 10 paragraph 1"
+    )
     entity = Household
     definition_period = YEAR
     value_type = float

--- a/policyengine_uk/variables/input/non_residential_property_value.py
+++ b/policyengine_uk/variables/input/non_residential_property_value.py
@@ -3,7 +3,12 @@ from policyengine_uk.model_api import *
 
 class non_residential_property_value(Variable):
     label = "non-residential property value"
-    documentation = "Total value of all non-residential property owned by the household"
+    documentation = (
+        "Total value of non-residential property owned by the household, before "
+        "any additional Universal Credit Schedule 10 disregards within this "
+        "broad asset class that are not separately split out in the current "
+        "dataset"
+    )
     entity = Household
     definition_period = YEAR
     value_type = float

--- a/policyengine_uk/variables/input/other_residential_property_value.py
+++ b/policyengine_uk/variables/input/other_residential_property_value.py
@@ -3,7 +3,12 @@ from policyengine_uk.model_api import *
 
 class other_residential_property_value(Variable):
     label = "other residence value"
-    documentation = "Total value of all residential property owned by the household"
+    documentation = (
+        "Total value of residential property owned by the household other than "
+        "the main residence, before any additional Universal Credit Schedule "
+        "10 disregards within this broad asset class that are not separately "
+        "split out in the current dataset"
+    )
     entity = Household
     definition_period = YEAR
     value_type = float


### PR DESCRIPTION
## Summary
- add UC capital thresholds and tariff-income parameters
- proxy UC assessable capital from household liquid savings
- reduce UC entitlement for tariff income and disqualify benunits above the upper capital limit
- add YAML regression coverage for the lower threshold, upper threshold, and end-to-end UC effect

## Verification
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_UC_eligible.yaml -c policyengine_uk`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_tariff_income.yaml -c policyengine_uk`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/income/uc_income_reduction.yaml -c policyengine_uk`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/universal_credit.yaml -c policyengine_uk`
- `uv run python -m pytest -q policyengine_uk/tests`
- `uvx ruff check`
- `uvx ruff format --check`

## Caveat
This uses household `savings` as the current proxy for UC assessable capital. It does not yet model more detailed capital disregards or managed-migration transitional protections.