### PR TITLE
Add Housing Benefit capital rules and tariff income

### DIFF
--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/lower_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/lower_threshold.yaml
@@ -1,0 +1,10 @@
+description: Standard pension-age Housing Benefit lower capital threshold.
+metadata:
+  label: Pension-age Housing Benefit lower capital threshold
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: The Housing Benefit (Persons who have attained the qualifying age for state pension credit) Regulations 2006 reg. 29(2)
+      href: https://www.legislation.gov.uk/uksi/2006/214/regulation/29
+values:
+  2006-04-10: 10000

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/tariff_income/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/tariff_income/amount.yaml
@@ -1,0 +1,10 @@
+description: Weekly pension-age Housing Benefit tariff income for each capital step above the lower threshold.
+metadata:
+  label: Pension-age Housing Benefit weekly tariff income per capital step
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: The Housing Benefit (Persons who have attained the qualifying age for state pension credit) Regulations 2006 reg. 29(2)
+      href: https://www.legislation.gov.uk/uksi/2006/214/regulation/29
+values:
+  2006-04-10: 1

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/tariff_income/step.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/tariff_income/step.yaml
@@ -1,0 +1,10 @@
+description: Pension-age Housing Benefit capital step used to calculate tariff income.
+metadata:
+  label: Pension-age Housing Benefit capital step for tariff income
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: The Housing Benefit (Persons who have attained the qualifying age for state pension credit) Regulations 2006 reg. 29(2)
+      href: https://www.legislation.gov.uk/uksi/2006/214/regulation/29
+values:
+  2006-04-10: 500

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/upper_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/pension_age/upper_threshold.yaml
@@ -1,0 +1,10 @@
+description: Pension-age Housing Benefit upper capital threshold.
+metadata:
+  label: Pension-age Housing Benefit upper capital threshold
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: The Housing Benefit (Persons who have attained the qualifying age for state pension credit) Regulations 2006 reg. 43
+      href: https://www.legislation.gov.uk/uksi/2006/214/regulation/43
+values:
+  2006-04-10: 16000

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/sources.yaml
@@ -2,14 +2,17 @@ description: >
   Model variables currently mapped to countable Housing Benefit capital.
   The Housing Benefit Regulations 2006 treat the whole of a claimant's capital
   as assessable unless it is disregarded under Schedule 6. The current mappings
-  are `savings` for liquid capital, `other_residential_property_value` for
-  residential property other than the home, `non_residential_property_value`
-  for other land and premises, and `corporate_wealth` for shares and similar
-  investment assets. `main_residence_value` is excluded because Schedule 6
-  paragraph 1 disregards premises occupied as the claimant's home. Other
-  Schedule 6 disregards within these broad asset classes are not yet split out
-  separately. Because the dataset only provides household-level capital stocks,
-  the model allocates them across benunits using an adult-share proxy.
+  are `savings` for liquid capital, `owned_land` for land held directly,
+  `other_residential_property_value` for residential property other than the
+  home, and `non_residential_property_value` for other land and premises.
+  `main_residence_value` is excluded because Schedule 6 paragraph 1 disregards
+  premises occupied as the claimant's home. `corporate_wealth` is also
+  excluded for now because the current dataset definition bundles pension pots
+  together with shares and investment ISAs, and Housing Benefit pension-capital
+  treatment is not separately modelled yet. Other Schedule 6 disregards within
+  these broad asset classes are not yet split out separately. Because the
+  dataset only provides household-level capital stocks, the model allocates
+  them across benunits using an adult-share proxy.
 metadata:
   label: Housing Benefit countable capital sources
   period: year
@@ -26,6 +29,6 @@ metadata:
 values:
   2006-04-10:
     - savings
+    - owned_land
     - other_residential_property_value
     - non_residential_property_value
