### PR TITLE
Add Pension Credit capital rules

### DIFF
--- a/policyengine_uk/parameters/gov/dwp/pension_credit/guarantee_credit/income.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pension_credit/guarantee_credit/income.yaml
@@ -6,6 +6,8 @@ metadata:
   reference:
   - href: https://www.legislation.gov.uk/ukpga/2002/16/section/15
     title: State Pension Credit Act 2002 s. 15(1)
+  - href: https://www.legislation.gov.uk/uksi/2002/1792/regulation/15
+    title: State Pension Credit Regulations 2002 reg. 15
   unit: list
 values:
   2002-01-01:
@@ -13,6 +15,6 @@ values:
   - working_tax_credit
   - state_pension
   - private_pension_income
-  - capital_income
+  - pension_credit_deemed_income
   - esa_contrib
   - jsa_contrib

--- a/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/lower_threshold.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/lower_threshold.yaml
@@ -1,0 +1,12 @@
+description: Capital amount disregarded before Pension Credit deemed income applies.
+metadata:
+  unit: currency-GBP
+  period: year
+  reference:
+    - href: https://www.legislation.gov.uk/uksi/2002/1792/regulation/15
+      title: State Pension Credit Regulations 2002 reg. 15(6)
+    - href: https://www.gov.uk/pension-credit/eligibility
+      title: Pension Credit eligibility guidance
+values:
+  2003-10-06: 6000
+  2009-11-16: 10000

--- a/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/sources.yaml
@@ -16,6 +16,7 @@ metadata:
 values:
   2003-10-06:
     - savings
+    - owned_land
     - other_residential_property_value
     - non_residential_property_value
     - corporate_wealth

--- a/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/sources.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/sources.yaml
@@ -1,0 +1,21 @@
+description: >
+  PolicyEngine approximation of Pension Credit capital sources that count
+  toward deemed income from capital, excluding the claimant's main home.
+metadata:
+  label: Pension Credit capital sources
+  name: pension_credit_capital_sources
+  unit: list
+  reference:
+    - href: https://www.legislation.gov.uk/uksi/2002/1792/regulation/15
+      title: State Pension Credit Regulations 2002 reg. 15
+    - href: https://www.legislation.gov.uk/uksi/2002/1792/schedule/5
+      title: State Pension Credit Regulations 2002 Sch. 5
+    - href: https://www.gov.uk/government/publications/pension-credit-technical-guidance/a-detailed-guide-to-pension-credit-for-advisers-and-others
+      title: Pension Credit technical guidance
+  propagate_metadata_to_children: true
+values:
+  2003-10-06:
+    - savings
+    - other_residential_property_value
+    - non_residential_property_value
+    - corporate_wealth

--- a/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/tariff_income/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/tariff_income/amount.yaml
@@ -1,0 +1,11 @@
+description: Weekly deemed income amount for each Pension Credit capital step.
+metadata:
+  unit: currency-GBP
+  period: week
+  reference:
+    - href: https://www.legislation.gov.uk/uksi/2002/1792/regulation/15
+      title: State Pension Credit Regulations 2002 reg. 15(6)
+    - href: https://www.gov.uk/pension-credit/eligibility
+      title: Pension Credit eligibility guidance
+values:
+  2003-10-06: 1

--- a/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/tariff_income/step.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pension_credit/income/capital/tariff_income/step.yaml
@@ -1,0 +1,11 @@
+description: Capital step used for Pension Credit deemed income from capital.
+metadata:
+  unit: currency-GBP
+  period: year
+  reference:
+    - href: https://www.legislation.gov.uk/uksi/2002/1792/regulation/15
+      title: State Pension Credit Regulations 2002 reg. 15(6)
+    - href: https://www.gov.uk/pension-credit/eligibility
+      title: Pension Credit eligibility guidance
+values:
+  2003-10-06: 500

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/guarantee_credit/is_guarantee_credit_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/guarantee_credit/is_guarantee_credit_eligible.yaml
@@ -13,3 +13,22 @@
     minimum_guarantee: 180
   output:
     is_guarantee_credit_eligible: false
