### PR TITLE
Add local-authority target uprating parameters

### DIFF
--- a/changelog.d/local-authority-target-uprating-parameters.added.md
+++ b/changelog.d/local-authority-target-uprating-parameters.added.md
@@ -1,0 +1,1 @@
+Add named economic-assumption parameters for the local-authority ONS income target uprating factors used by `policyengine-uk-data`.

--- a/policyengine_uk/parameters/gov/economic_assumptions/local_authority_targets/ons_income/housing_costs_uprating_factor.yaml
+++ b/policyengine_uk/parameters/gov/economic_assumptions/local_authority_targets/ons_income/housing_costs_uprating_factor.yaml
@@ -1,0 +1,9 @@
+description: Factor used to uprate ONS FYE 2020 local-authority housing costs targets to the 2025 calibration year, using the OBR house price index as the calibration proxy.
+values:
+  2025-01-01: 1.2190812720848057
+metadata:
+  unit: /1
+  label: Local-authority ONS housing costs uprating factor
+  reference:
+    - title: OBR EFO November 2025 (economy detailed forecast tables, house price index)
+      href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/

--- a/policyengine_uk/parameters/gov/economic_assumptions/local_authority_targets/ons_income/net_income_bhc_uprating_factor.yaml
+++ b/policyengine_uk/parameters/gov/economic_assumptions/local_authority_targets/ons_income/net_income_bhc_uprating_factor.yaml
@@ -1,0 +1,9 @@
+description: Factor used to uprate ONS FYE 2020 local-authority net income before housing costs targets to the 2025 calibration year.
+values:
+  2025-01-01: 1.3526165167620605
+metadata:
+  unit: /1
+  label: Local-authority ONS net income BHC uprating factor
+  reference:
+    - title: OBR EFO November 2025 (economy detailed forecast tables, real household disposable income index)
+      href: https://obr.uk/efo/economic-and-fiscal-outlook-november-2025/

--- a/policyengine_uk/tests/test_local_authority_target_parameters.py
+++ b/policyengine_uk/tests/test_local_authority_target_parameters.py
@@ -1,0 +1,17 @@
+from policyengine_uk.system import system
+
+
+def test_local_authority_target_uprating_parameters():
+    params = system.parameters.gov.economic_assumptions.local_authority_targets
+    ons_income = params.ons_income
+
+    assert ons_income.net_income_bhc_uprating_factor("2025-01-01") == (1985.1 / 1467.6)
+    assert ons_income.housing_costs_uprating_factor("2025-01-01") == (103.5 / 84.9)
+
+    bhc_reference = ons_income.net_income_bhc_uprating_factor.metadata["reference"][0]
+    housing_reference = ons_income.housing_costs_uprating_factor.metadata["reference"][
+        0
+    ]
+
+    assert "November 2025" in bhc_reference["title"]
+    assert "November 2025" in housing_reference["title"]


### PR DESCRIPTION
## Summary
- add named `policyengine-uk` economic-assumption parameters for the ONS LA income target uprating factors
- keep the values explicit and self-documenting instead of leaving them as raw numbers in `policyengine-uk-data`
- cover the new parameter paths with a focused regression test

## Testing
- uv run pytest -q policyengine_uk/tests/test_local_authority_target_parameters.py
- uvx ruff check policyengine_uk/tests/test_local_authority_target_parameters.py