### PR TITLE
Add Income Support capital rules

### DIFF
--- a/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/lower_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/lower_threshold.yaml
@@ -1,0 +1,11 @@
+description: Lower capital threshold for Income Support tariff income.
+metadata:
+  label: Income Support lower capital threshold
+  period: year
+  reference:
+    - title: Income Support (General) Regulations 1987 reg. 53(1)
+      href: https://www.legislation.gov.uk/uksi/1987/1967/data.pdf#page=76
+  unit: GBP
+
+values:
+  2010-01-01: 6000

--- a/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/sources.yaml
@@ -1,0 +1,20 @@
+description: Capital sources included in the Income Support capital test.
+metadata:
+  label: Income Support capital sources
+  period: year
+  propagate_metadata_to_children: true
+  reference:
+    - title: Income Support (General) Regulations 1987 reg. 46(1)-(2)
+      href: https://www.legislation.gov.uk/uksi/1987/1967/data.pdf#page=70
+    - title: Income Support (General) Regulations 1987 reg. 48(4)
+      href: https://www.legislation.gov.uk/uksi/1987/1967/data.pdf#page=70
+    - title: Income Support (General) Regulations 1987 Sch. 10
+      href: https://www.legislation.gov.uk/uksi/1987/1967/data.pdf#page=188
+  unit: list
+
+values:
+  2010-01-01:
+  - savings
+  - corporate_wealth
+  - other_residential_property_value
+  - non_residential_property_value

--- a/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/sources.yaml
@@ -15,6 +15,7 @@ metadata:
 values:
   2010-01-01:
   - savings
+  - owned_land
   - corporate_wealth
   - other_residential_property_value
   - non_residential_property_value

--- a/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/tariff_income/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/tariff_income/amount.yaml
@@ -1,0 +1,11 @@
+description: Weekly amount of Income Support tariff income per capital step.
+metadata:
+  label: Income Support tariff income amount
+  period: year
+  reference:
+    - title: Income Support (General) Regulations 1987 reg. 53(1)
+      href: https://www.legislation.gov.uk/uksi/1987/1967/data.pdf#page=76
+  unit: GBP
+
+values:
+  2010-01-01: 1

--- a/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/tariff_income/step.yaml
+++ b/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/tariff_income/step.yaml
@@ -1,0 +1,11 @@
+description: Capital amount that generates one unit of Income Support tariff income.
+metadata:
+  label: Income Support tariff income step
+  period: year
+  reference:
+    - title: Income Support (General) Regulations 1987 reg. 53(1)
+      href: https://www.legislation.gov.uk/uksi/1987/1967/data.pdf#page=76
+  unit: GBP
+
+values:
+  2010-01-01: 250

--- a/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/upper_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/income_support/means_test/capital/upper_threshold.yaml
@@ -1,0 +1,11 @@
+description: Upper capital threshold for Income Support eligibility.
+metadata:
+  label: Income Support upper capital threshold
+  period: year
+  reference:
+    - title: Income Support (General) Regulations 1987 reg. 45
+      href: https://www.legislation.gov.uk/uksi/1987/1967/data.pdf#page=70
+  unit: GBP
+
+values:
+  2010-01-01: 16000

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
@@ -17,12 +17,35 @@
       household:
         members: [p1, c1]
         savings: 1000
+        owned_land: 500
         corporate_wealth: 2000
         main_residence_value: 300000
         other_residential_property_value: 3000
         non_residential_property_value: 4000
   output:
-    income_support_assessable_capital: 10000
+    income_support_assessable_capital: 10500
+
+- name: Income Support has no tariff income at the lower capital threshold
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: true
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 6000
+  output:
+    income_support_tariff_income: 0
 
 - name: Income Support tariff income rounds up to the next 250 pounds
   period: 2021
@@ -69,6 +92,28 @@
     income_support_eligible: true
     income_support_tariff_income: 104
     income_support: 4209.82
+
+- name: Income Support remains eligible at the upper capital limit
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: true
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 16000
+  output:
+    income_support_eligible: true
 
 - name: Income Support is not eligible above the capital limit
   period: 2021

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
@@ -1,0 +1,94 @@
+- name: Income Support capital test ignores the main residence
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: true
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 1000
+        corporate_wealth: 2000
+        main_residence_value: 300000
+        other_residential_property_value: 3000
+        non_residential_property_value: 4000
+  output:
+    income_support_assessable_capital: 10000
+
+- name: Income Support tariff income rounds up to the next 250 pounds
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: true
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 6251
+  output:
+    income_support_tariff_income: 104
+
+- name: Income Support entitlement is reduced by tariff income above the lower threshold
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: true
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 6251
+  output:
+    income_support_eligible: true
+    income_support_tariff_income: 104
+    income_support: 4209.82
+
+- name: Income Support is not eligible above the capital limit
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: true
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 16001
+  output:
+    income_support_eligible: false
+    income_support: 0

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
@@ -152,11 +152,61 @@
     benunits:
       b1:
         members: [p1]