-    - corporate_wealth

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/sources.yaml
@@ -1,0 +1,31 @@
+description: >
+  Model variables currently mapped to countable Housing Benefit capital.
+  The Housing Benefit Regulations 2006 treat the whole of a claimant's capital
+  as assessable unless it is disregarded under Schedule 6. The current mappings
+  are `savings` for liquid capital, `other_residential_property_value` for
+  residential property other than the home, `non_residential_property_value`
+  for other land and premises, and `corporate_wealth` for shares and similar
+  investment assets. `main_residence_value` is excluded because Schedule 6
+  paragraph 1 disregards premises occupied as the claimant's home. Other
+  Schedule 6 disregards within these broad asset classes are not yet split out
+  separately. Because the dataset only provides household-level capital stocks,
+  the model allocates them across benunits using an adult-share proxy.
+metadata:
+  label: Housing Benefit countable capital sources
+  period: year
+  unit: list
+  reference:
+    - title: The Housing Benefit Regulations 2006 reg. 44(1)
+      href: https://www.legislation.gov.uk/uksi/2006/213/regulation/44
+    - title: The Housing Benefit Regulations 2006 Schedule 6 para. 1
+      href: https://www.legislation.gov.uk/uksi/2006/213/schedule/6/paragraph/1
+    - title: The Housing Benefit (Persons who have attained the qualifying age for state pension credit) Regulations 2006 reg. 44(1)
+      href: https://www.legislation.gov.uk/uksi/2006/214/regulation/44
+    - title: The Housing Benefit (Persons who have attained the qualifying age for state pension credit) Regulations 2006 Schedule 6 para. 1
+      href: https://www.legislation.gov.uk/uksi/2006/214/schedule/6/paragraph/1
+values:
+  2006-04-10:
+    - savings
+    - other_residential_property_value
+    - non_residential_property_value
+    - corporate_wealth

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/sources.yaml
@@ -3,13 +3,16 @@ description: >
   The Housing Benefit Regulations 2006 treat the whole of a claimant's capital
   as assessable unless it is disregarded under Schedule 6. The current mappings
   are `savings` for liquid capital, `owned_land` for land held directly,
+  `corporate_wealth` as the broad available proxy for share-like financial
+  assets such as stocks, shares, unit trusts, and investment ISAs,
   `other_residential_property_value` for residential property other than the
   home, and `non_residential_property_value` for other land and premises.
   `main_residence_value` is excluded because Schedule 6 paragraph 1 disregards
-  premises occupied as the claimant's home. `corporate_wealth` is also
-  excluded for now because the current dataset definition bundles pension pots
-  together with shares and investment ISAs, and Housing Benefit pension-capital
-  treatment is not separately modelled yet. Other Schedule 6 disregards within
+  premises occupied as the claimant's home. The current dataset definition for
+  `corporate_wealth` also bundles private pension wealth together with those
+  countable assets; the model currently includes that mixed bucket rather than
+  omitting share-like financial wealth entirely, so pension-capital treatment
+  remains an unresolved data limitation. Other Schedule 6 disregards within
   these broad asset classes are not yet split out separately. Because the
   dataset only provides household-level capital stocks, the model allocates
   them across benunits using an adult-share proxy.
@@ -30,5 +33,6 @@ values:
   2006-04-10:
     - savings
     - owned_land
+    - corporate_wealth
     - other_residential_property_value
     - non_residential_property_value

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/lower_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/lower_threshold.yaml
@@ -1,0 +1,10 @@
+description: Standard working-age Housing Benefit lower capital threshold.
+metadata:
+  label: Working-age Housing Benefit lower capital threshold
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: Explanatory Memorandum to the Social Security (Miscellaneous Amendments) Regulations 2005 para. 7.2
+      href: https://www.legislation.gov.uk/uksi/2005/2465/pdfs/uksiem_20052465_en.pdf
+values:
+  2006-04-10: 6000

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/tariff_income/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/tariff_income/amount.yaml
@@ -1,0 +1,10 @@
+description: Weekly working-age Housing Benefit tariff income for each capital step above the lower threshold.
+metadata:
+  label: Working-age Housing Benefit weekly tariff income per capital step
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: The Housing Benefit Regulations 2006 reg. 52(6)
+      href: https://www.legislation.gov.uk/uksi/2006/213/regulation/52
+values:
+  2006-04-10: 1

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/tariff_income/step.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/tariff_income/step.yaml
@@ -1,0 +1,10 @@
+description: Working-age Housing Benefit capital step used to calculate tariff income.
+metadata:
+  label: Working-age Housing Benefit capital step for tariff income
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: The Housing Benefit Regulations 2006 reg. 52(6)
+      href: https://www.legislation.gov.uk/uksi/2006/213/regulation/52
+values:
+  2006-04-10: 250

--- a/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/upper_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital/working_age/upper_threshold.yaml
@@ -1,0 +1,12 @@
+description: Standard working-age Housing Benefit upper capital threshold.
+metadata:
+  label: Working-age Housing Benefit upper capital threshold
+  period: year
+  unit: currency-GBP
+  reference:
+    - title: The Housing Benefit Regulations 2006 reg. 43
+      href: https://www.legislation.gov.uk/uksi/2006/213/regulation/43
+    - title: Explanatory Memorandum to the Social Security (Miscellaneous Amendments) Regulations 2005 para. 7.2
+      href: https://www.legislation.gov.uk/uksi/2005/2465/pdfs/uksiem_20052465_en.pdf
+values:
+  2006-04-10: 16000

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_capital.yaml
@@ -108,7 +108,7 @@
     housing_benefit_assessable_capital: 16_001
     housing_benefit_eligible: false
 
