### PR TITLE
Add maintenance loan model for English HE students

### DIFF
--- a/changelog.d/maintenance-loans.added.md
+++ b/changelog.d/maintenance-loans.added.md
@@ -1,0 +1,1 @@
+- Add an approximate England full-time maintenance loan model, with explicit override inputs for living arrangement and assessed household income.

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/maximum.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/maximum.yaml
@@ -1,0 +1,43 @@
+description: Maximum full-year full-time maintenance loan amounts in England.
+living_with_parents:
+  description: Maximum maintenance loan for students living with parents.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Full-time maintenance loan maximum while living with parents
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 8_877
+    2026-01-01: 9_118
+away_outside_london:
+  description: Maximum maintenance loan for students living away from home and studying outside London.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Full-time maintenance loan maximum away from home outside London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 10_544
+    2026-01-01: 10_830
+away_in_london:
+  description: Maximum maintenance loan for students living away from home and studying in London.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Full-time maintenance loan maximum away from home in London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 13_762
+    2026-01-01: 14_135

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/maximum_entitled_to_benefits.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/maximum_entitled_to_benefits.yaml
@@ -1,0 +1,43 @@
+description: Maximum full-year full-time maintenance loan amounts in England for students entitled to benefits.
+living_with_parents:
+  description: Maximum maintenance loan for students living with parents and entitled to benefits.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Full-time maintenance loan maximum while living with parents if entitled to benefits
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 10_473
+    2026-01-01: 10_757
+away_outside_london:
+  description: Maximum maintenance loan for students living away from home, studying outside London, and entitled to benefits.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Full-time maintenance loan maximum away from home outside London if entitled to benefits
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 12_019
+    2026-01-01: 12_345
+away_in_london:
+  description: Maximum maintenance loan for students living away from home, studying in London, and entitled to benefits.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Full-time maintenance loan maximum away from home in London if entitled to benefits
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 15_008
+    2026-01-01: 15_415

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/minimum_rate/entitled_to_benefits.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/minimum_rate/entitled_to_benefits.yaml
@@ -1,0 +1,40 @@
+description: Minimum share of the full-time maintenance loan that remains when the student is entitled to benefits.
+living_with_parents:
+  metadata:
+    unit: /1
+    period: year
+    label: Minimum maintenance loan share while living with parents if entitled to benefits
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 0.373
+    2026-01-01: 0.373
+away_outside_london:
+  metadata:
+    unit: /1
+    period: year
+    label: Minimum maintenance loan share away from home outside London if entitled to benefits
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 0.409
+    2026-01-01: 0.409
+away_in_london:
+  metadata:
+    unit: /1
+    period: year
+    label: Minimum maintenance loan share away from home in London if entitled to benefits
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 0.457
+    2026-01-01: 0.457

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/minimum_rate/not_entitled.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/minimum_rate/not_entitled.yaml
@@ -1,0 +1,40 @@
+description: Minimum share of the full-time maintenance loan that remains when the student is not entitled to benefits.
+living_with_parents:
+  metadata:
+    unit: /1
+    period: year
+    label: Minimum maintenance loan share while living with parents
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 0.44
+    2026-01-01: 0.44
+away_outside_london:
+  metadata:
+    unit: /1
+    period: year
+    label: Minimum maintenance loan share away from home outside London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 0.466
+    2026-01-01: 0.466
+away_in_london:
+  metadata:
+    unit: /1
+    period: year
+    label: Minimum maintenance loan share away from home in London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 0.498
+    2026-01-01: 0.498

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/taper/entitled_to_benefits/first_stage.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/taper/entitled_to_benefits/first_stage.yaml
@@ -1,0 +1,40 @@
+description: First-stage household income taper for full-time maintenance loans where the student is entitled to benefits.
+living_with_parents:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: First-stage maintenance loan taper while living with parents
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 4.196
+    2026-01-01: 4.088
+away_outside_london:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: First-stage maintenance loan taper away from home outside London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 4.289
+    2026-01-01: 4.179
+away_in_london:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: First-stage maintenance loan taper away from home in London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 4.487
+    2026-01-01: 4.37

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/taper/entitled_to_benefits/second_stage.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/taper/entitled_to_benefits/second_stage.yaml
@@ -1,0 +1,40 @@
+description: Second-stage household income taper for full-time maintenance loans where the student is entitled to benefits.
+living_with_parents:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Second-stage maintenance loan taper while living with parents
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 6.71
+    2026-01-01: 6.54
+away_outside_london:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Second-stage maintenance loan taper away from home outside London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 6.64
+    2026-01-01: 6.47
+away_in_london:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Second-stage maintenance loan taper away from home in London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 6.53
+    2026-01-01: 6.36

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/taper/not_entitled.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/full_time/taper/not_entitled.yaml
@@ -1,0 +1,40 @@
+description: Household income taper used for full-time maintenance loans where the student is not entitled to benefits.
+living_with_parents:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Maintenance loan taper while living with parents
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 6.71
+    2026-01-01: 6.54
+away_outside_london:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Maintenance loan taper away from home outside London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 6.64
+    2026-01-01: 6.47
+away_in_london:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Maintenance loan taper away from home in London
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 6.53
+    2026-01-01: 6.36

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/household_income.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/household_income.yaml
@@ -1,0 +1,29 @@
+description: Student Finance England household income parameters for full-time maintenance loan assessment in England.
+threshold:
+  description: Household income up to this amount receives the full-rate maintenance loan.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Maintenance loan full-rate income threshold
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 25_000
+    2026-01-01: 25_000
+higher_threshold:
+  description: Higher household income threshold used in the two-stage maintenance loan taper for students entitled to benefits.
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Maintenance loan higher taper threshold
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 42_875
+    2026-01-01: 42_875