+        would_claim_IS: false
       b2:
         members: [p2, p3]
+        would_claim_IS: false
     households:
       household:
         members: [p1, p2, p3]
         savings: 18_000
   output:
     income_support_assessable_capital: [6_000, 12_000]
+
+- name: Income Support does not dilute claimant capital across unrelated non-claiming adults
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      claimant:
+        age: 26
+      unrelated_adult:
+        age: 30
+    benunits:
+      claimant_benunit:
+        members: [claimant]
+        would_claim_IS: true
+      unrelated_benunit:
+        members: [unrelated_adult]
+        would_claim_IS: false
+    households:
+      household:
+        members: [claimant, unrelated_adult]
+        savings: 18_000
+  output:
+    income_support_assessable_capital: [18_000, 0]
+
+- name: Income Support does not dilute household capital across multiple claiming benunits
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      claimant_1:
+        age: 26
+        income_support_reported: true
+      claimant_2:
+        age: 30
+        income_support_reported: true
+    benunits:
+      benunit_1:
+        members: [claimant_1]
+        would_claim_IS: true
+      benunit_2:
+        members: [claimant_2]
+        would_claim_IS: true
+    households:
+      household:
+        members: [claimant_1, claimant_2]
+        savings: 18_000
+  output:
+    income_support_assessable_capital: [18_000, 18_000]

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml
@@ -92,3 +92,26 @@
   output:
     income_support_eligible: false
     income_support: 0
+
+- name: Income Support allocates household capital by adult share across benunits
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      p1:
+        age: 26
+      p2:
+        age: 30
+      p3:
+        age: 32
+    benunits:
+      b1:
+        members: [p1]
+      b2:
+        members: [p2, p3]
+    households:
+      household:
+        members: [p1, p2, p3]
+        savings: 18_000
+  output:
+    income_support_assessable_capital: [6_000, 12_000]

--- a/policyengine_uk/variables/gov/dwp/income_support_applicable_income.py
+++ b/policyengine_uk/variables/gov/dwp/income_support_applicable_income.py
@@ -26,6 +26,7 @@ class income_support_applicable_income(Variable):
             ["income_tax", "national_insurance"],
         )
         income += add(benunit, period, ["social_security_income"])
+        income += benunit("income_support_tariff_income", period)
         income -= tax
         income -= add(benunit, period, ["pension_contributions"]) * 0.5
         family_type = benunit("family_type", period)