-- name: Housing Benefit ignores pension-blended corporate wealth until it is split from pensions
+- name: Housing Benefit counts corporate wealth as a broad financial-capital proxy
   period: 2025
   absolute_error_margin: 0
   input:
@@ -126,8 +126,8 @@
         members: person
         corporate_wealth: 50_000
   output:
-    housing_benefit_assessable_capital: 0
-    housing_benefit_eligible: true
+    housing_benefit_assessable_capital: 50_000
+    housing_benefit_eligible: false
 
 - name: Mixed benunits split household Housing Benefit capital by adult share
   period: 2025
@@ -198,6 +198,28 @@
     housing_benefit_tariff_income: 52
     housing_benefit_applicable_income: 52
     housing_benefit_eligible: true
+
+- name: Pension-age Housing Benefit is ineligible above the upper capital limit without Guarantee Credit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 70
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        guarantee_credit: 0
+        would_claim_uc: false
+    households:
+      household:
+        members: person
+        savings: 16_001
+  output:
+    housing_benefit_assessable_capital: 16_001
+    housing_benefit_eligible: false
 
 - name: Guarantee Credit passports Housing Benefit income and capital
   period: 2025

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_capital.yaml
@@ -1,0 +1,137 @@
+- name: Working-age Housing Benefit remains eligible at the upper capital limit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        would_claim_uc: false
+    households:
+      household:
+        members: person
+        savings: 16_000
+  output:
+    housing_benefit_assessable_capital: 16_000
+    housing_benefit_eligible: true
+
+- name: Working-age Housing Benefit is ineligible above the upper capital limit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        would_claim_uc: false
+    households:
+      household:
+        members: person
+        savings: 16_001
+  output:
+    housing_benefit_assessable_capital: 16_001
+    housing_benefit_eligible: false
+
+- name: Working-age Housing Benefit tariff income rounds incomplete capital steps up
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        would_claim_uc: false
+        housing_benefit_applicable_income_disregard: 0
+        housing_benefit_applicable_income_childcare_element: 0
+    households:
+      household:
+        members: person
+        savings: 6_001
+  output:
+    housing_benefit_tariff_income: 52
+    housing_benefit_applicable_income: 52
+
+- name: Mixed benunits split household Housing Benefit capital by adult share
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person_1:
+        age: 32
+      person_2:
+        age: 30
+    benunits:
+      benunit_1:
+        members: person_1
+      benunit_2:
+        members: person_2
+    households:
+      household:
+        members: [person_1, person_2]
+        savings: 20_000
+  output:
+    housing_benefit_assessable_capital: [10_000, 10_000]
+
+- name: Pension-age Housing Benefit uses the £500 tariff-income step above £10,000
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 70
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        guarantee_credit: 0
+        would_claim_uc: false
+        housing_benefit_applicable_income_disregard: 0
+        housing_benefit_applicable_income_childcare_element: 0
+    households:
+      household:
+        members: person
+        savings: 10_001
+  output:
+    housing_benefit_tariff_income: 52
+    housing_benefit_applicable_income: 52
+    housing_benefit_eligible: true
+
+- name: Guarantee Credit passports Housing Benefit income and capital
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 70
+        in_social_housing: true
+        housing_benefit_reported: 1
+        private_pension_income: 10_000
+    benunits:
+      benunit:
+        members: person
+        guarantee_credit: 1
+        would_claim_uc: false
+        housing_benefit_applicable_income_disregard: 0
+        housing_benefit_applicable_income_childcare_element: 0
+    households:
+      household:
+        members: person
+        savings: 50_000
+  output:
+    housing_benefit_assessable_capital: 0
+    housing_benefit_tariff_income: 0
+    housing_benefit_applicable_income: 0
+    housing_benefit_eligible: true

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_capital.yaml
@@ -17,6 +17,7 @@
         savings: 16_000
   output:
     housing_benefit_assessable_capital: 16_000
+    housing_benefit_tariff_income: 2_080
     housing_benefit_eligible: true
 
 - name: Working-age Housing Benefit is ineligible above the upper capital limit