+
+- name: Pension Credit deemed income from capital can remove Guarantee Credit eligibility.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+    benunits:
+      benunit:
+        members: person
+        minimum_guarantee: 100
+    households:
+      household:
+        members: person
+        savings: 10_501
+  output:
+    pension_credit_deemed_income: 104
+    pension_credit_income: 104
+    is_guarantee_credit_eligible: false

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_deemed_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_deemed_income.yaml
@@ -66,6 +66,23 @@
     pension_credit_assessable_capital: 10_501
     pension_credit_deemed_income: 104
 
+- name: Pension Credit counts direct land holdings as capital.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        owned_land: 10_001
+  output:
+    pension_credit_assessable_capital: 10_001
+    pension_credit_deemed_income: 52
+
 - name: Pension Credit does not dilute pensioner capital across unrelated adult benunits.
   period: 2021
   input:

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_deemed_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_deemed_income.yaml
@@ -1,0 +1,88 @@
+- name: Pension Credit has no deemed income at the capital disregard.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 10_000
+  output:
+    pension_credit_assessable_capital: 10_000
+    pension_credit_deemed_income: 0
+
+- name: Pension Credit rounds the first capital step up.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 10_001
+  output:
+    pension_credit_assessable_capital: 10_001
+    pension_credit_deemed_income: 52
+
+- name: Pension Credit keeps one deemed-income step through the interval.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 10_500
+  output:
+    pension_credit_assessable_capital: 10_500
+    pension_credit_deemed_income: 52
+
+- name: Pension Credit rounds the second capital step up.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 10_501
+  output:
+    pension_credit_assessable_capital: 10_501
+    pension_credit_deemed_income: 104
+
+- name: Pension Credit does not dilute pensioner capital across unrelated adult benunits.
+  period: 2021
+  input:
+    people:
+      pensioner:
+        age: 70
+      adult_child:
+        age: 30
+    benunits:
+      pensioner_benunit:
+        members: [pensioner]
+      child_benunit:
+        members: [adult_child]
+    households:
+      household:
+        members: [pensioner, adult_child]
+        savings: 10_501
+  output:
+    pension_credit_assessable_capital: [10_501, 0]
+    pension_credit_deemed_income: [104, 0]

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_deemed_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_deemed_income.yaml
@@ -86,3 +86,24 @@
   output:
     pension_credit_assessable_capital: [10_501, 0]
     pension_credit_deemed_income: [104, 0]
+
+- name: Pension Credit splits capital across separate pension-age benunits.
+  period: 2021
+  input:
+    people:
+      pensioner_1:
+        age: 70
+      pensioner_2:
+        age: 72
+    benunits:
+      benunit_1:
+        members: [pensioner_1]
+      benunit_2:
+        members: [pensioner_2]
+    households:
+      household:
+        members: [pensioner_1, pensioner_2]
+        savings: 20_002
+  output:
+    pension_credit_assessable_capital: [10_001, 10_001]
+    pension_credit_deemed_income: [52, 52]

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_income.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_income.yaml
@@ -1,13 +1,60 @@
 - name: All income sources are included.
   period: 2021
   input:
-    employment_income: 1
-    working_tax_credit: 2
-    state_pension: 4
-    private_pension_income: 8
-    capital_income: 16
-    esa_contrib: 32
-    jsa_contrib: 64
-    self_employment_income: 128
+    people:
+      person:
+        age: 70
+        employment_income: 1
+        state_pension: 4
+        private_pension_income: 8
+        esa_contrib: 32
+        jsa_contrib: 64
+        self_employment_income: 128
+    benunits:
+      benunit:
+        members: person
+        working_tax_credit: 2
+    households:
+      household:
+        members: person
+        savings: 11_000
   output:
-    pension_credit_income: 255
+    pension_credit_deemed_income: 104
+    pension_credit_income: 343
+
+- name: Interest and dividends are not counted directly in Pension Credit income.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+        savings_interest_income: 500
+        dividend_income: 300
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 10_000
+  output:
+    pension_credit_deemed_income: 0
+    pension_credit_income: 0
+
+- name: Pension Credit deemed income starts above the capital disregard.
+  period: 2021
+  input:
+    people:
+      person:
+        age: 70
+    benunits:
+      benunit:
+        members: person
+    households:
+      household:
+        members: person
+        savings: 10_001
+  output:
+    pension_credit_assessable_capital: 10_001
+    pension_credit_deemed_income: 52
+    pension_credit_income: 52