--- a/policyengine_uk/parameters/gov/dfe/maintenance_loans/over_60.yaml
+++ b/policyengine_uk/parameters/gov/dfe/maintenance_loans/over_60.yaml
@@ -1,0 +1,53 @@
+description: Loan for living costs parameters for higher education students aged 60 or over in England.
+max_amount:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Maximum over-60 loan for living costs
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 4_461
+    2026-01-01: 4_582
+reduction_per_pound:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Household income per pound reduction for over-60 loan for living costs
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 4.27
+    2026-01-01: 4.16
+maximum_income:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Maximum household income for over-60 loan for living costs
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 43_835
+    2026-01-01: 43_835
+minimum_amount:
+  metadata:
+    unit: currency-GBP
+    period: year
+    label: Minimum positive over-60 loan for living costs
+    reference:
+      - title: "Student finance: how you're assessed and paid 2025 to 2026"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2025-to-2026
+      - title: "Student finance: how you're assessed and paid 2026 to 2027"
+        href: https://www.gov.uk/government/publications/student-finance-how-youre-assessed-and-paid/student-finance-how-youre-assessed-and-paid-2026-to-2027
+  values:
+    2025-01-01: 50
+    2026-01-01: 50

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/maintenance_loans/maintenance_loan.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/maintenance_loans/maintenance_loan.yaml
@@ -1,0 +1,186 @@
+- name: Full-time maintenance loan - away from home outside London at full rate
+  period: 2025
+  input:
+    people:
+      student:
+        age: 19
+        current_education: TERTIARY
+        maintenance_loan_living_arrangement: AWAY_OUTSIDE_LONDON
+        maintenance_loan_household_income: 25_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    maintenance_loan: [10_544]
+
+- name: Full-time maintenance loan - living with parents tapered
+  period: 2025
+  input:
+    people:
+      student:
+        age: 19
+        current_education: TERTIARY
+        maintenance_loan_living_arrangement: LIVING_WITH_PARENTS
+        maintenance_loan_household_income: 40_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    maintenance_loan: [6_642]
+
+- name: Full-time maintenance loan - away from home in London tapered
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      student:
+        age: 20
+        current_education: TERTIARY
+        maintenance_loan_living_arrangement: AWAY_IN_LONDON
+        maintenance_loan_household_income: 45_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+        region: LONDON
+  output:
+    maintenance_loan: [10_700]
+
+- name: Full-time maintenance loan - benefits schedule
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      student:
+        age: 22
+        current_education: TERTIARY
+        maintenance_loan_living_arrangement: AWAY_OUTSIDE_LONDON
+        maintenance_loan_household_income: 35_000
+        is_parent: true
+      child:
+        age: 1
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    maintenance_loan_entitled_to_benefits: [true, false]
+    maintenance_loan: [9_688, 0]
+
+- name: Maintenance loan - over 60 schedule
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      student:
+        age: 61
+        current_education: TERTIARY
+        maintenance_loan_household_income: 40_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    maintenance_loan: [949]
+
+- name: Maintenance loan - not in England
+  period: 2025
+  input:
+    people:
+      student:
+        age: 19
+        current_education: TERTIARY
+        maintenance_loan_household_income: 25_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: SCOTLAND
+  output:
+    maintenance_loan: [0]
+
+- name: Maintenance loan - not in higher education
+  period: 2025
+  input:
+    people:
+      student:
+        age: 19
+        current_education: POST_SECONDARY
+        maintenance_loan_household_income: 25_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    maintenance_loan: [0]
+
+- name: Maintenance loan living arrangement proxy detects parental household
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 52
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 30_000
+        is_household_head: true
+      student:
+        age: 20
+        current_education: TERTIARY
+        adjusted_net_income: 2_000
+        is_household_head: false
+    benunits:
+      parent_benunit:
+        members: ["parent"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["parent", "student"]
+        country: ENGLAND
+        region: NORTH_WEST
+  output:
+    maintenance_loan_living_arrangement: [AWAY_OUTSIDE_LONDON, LIVING_WITH_PARENTS]
+    maintenance_loan_household_income: [30_000, 32_000]
+
+- name: Full-time maintenance loan - 2026 full rate uprates to latest published schedule
+  period: 2026
+  input:
+    people:
+      student:
+        age: 19
+        current_education: TERTIARY
+        maintenance_loan_living_arrangement: AWAY_IN_LONDON
+        maintenance_loan_household_income: 25_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+        region: LONDON
+  output:
+    maintenance_loan: [14_135]

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan.py
@@ -1,0 +1,147 @@
+import numpy as np
+
+from policyengine_uk.model_api import *
+from policyengine_uk.variables.household.demographic.highest_education import (
+    EducationType,
+)
+from policyengine_uk.variables.gov.dfe.maintenance_loans.maintenance_loan_living_arrangement import (
+    MaintenanceLoanLivingArrangement,
+)
+
+
+class maintenance_loan(Variable):
+    value_type = float
+    entity = Person
+    label = "Maintenance loan"
+    documentation = (
+        "Approximate full-time England maintenance loan. "
+        "This models the 2025/26 and 2026/27 full-year schedules, including the special-support schedule "
+        "and the separate loan-for-living-costs schedule for students aged 60 or over. "
+        "It relies on proxy variables for living arrangement and assessed household income when those are not provided explicitly."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(person, period, parameters):
+        country = person.household("country", period)
+        in_england = country == country.possible_values.ENGLAND
+        current_education = person("current_education", period)
+        in_higher_education = current_education == EducationType.TERTIARY
+        age = person("age", period)
+        eligible = in_england & in_higher_education & (age >= 18)
+
+        income = person("maintenance_loan_household_income", period)
+        living_arrangement = person("maintenance_loan_living_arrangement", period)
+        benefits_schedule = person("maintenance_loan_entitled_to_benefits", period)
+
+        p = parameters(period).gov.dfe.maintenance_loans
+        threshold = p.household_income.threshold
+
+        full_time_maximum = p.full_time.maximum
+        benefit_maximum = p.full_time.maximum_entitled_to_benefits
+        living_with_parents = (
+            living_arrangement == MaintenanceLoanLivingArrangement.LIVING_WITH_PARENTS
+        )
+        away_in_london = (
+            living_arrangement == MaintenanceLoanLivingArrangement.AWAY_IN_LONDON
+        )
+
+        standard_maximum_amount = select(
+            [living_with_parents, away_in_london],
+            [
+                full_time_maximum.living_with_parents,
+                full_time_maximum.away_in_london,
+            ],
+            default=full_time_maximum.away_outside_london,
+        )
+        benefit_maximum_amount = select(
+            [living_with_parents, away_in_london],
+            [
+                benefit_maximum.living_with_parents,
+                benefit_maximum.away_in_london,
+            ],
+            default=benefit_maximum.away_outside_london,
+        )
+
+        not_entitled_taper = p.full_time.taper.not_entitled
+        one_stage_taper = select(
+            [living_with_parents, away_in_london],
+            [
+                not_entitled_taper.living_with_parents,
+                not_entitled_taper.away_in_london,
+            ],
+            default=not_entitled_taper.away_outside_london,
+        )
+
+        not_entitled_floor_rate = p.full_time.minimum_rate.not_entitled
+        one_stage_floor_rate = select(
+            [living_with_parents, away_in_london],
+            [
+                not_entitled_floor_rate.living_with_parents,
+                not_entitled_floor_rate.away_in_london,
+            ],
+            default=not_entitled_floor_rate.away_outside_london,
+        )
+
+        entitled_first_stage = p.full_time.taper.entitled_to_benefits.first_stage
+        first_stage_taper = select(
+            [living_with_parents, away_in_london],
+            [
+                entitled_first_stage.living_with_parents,
+                entitled_first_stage.away_in_london,
+            ],
+            default=entitled_first_stage.away_outside_london,
+        )
+
+        entitled_second_stage = p.full_time.taper.entitled_to_benefits.second_stage
+        second_stage_taper = select(
+            [living_with_parents, away_in_london],
+            [
+                entitled_second_stage.living_with_parents,
+                entitled_second_stage.away_in_london,
+            ],
+            default=entitled_second_stage.away_outside_london,
+        )
+
+        entitled_floor_rate = p.full_time.minimum_rate.entitled_to_benefits
+        two_stage_floor_rate = select(
+            [living_with_parents, away_in_london],
+            [
+                entitled_floor_rate.living_with_parents,
+                entitled_floor_rate.away_in_london,
+            ],
+            default=entitled_floor_rate.away_outside_london,
+        )
+
+        one_stage_reduction = max_(0, income - threshold) / one_stage_taper
+
+        higher_threshold = p.household_income.higher_threshold
+        first_stage_income = max_(0, min_(income, higher_threshold) - threshold)
+        second_stage_income = max_(0, income - higher_threshold)
+        two_stage_reduction = (
+            first_stage_income / first_stage_taper
+            + second_stage_income / second_stage_taper
+        )
+
+        standard_amount = where(
+            benefits_schedule,
+            max_(
+                two_stage_floor_rate * benefit_maximum_amount,
+                benefit_maximum_amount - two_stage_reduction,
+            ),
+            max_(
+                one_stage_floor_rate * standard_maximum_amount,
+                standard_maximum_amount - one_stage_reduction,
+            ),
+        )
+
+        over_60 = p.over_60
+        over_60_reduction = max_(0, income - threshold) / over_60.reduction_per_pound
+        over_60_amount = where(
+            income > over_60.maximum_income,
+            0,
+            max_(over_60.minimum_amount, over_60.max_amount - over_60_reduction),
+        )
+
+        amount = where(age >= 60, over_60_amount, standard_amount)
+        return eligible * np.round(amount, 0)

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_entitled_to_benefits.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_entitled_to_benefits.py
@@ -1,0 +1,32 @@
+from policyengine_uk.model_api import *
+
+
+class maintenance_loan_entitled_to_benefits(Variable):
+    value_type = bool
+    entity = Person
+    label = "Entitled to benefits for maintenance loan assessment"
+    documentation = (
+        "Proxy for the Student Finance England 'students entitled to benefits' maintenance loan schedule. "
+        "This uses observable parent/disability/ESA-related signals already present in the model."
+    )
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        qualifying_disability_support = (
+            add(
+                person,
+                period,
+                [
+                    "pip_dl",
+                    "pip_m",
+                    "dla_sc",
+                    "dla_m",
+                    "armed_forces_independence_payment",
+                ],
+            )
+            > 0
+        )
+        has_child = person("is_parent", period)
+        receives_income_related_esa = person.benunit("esa_income", period) > 0
+
+        return has_child | qualifying_disability_support | receives_income_related_esa

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_household_income.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_household_income.py
@@ -1,0 +1,44 @@
+from policyengine_uk.model_api import *
+from policyengine_uk.variables.household.demographic.highest_education import (
+    EducationType,
+)
+from policyengine_uk.variables.gov.dfe.maintenance_loans.maintenance_loan_living_arrangement import (
+    MaintenanceLoanLivingArrangement,
+)
+
+
+class maintenance_loan_household_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Maintenance loan assessed household income"
+    documentation = (
+        "Student Finance England-style household income for maintenance loan assessment. "
+        "This can be set explicitly in simulations. By default, the model uses a proxy: "
+        "students living with parents use older non-student household adults plus their own benefit-unit income; "
+        "students living away from home use benefit-unit adjusted net income."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(person, period, parameters):
+        arrangement = person("maintenance_loan_living_arrangement", period)
+        household = person.household
+
+        members_age = household.members("age", period)
+        members_education = household.members("current_education", period)
+        members_income = household.members("adjusted_net_income", period)
+
+        parent_proxy_income = household.sum(
+            ((members_age >= 30) & (members_education != EducationType.TERTIARY))
+            * members_income
+        ) + person.benunit.sum(person.benunit.members("adjusted_net_income", period))
+
+        benunit_income = person.benunit.sum(
+            person.benunit.members("adjusted_net_income", period)
+        )
+
+        return where(
+            arrangement == MaintenanceLoanLivingArrangement.LIVING_WITH_PARENTS,
+            parent_proxy_income,
+            benunit_income,
+        )

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_living_arrangement.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_living_arrangement.py
@@ -1,0 +1,43 @@
+from policyengine_uk.model_api import *
+from policyengine_uk.variables.household.demographic.geography import Region
+
+
+class MaintenanceLoanLivingArrangement(Enum):
+    LIVING_WITH_PARENTS = "Living with parents"
+    AWAY_OUTSIDE_LONDON = "Living away from home and studying outside London"
+    AWAY_IN_LONDON = "Living away from home and studying in London"
+
+
+class maintenance_loan_living_arrangement(Variable):
+    value_type = Enum
+    possible_values = MaintenanceLoanLivingArrangement
+    default_value = MaintenanceLoanLivingArrangement.AWAY_OUTSIDE_LONDON
+    entity = Person
+    label = "Maintenance loan living arrangement"
+    documentation = (
+        "Student Finance England living-arrangement category. "
+        "By default this is proxied from current household composition and region, "
+        "but it can be set explicitly in simulations."
+    )
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        age = person("age", period)
+        is_household_head = person("is_household_head", period)
+        household = person.household
+        region = household("region", period)
+        eldest_age_in_household = household.max(household.members("age", period))
+
+        living_with_parents_proxy = ~is_household_head & (
+            eldest_age_in_household >= age + 15
+        )
+        away_in_london = region == Region.LONDON
+
+        return select(
+            [living_with_parents_proxy, away_in_london],
+            [
+                MaintenanceLoanLivingArrangement.LIVING_WITH_PARENTS,
+                MaintenanceLoanLivingArrangement.AWAY_IN_LONDON,
+            ],
+            default=MaintenanceLoanLivingArrangement.AWAY_OUTSIDE_LONDON,
+        )


### PR DESCRIPTION
## Summary
- add an approximate England full-time higher-education maintenance loan model under `gov.dfe.maintenance_loans`
- add explicit override variables for assessed household income and living arrangement, with documented proxy formulas when those inputs are not supplied
- cover the non-benefit schedule, the special-support schedule, and the separate over-60 loan-for-living-costs schedule for 2025/26 and 2026/27

## Testing
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/maintenance_loans/maintenance_loan.yaml`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_repayment.yaml policyengine_uk/tests/policy/baseline/gov/hmrc/student_loans/student_loan_interest_rate.yaml`

## Notes
- I kept this as a standalone `maintenance_loan` variable rather than defaulting the generic `student_loans` input to the new formula.
- The observed FRS `student_loans` field (`tuborr`) clusters heavily around values like `9000` and `9250`, which strongly suggests it is tuition-fee-dominated or total borrowing, not pure maintenance borrowing.
- That means using `maintenance_loan` as the fallback for `student_loans` would blur two different concepts.

Closes #560
Partially addresses #460