@@ -39,6 +40,29 @@
   output:
     housing_benefit_assessable_capital: 16_001
     housing_benefit_eligible: false
+
+- name: Working-age Housing Benefit has no tariff income at the lower capital disregard
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        would_claim_uc: false
+        housing_benefit_applicable_income_disregard: 0
+        housing_benefit_applicable_income_childcare_element: 0
+    households:
+      household:
+        members: person
+        savings: 6_000
+  output:
+    housing_benefit_tariff_income: 0
+    housing_benefit_applicable_income: 0
 
 - name: Working-age Housing Benefit tariff income rounds incomplete capital steps up
   period: 2025
@@ -63,6 +87,48 @@
     housing_benefit_tariff_income: 52
     housing_benefit_applicable_income: 52
 
+- name: Housing Benefit counts direct land holdings as capital
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        would_claim_uc: false
+    households:
+      household:
+        members: person
+        owned_land: 16_001
+  output:
+    housing_benefit_assessable_capital: 16_001
+    housing_benefit_eligible: false
+
+- name: Housing Benefit ignores pension-blended corporate wealth until it is split from pensions
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 30
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        would_claim_uc: false
+    households:
+      household:
+        members: person
+        corporate_wealth: 50_000
+  output:
+    housing_benefit_assessable_capital: 0
+    housing_benefit_eligible: true
+
 - name: Mixed benunits split household Housing Benefit capital by adult share
   period: 2025
   absolute_error_margin: 0
@@ -83,6 +149,30 @@
         savings: 20_000
   output:
     housing_benefit_assessable_capital: [10_000, 10_000]
+
+- name: Pension-age Housing Benefit has no tariff income at the capital disregard
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person:
+        age: 70
+        in_social_housing: true
+        housing_benefit_reported: 1
+    benunits:
+      benunit:
+        members: person
+        guarantee_credit: 0
+        would_claim_uc: false
+        housing_benefit_applicable_income_disregard: 0
+        housing_benefit_applicable_income_childcare_element: 0
+    households:
+      household:
+        members: person
+        savings: 10_000
+  output:
+    housing_benefit_tariff_income: 0
+    housing_benefit_applicable_income: 0
 
 - name: Pension-age Housing Benefit uses the £500 tariff-income step above £10,000
   period: 2025

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_applicable_income.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_applicable_income.py
@@ -9,6 +9,7 @@ class housing_benefit_applicable_income(Variable):
     unit = GBP
 
     def formula(benunit, period, parameters):