--- a/policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py
@@ -1,0 +1,27 @@
+from policyengine_uk.model_api import *
+
+
+class income_support_assessable_capital(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Assessable capital for Income Support"
+    documentation = (
+        "Household capital apportioned to the benefit unit for the Income Support "
+        "capital test."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        IS = parameters(period).gov.dwp.income_support
+        sources = IS.means_test.capital.sources
+
+        # The data model stores these capital stocks at household level, so split
+        # them across the benefit units in the household as a pragmatic proxy.
+        household_capital = sum(
+            benunit.max(benunit.members.household(source, period)) for source in sources
+        )
+        household_num_benunits = benunit.max(
+            benunit.members.household("household_num_benunits", period)
+        )
+        return household_capital / max_(1, household_num_benunits)

--- a/policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py
@@ -15,13 +15,17 @@ class income_support_assessable_capital(Variable):
     def formula(benunit, period, parameters):
         IS = parameters(period).gov.dwp.income_support
         sources = IS.means_test.capital.sources
+        person = benunit.members
 
         # The data model stores these capital stocks at household level, so split
-        # them across the benefit units in the household as a pragmatic proxy.
+        # them across the benefit units in the household using an adult-share
+        # proxy rather than treating all benunits as equal-sized claim units.
         household_capital = sum(
-            benunit.max(benunit.members.household(source, period)) for source in sources
+            benunit.max(person.household(source, period)) for source in sources
         )
-        household_num_benunits = benunit.max(
-            benunit.members.household("household_num_benunits", period)
+        benunit_adults = add(benunit, period, ["is_adult"])
+        household_adults = benunit.max(
+            person.household.sum(person.household.members("is_adult", period))
         )
-        return household_capital / max_(1, household_num_benunits)
+        adult_divisor = max_(1, household_adults)
+        return household_capital * benunit_adults / adult_divisor

--- a/policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py
@@ -7,7 +7,10 @@ class income_support_assessable_capital(Variable):
     label = "Assessable capital for Income Support"
     documentation = (
         "Household capital apportioned to the benefit unit for the Income Support "
-        "capital test."
+        "capital test. Because the dataset only stores these stocks at household "
+        "level, the model allocates full household capital to any benunit on the "
+        "IS claim path and only falls back to an adult-share proxy when nobody in "
+        "the household is on that path."
     )
     definition_period = YEAR
     unit = GBP
@@ -16,16 +19,26 @@ class income_support_assessable_capital(Variable):
         IS = parameters(period).gov.dwp.income_support
         sources = IS.means_test.capital.sources
         person = benunit.members
+        would_claim_is = benunit("would_claim_IS", period)
 
-        # The data model stores these capital stocks at household level, so split
-        # them across the benefit units in the household using an adult-share
-        # proxy rather than treating all benunits as equal-sized claim units.
+        # The data model stores these capital stocks at household level. For the
+        # live Income Support path, avoid diluting capital across separate claims:
+        # any benunit on the IS claim path gets the full observed household total.
+        # If nobody in the household is on that path, fall back to an all-adults
+        # proxy so direct inspection still returns a usable value.
         household_capital = sum(
             benunit.max(person.household(source, period)) for source in sources
         )
         benunit_adults = add(benunit, period, ["is_adult"])
+        household_claiming_adults = benunit.max(
+            person.household.sum(
+                person("is_adult", period) & person.benunit("would_claim_IS", period)
+            )
+        )
         household_adults = benunit.max(
             person.household.sum(person.household.members("is_adult", period))
         )
-        adult_divisor = max_(1, household_adults)
-        return household_capital * benunit_adults / adult_divisor
+        fallback_divisor = max_(1, household_adults)
+        claiming_proxy = where(would_claim_is, household_capital, 0)
+        fallback_proxy = household_capital * benunit_adults / fallback_divisor
+        return where(household_claiming_adults > 0, claiming_proxy, fallback_proxy)

--- a/policyengine_uk/variables/gov/dwp/income_support_eligible.py
+++ b/policyengine_uk/variables/gov/dwp/income_support_eligible.py
@@ -8,6 +8,7 @@ class income_support_eligible(Variable):
     definition_period = YEAR
 
     def formula(benunit, period, parameters):
+        IS = parameters(period).gov.dwp.income_support
         youngest_child_5_or_under = benunit("youngest_child_age", period) <= 5
         lone_parent = benunit("is_lone_parent", period)
         lone_parent_with_young_child = lone_parent & youngest_child_5_or_under
@@ -15,9 +16,12 @@ class income_support_eligible(Variable):
         none_SP_age = ~benunit.any(benunit.members("is_SP_age", period))
         has_esa_income = benunit("esa_income", period) > 0
         already_claiming = add(benunit, period, ["income_support_reported"]) > 0
+        capital = benunit("income_support_assessable_capital", period)
+        capital_limit = IS.means_test.capital.upper_threshold
         return (
             (has_carers | lone_parent_with_young_child)
             & none_SP_age
             & ~has_esa_income
             & already_claiming
+            & (capital <= capital_limit)
         )

--- a/policyengine_uk/variables/gov/dwp/income_support_tariff_income.py
+++ b/policyengine_uk/variables/gov/dwp/income_support_tariff_income.py
@@ -1,0 +1,18 @@
+from policyengine_uk.model_api import *
+import numpy as np
+
+
+class income_support_tariff_income(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Income Support tariff income from capital"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        IS = parameters(period).gov.dwp.income_support
+        capital = benunit("income_support_assessable_capital", period)
+        mt = IS.means_test.capital
+        excess_capital = max_(0, capital - mt.lower_threshold)
+        tariff_units = np.ceil(excess_capital / mt.tariff_income.step)
+        return tariff_units * mt.tariff_income.amount * WEEKS_IN_YEAR


### PR DESCRIPTION
Implements issue #1573.

Adds Income Support capital parameters, assessable capital, tariff income, eligibility/entitlement wiring, and YAML policy coverage.

Checks:
- uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support.yaml policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support/income_support_capital.yaml -c policyengine_uk
- uvx ruff check policyengine_uk/variables/gov/dwp/income_support_eligible.py policyengine_uk/variables/gov/dwp/income_support_applicable_income.py policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py policyengine_uk/variables/gov/dwp/income_support_tariff_income.py
- uvx ruff format --check policyengine_uk/variables/gov/dwp/income_support_eligible.py policyengine_uk/variables/gov/dwp/income_support_applicable_income.py policyengine_uk/variables/gov/dwp/income_support_assessable_capital.py policyengine_uk/variables/gov/dwp/income_support_tariff_income.py