--- a/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_assessable_capital.py
@@ -7,9 +7,9 @@ class pension_credit_assessable_capital(Variable):
     label = "Pension Credit assessable capital"
     documentation = (
         "Pension Credit capital counted from the configured capital sources, "
-        "assigned in full to pension-age benunits because the dataset stores "
-        "capital at household level and does not distinguish ownership across "
-        "separate adult benunits."
+        "split only across pension-age adults in the household so pensioner "
+        "couples pool capital together without dilution by unrelated working-"
+        "age adults."
     )
     definition_period = YEAR
     unit = GBP
@@ -20,4 +20,14 @@ class pension_credit_assessable_capital(Variable):
         p = parameters(period).gov.dwp.pension_credit.income.capital
         household_capital = add(household, period, p.sources)
         any_pension_age = benunit.any(person("is_SP_age", period))
-        return where(any_pension_age, max_(0, household_capital), 0)
+        benunit_pension_age_adults = benunit.sum(person("is_SP_age", period))
+        household_pension_age_adults = benunit.max(
+            person.household.sum(
+                person.household.members("is_SP_age", period)
+            )
+        )
+        adult_divisor = max_(1, household_pension_age_adults)
+        household_capital_proxy = (
+            household_capital * benunit_pension_age_adults / adult_divisor
+        )
+        return where(any_pension_age, max_(0, household_capital_proxy), 0)

--- a/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_assessable_capital.py
@@ -22,9 +22,7 @@ class pension_credit_assessable_capital(Variable):
         any_pension_age = benunit.any(person("is_SP_age", period))
         benunit_pension_age_adults = benunit.sum(person("is_SP_age", period))
         household_pension_age_adults = benunit.max(
-            person.household.sum(
-                person.household.members("is_SP_age", period)
-            )
+            person.household.sum(person.household.members("is_SP_age", period))
         )
         adult_divisor = max_(1, household_pension_age_adults)
         household_capital_proxy = (

--- a/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_assessable_capital.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_assessable_capital.py
@@ -1,0 +1,23 @@
+from policyengine_uk.model_api import *
+
+
+class pension_credit_assessable_capital(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Pension Credit assessable capital"
+    documentation = (
+        "Pension Credit capital counted from the configured capital sources, "
+        "assigned in full to pension-age benunits because the dataset stores "
+        "capital at household level and does not distinguish ownership across "
+        "separate adult benunits."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        household = benunit.household
+        person = benunit.members
+        p = parameters(period).gov.dwp.pension_credit.income.capital
+        household_capital = add(household, period, p.sources)
+        any_pension_age = benunit.any(person("is_SP_age", period))
+        return where(any_pension_age, max_(0, household_capital), 0)

--- a/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_deemed_income.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/pension_credit_deemed_income.py
@@ -1,0 +1,18 @@
+from policyengine_uk.model_api import *
+import numpy as np
+
+
+class pension_credit_deemed_income(Variable):
+    label = "Pension Credit deemed income from capital"
+    entity = BenUnit
+    definition_period = YEAR
+    value_type = float
+    unit = GBP
+    reference = "https://www.legislation.gov.uk/uksi/2002/1792/regulation/15"
+
+    def formula(benunit, period, parameters):
+        p = parameters(period).gov.dwp.pension_credit.income.capital
+        capital = benunit("pension_credit_assessable_capital", period)
+        excess = max_(0, capital - p.lower_threshold)
+        steps = np.ceil(excess / p.tariff_income.step)
+        return steps * p.tariff_income.amount * WEEKS_IN_YEAR


### PR DESCRIPTION
Closes #1574

## Summary
- add legislation-backed Pension Credit capital parameters and a capital-source list parameter
- replace direct capital-income counting with deemed income from capital above the threshold
- add a household-capital proxy that pools capital across pension-age adults without diluting by unrelated working-age adults
- add YAML regressions for threshold breakpoints, mixed-age households, separate pension-age benunits, and Guarantee Credit interaction

## Testing
- /opt/homebrew/bin/ruff check policyengine_uk/variables/gov/dwp/pension_credit policyengine_uk/parameters/gov/dwp/pension_credit policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit
- ./.venv/bin/policyengine-core test policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/is_pension_credit_eligible.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_income.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_deemed_income.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/pension_credit_earnings.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/guarantee_credit/is_guarantee_credit_eligible.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/meets_savings_credit_age_requirement.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/housing_benefit.yaml -c policyengine_uk