+        any_over_SP_age = benunit.any(benunit.members("is_SP_age", period))
         BENUNIT_MEANS_TESTED_BENEFITS = [
             "child_benefit",
             "income_support",
@@ -49,13 +50,17 @@ class housing_benefit_applicable_income(Variable):
         increased_income_reduced_by_tax_and_pensions = (
             increased_income - tax - pension_contributions
         )
+        tariff_income = benunit("housing_benefit_tariff_income", period)
         disregard = benunit("housing_benefit_applicable_income_disregard", period)
         childcare_element = benunit(
             "housing_benefit_applicable_income_childcare_element", period
         )
-        return max_(
+        applicable_income = max_(
             0,
             increased_income_reduced_by_tax_and_pensions
+            + tariff_income
             - disregard
             - childcare_element,
         )
+        guarantee_credit = any_over_SP_age & (benunit("guarantee_credit", period) > 0)
+        return where(guarantee_credit, 0, applicable_income)

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_tariff_income.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_tariff_income.py
@@ -12,6 +12,7 @@ class housing_benefit_tariff_income(Variable):
     def formula(benunit, period, parameters):
         capital = benunit("housing_benefit_assessable_capital", period)
         any_over_SP_age = benunit.any(benunit.members("is_SP_age", period))
+        guarantee_credit = any_over_SP_age & (benunit("guarantee_credit", period) > 0)
         p = parameters(period).gov.dwp.housing_benefit.means_test.capital
         lower_threshold = where(
             any_over_SP_age,
@@ -30,4 +31,5 @@ class housing_benefit_tariff_income(Variable):
         )
         excess_capital = max_(0, capital - lower_threshold)
         steps = np.ceil(excess_capital / step)
-        return steps * amount * WEEKS_IN_YEAR
+        tariff_income = steps * amount * WEEKS_IN_YEAR
+        return where(guarantee_credit, 0, tariff_income)

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_tariff_income.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_tariff_income.py
@@ -1,0 +1,33 @@
+from policyengine_uk.model_api import *
+
+
+class housing_benefit_tariff_income(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Housing Benefit tariff income from capital"
+    documentation = "Weekly Housing Benefit tariff income from capital annualised to the model period."
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        capital = benunit("housing_benefit_assessable_capital", period)
+        any_over_SP_age = benunit.any(benunit.members("is_SP_age", period))
+        p = parameters(period).gov.dwp.housing_benefit.means_test.capital
+        lower_threshold = where(
+            any_over_SP_age,
+            p.pension_age.lower_threshold,
+            p.working_age.lower_threshold,
+        )
+        step = where(
+            any_over_SP_age,
+            p.pension_age.tariff_income.step,
+            p.working_age.tariff_income.step,
+        )
+        amount = where(
+            any_over_SP_age,
+            p.pension_age.tariff_income.amount,
+            p.working_age.tariff_income.amount,
+        )
+        excess_capital = max_(0, capital - lower_threshold)
+        steps = np.ceil(excess_capital / step)
+        return steps * amount * WEEKS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_assessable_capital.py
@@ -1,0 +1,30 @@
+from policyengine_uk.model_api import *
+
+
+class housing_benefit_assessable_capital(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Housing Benefit assessable capital"
+    documentation = (
+        "Housing Benefit capital counted from the configured capital sources, "
+        "allocated across benunits using a household adult-share proxy."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        household = benunit.household
+        person = benunit.members
+        any_over_SP_age = benunit.any(person("is_SP_age", period))
+        p = parameters(period).gov.dwp.housing_benefit.means_test.capital
+        household_capital = add(household, period, p.sources)
+        benunit_adults = add(benunit, period, ["is_adult"])
+        household_adults = benunit.max(household.sum(person("is_adult", period)))
+        adult_divisor = max_(1, household_adults)
+        household_capital_proxy = where(
+            household_adults > 0,
+            household_capital * benunit_adults / adult_divisor,
+            0,
+        )
+        guarantee_credit = any_over_SP_age & (benunit("guarantee_credit", period) > 0)
+        return where(guarantee_credit, 0, max_(0, household_capital_proxy))

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_assessable_capital.py
@@ -19,7 +19,9 @@ class housing_benefit_assessable_capital(Variable):
         p = parameters(period).gov.dwp.housing_benefit.means_test.capital
         household_capital = add(household, period, p.sources)
         benunit_adults = add(benunit, period, ["is_adult"])
-        household_adults = benunit.max(household.sum(person("is_adult", period)))
+        household_adults = benunit.max(
+            person.household.sum(person.household.members("is_adult", period))
+        )
         adult_divisor = max_(1, household_adults)
         household_capital_proxy = where(
             household_adults > 0,

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_eligible.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_eligible.py
@@ -12,4 +12,17 @@ class housing_benefit_eligible(Variable):
         already_claiming = add(benunit, period, ["housing_benefit_reported"]) > 0
         claiming_uc = benunit("would_claim_uc", period)
         lha_eligible = benunit("LHA_eligible", period)
-        return already_claiming & (social | lha_eligible) & ~claiming_uc
+        any_over_SP_age = benunit.any(benunit.members("is_SP_age", period))
+        capital = benunit("housing_benefit_assessable_capital", period)
+        hb_capital = parameters(period).gov.dwp.housing_benefit.means_test.capital
+        upper_threshold = where(
+            any_over_SP_age,
+            hb_capital.pension_age.upper_threshold,
+            hb_capital.working_age.upper_threshold,
+        )
+        return (
+            already_claiming
+            & (social | lha_eligible)
+            & ~claiming_uc
+            & (capital <= upper_threshold)
+        )


### PR DESCRIPTION
Closes #1576

## Summary
- add legislation-backed Housing Benefit capital parameters for working-age and pension-age cases
- add assessable-capital and tariff-income variables to the Housing Benefit means test
- apply the upper-capital-limit eligibility rule and Guarantee Credit passporting
- add YAML regression coverage for thresholds, tariff-income rounding, pension-age treatment, and shared-household allocation

## Testing
- uvx ruff check policyengine_uk/variables/gov/dwp/housing_benefit policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit policyengine_uk/parameters/gov/dwp/housing_benefit/means_test/capital
- uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_capital.yaml policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit_eligible.yaml policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/applicable_income/housing_benefit_applicable_income.yaml policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/entitlement/housing_benefit_entitlement.yaml policyengine_uk/tests/policy/baseline/finance/benefit/family/housing_benefit/housing_benefit.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/housing_benefit.yaml -c policyengine_uk