### PR TITLE
Tighten maintenance loan proxy logic

### DIFF
--- a/changelog.d/maintenance-loan-proxy-fixes.fixed.md
+++ b/changelog.d/maintenance-loan-proxy-fixes.fixed.md
@@ -1,0 +1,1 @@
+Fix maintenance loan proxy logic to require explicit higher-education evidence and improve sponsor-income assessment.

--- a/changelog.d/maintenance-loans.added.md
+++ b/changelog.d/maintenance-loans.added.md
@@ -1,0 +1,1 @@
+- Add an approximate England full-time maintenance loan model, with explicit override inputs for living arrangement and assessed household income.

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/maintenance_loans/maintenance_loan.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/maintenance_loans/maintenance_loan.yaml
@@ -137,6 +137,43 @@
   output:
     maintenance_loan: [0]
 
+- name: Maintenance loan - missing higher-education input does not use age fallback
+  period: 2025
+  input:
+    people:
+      student:
+        age: 19
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    maintenance_loan_eligible: [false]
+    maintenance_loan: [0]
+
+- name: Maintenance loan - explicit current-year non-HE overrides in_HE flag
+  period: 2025
+  input:
+    people:
+      student:
+        age: 21
+        current_education: POST_SECONDARY
+        in_HE: true
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    maintenance_loan_in_higher_education: [false]
+    maintenance_loan_eligible: [false]
+    maintenance_loan: [0]
+
 - name: Maintenance loan living arrangement proxy detects parental household
   period: 2025
   input:
@@ -164,6 +201,307 @@
   output:
     maintenance_loan_living_arrangement: [AWAY_OUTSIDE_LONDON, LIVING_WITH_PARENTS]
     maintenance_loan_household_income: [30_000, 32_000]
+
+- name: Maintenance loan proxy ignores older HE adults as sponsors
+  period: 2025
+  input:
+    people:
+      older_student:
+        age: 26
+        in_HE: true
+        adjusted_net_income: 20_000
+        is_household_head: true
+      student:
+        age: 19
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        is_household_head: false
+    benunits:
+      older_student_benunit:
+        members: ["older_student"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["older_student", "student"]
+        country: ENGLAND
+        region: NORTH_WEST
+  output:
+    maintenance_loan_has_sponsor: [false, false]
+    maintenance_loan_sponsor_income: [0, 0]
+    maintenance_loan_household_income: [20_000, 5_000]
+
+- name: Maintenance loan proxy ignores ambiguous 25-29 adults without explicit education evidence
+  period: 2025
+  input:
+    people:
+      older_adult:
+        age: 26
+        adjusted_net_income: 20_000
+        is_household_head: true
+      student:
+        age: 19
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        is_household_head: false
+    benunits:
+      older_adult_benunit:
+        members: ["older_adult"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["older_adult", "student"]
+        country: ENGLAND
+        region: NORTH_WEST
+  output:
+    maintenance_loan_has_sponsor: [false, false]
+    maintenance_loan_sponsor_income: [0, 0]
+    maintenance_loan_household_income: [20_000, 5_000]
+
+- name: Maintenance loan household income proxy includes younger sponsor adults
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 29
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 30_000
+        is_household_head: true
+      student:
+        age: 19
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        is_household_head: false
+    benunits:
+      parent_benunit:
+        members: ["parent"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["parent", "student"]
+        country: ENGLAND
+  output:
+    maintenance_loan_sponsor_income: [0, 30_000]
+    maintenance_loan_has_sponsor: [false, true]
+    maintenance_loan_household_income: [30_000, 35_000]
+
+- name: Maintenance loan sponsor proxy uses nearest older sponsor benunit
+  period: 2025
+  input:
+    people:
+      grandparent:
+        age: 62
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 40_000
+        is_household_head: true
+      parent:
+        age: 45
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 30_000
+        is_household_head: false
+      student:
+        age: 19
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        is_household_head: false
+    benunits:
+      grandparent_benunit:
+        members: ["grandparent"]
+      parent_benunit:
+        members: ["parent"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["grandparent", "parent", "student"]
+        country: ENGLAND
+        region: NORTH_WEST
+  output:
+    maintenance_loan_sponsor_income: [0, 0, 30_000]
+    maintenance_loan_household_income: [40_000, 30_000, 35_000]
+
+- name: Maintenance loan sponsor detection survives zero sponsor income
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 45
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 0
+        is_household_head: true
+      student:
+        age: 19
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        is_household_head: false
+    benunits:
+      parent_benunit:
+        members: ["parent"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["parent", "student"]
+        country: ENGLAND
+        region: NORTH_WEST
+  output:
+    maintenance_loan_has_sponsor: [false, true]
+    maintenance_loan_living_arrangement: [AWAY_OUTSIDE_LONDON, LIVING_WITH_PARENTS]
+    maintenance_loan_household_income: [0, 5_000]
+
+- name: Maintenance loan sponsor income sums both parents in the same sponsor benunit
+  period: 2025
+  input:
+    people:
+      parent_1:
+        age: 45
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 30_000
+        is_household_head: true
+      parent_2:
+        age: 43
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 20_000
+        is_household_head: false
+      student:
+        age: 19
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        is_household_head: false
+    benunits:
+      parent_benunit:
+        members: ["parent_1", "parent_2"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["parent_1", "parent_2", "student"]
+        country: ENGLAND
+        region: NORTH_WEST
+  output:
+    maintenance_loan_sponsor_income: [0, 0, 50_000]
+    maintenance_loan_household_income: [50_000, 50_000, 55_000]
+
+- name: Maintenance loan household income proxy does not double count partner income
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 45
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 30_000
+        is_household_head: true
+      student:
+        age: 20
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        is_household_head: false
+      partner:
+        age: 21
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 10_000
+        is_household_head: false
+    benunits:
+      parent_benunit:
+        members: ["parent"]
+      student_benunit:
+        members: ["student", "partner"]
+    households:
+      household:
+        members: ["parent", "student", "partner"]
+        country: ENGLAND
+  output:
+    maintenance_loan_household_income: [30_000, 15_000, 15_000]
+
+- name: Maintenance loan proxy treats lone parents as independent
+  period: 2025
+  input:
+    people:
+      grandparent:
+        age: 55
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 25_000
+        is_household_head: true
+      student:
+        age: 21
+        current_education: TERTIARY
+        adjusted_net_income: 6_000
+        is_household_head: false
+        is_parent: true
+      child:
+        age: 1
+        is_child: true
+    benunits:
+      grandparent_benunit:
+        members: ["grandparent"]
+      student_benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["grandparent", "student", "child"]
+        country: ENGLAND
+        region: NORTH_WEST
+  output:
+    maintenance_loan_living_arrangement: [AWAY_OUTSIDE_LONDON, AWAY_OUTSIDE_LONDON, AWAY_OUTSIDE_LONDON]
+    maintenance_loan_household_income: [25_000, 6_000, 6_000]
+
+- name: Maintenance loan proxy does not treat older renters as parents
+  period: 2025
+  input:
+    people:
+      flatmate:
+        age: 40
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 25_000
+        is_household_head: true
+      student:
+        age: 20
+        current_education: TERTIARY
+        adjusted_net_income: 4_000
+        is_household_head: false
+    benunits:
+      flatmate_benunit:
+        members: ["flatmate"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["flatmate", "student"]
+        country: ENGLAND
+        region: LONDON
+        tenure_type: RENT_PRIVATELY
+  output:
+    maintenance_loan_living_arrangement: [AWAY_IN_LONDON, AWAY_IN_LONDON]
+    maintenance_loan_household_income: [25_000, 4_000]
+
+- name: Maintenance loan household income proxy keeps sponsor income when arrangement is set away from home
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 45
+        current_education: NOT_IN_EDUCATION
+        adjusted_net_income: 30_000
+        is_household_head: true
+      student:
+        age: 19
+        current_education: TERTIARY
+        adjusted_net_income: 5_000
+        maintenance_loan_living_arrangement: AWAY_OUTSIDE_LONDON
+        is_household_head: false
+    benunits:
+      parent_benunit:
+        members: ["parent"]
+      student_benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["parent", "student"]
+        country: ENGLAND
+  output:
+    maintenance_loan_household_income: [30_000, 35_000]
 
 - name: Full-time maintenance loan - 2026 full rate uprates to latest published schedule
   period: 2026

--- a/policyengine_uk/tests/test_maintenance_loan_proxies.py
+++ b/policyengine_uk/tests/test_maintenance_loan_proxies.py
@@ -1,0 +1,121 @@
+from policyengine_uk import Simulation
+
+
+def test_maintenance_loan_in_higher_education_uses_prior_year_current_education():
+    sim = Simulation(
+        situation={
+            "people": {
+                "student": {
+                    "age": {2024: 18, 2025: 19},
+                    "current_education": {2024: "TERTIARY"},
+                }
+            },
+            "benunits": {"benunit": {"members": ["student"]}},
+            "households": {
+                "household": {"members": ["student"], "country": {2025: "ENGLAND"}}
+            },
+        }
+    )
+
+    result = sim.calculate("maintenance_loan_in_higher_education", 2025)
+
+    assert bool(result[0]) is True
+
+
+def test_maintenance_loan_in_higher_education_uses_current_year_in_he():
+    sim = Simulation(
+        situation={
+            "people": {
+                "student": {
+                    "age": {2025: 19},
+                    "in_HE": {2025: True},
+                }
+            },
+            "benunits": {"benunit": {"members": ["student"]}},
+            "households": {
+                "household": {"members": ["student"], "country": {2025: "ENGLAND"}}
+            },
+        }
+    )
+
+    result = sim.calculate("maintenance_loan_in_higher_education", 2025)
+
+    assert bool(result[0]) is True
+
+
+def test_maintenance_loan_current_year_current_education_overrides_in_he():
+    sim = Simulation(
+        situation={
+            "people": {
+                "student": {
+                    "age": {2025: 19},
+                    "current_education": {2025: "POST_SECONDARY"},
+                    "in_HE": {2025: True},
+                }
+            },
+            "benunits": {"benunit": {"members": ["student"]}},
+            "households": {
+                "household": {"members": ["student"], "country": {2025: "ENGLAND"}}
+            },
+        }
+    )
+
+    result = sim.calculate("maintenance_loan_in_higher_education", 2025)
+
+    assert bool(result[0]) is False
+
+
+def test_maintenance_loan_in_higher_education_uses_prior_year_in_he():
+    sim = Simulation(
+        situation={
+            "people": {
+                "student": {
+                    "age": {2024: 18, 2025: 19},
+                    "in_HE": {2024: True},
+                }
+            },
+            "benunits": {"benunit": {"members": ["student"]}},
+            "households": {
+                "household": {"members": ["student"], "country": {2025: "ENGLAND"}}
+            },
+        }
+    )
+
+    result = sim.calculate("maintenance_loan_in_higher_education", 2025)
+
+    assert bool(result[0]) is True
+
+
+def test_maintenance_loan_in_higher_education_handles_mixed_population_inputs():
+    sim = Simulation(
+        situation={
+            "people": {
+                "student_with_current_education": {
+                    "age": {2025: 19},
+                    "current_education": {2025: "TERTIARY"},
+                },
+                "student_with_in_he": {
+                    "age": {2025: 19},
+                    "in_HE": {2025: True},
+                },
+            },
+            "benunits": {
+                "benunit_1": {"members": ["student_with_current_education"]},
+                "benunit_2": {"members": ["student_with_in_he"]},
+            },
+            "households": {
+                "household": {
+                    "members": [
+                        "student_with_current_education",
+                        "student_with_in_he",
+                    ],
+                    "country": {2025: "ENGLAND"},
+                }
+            },
+        }
+    )
+
+    result = sim.calculate("maintenance_loan_in_higher_education", 2025)
+
+    assert bool(result[0]) is True
+    assert bool(result[1]) is True

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan.py
@@ -1,9 +1,6 @@
 import numpy as np
 
 from policyengine_uk.model_api import *
-from policyengine_uk.variables.household.demographic.highest_education import (
-    EducationType,
-)
 from policyengine_uk.variables.gov.dfe.maintenance_loans.maintenance_loan_living_arrangement import (
     MaintenanceLoanLivingArrangement,
 )
@@ -17,18 +14,15 @@ class maintenance_loan(Variable):
         "Approximate full-time England maintenance loan. "
         "This models the 2025/26 and 2026/27 full-year schedules, including the special-support schedule "
         "and the separate loan-for-living-costs schedule for students aged 60 or over. "
-        "It relies on proxy variables for living arrangement and assessed household income when those are not provided explicitly."
+        "It relies on proxy variables for eligibility, living arrangement, and assessed household income "
+        "when those are not provided explicitly."
     )
     definition_period = YEAR
     unit = GBP
 
     def formula(person, period, parameters):
-        country = person.household("country", period)
-        in_england = country == country.possible_values.ENGLAND
-        current_education = person("current_education", period)
-        in_higher_education = current_education == EducationType.TERTIARY
         age = person("age", period)
-        eligible = in_england & in_higher_education & (age >= 18)
+        eligible = person("maintenance_loan_eligible", period)
 
         income = person("maintenance_loan_household_income", period)
         living_arrangement = person("maintenance_loan_living_arrangement", period)

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_candidate_benunit_income.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_candidate_benunit_income.py
@@ -1,0 +1,16 @@
+from policyengine_uk.model_api import *
+
+
+class maintenance_loan_candidate_benunit_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Maintenance loan candidate sponsor benefit-unit income"
+    documentation = (
+        "Benefit-unit adjusted net income for a person, used when selecting a "
+        "maintenance loan sponsor proxy from household members."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(person, period, parameters):
+        return person.benunit.sum(person.benunit.members("adjusted_net_income", period))

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_eligible.py
@@ -1,0 +1,21 @@
+from policyengine_uk.model_api import *
+
+
+class maintenance_loan_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for maintenance loan"
+    documentation = (
+        "Whether the person is eligible for the maintenance loan model. "
+        "This can be set explicitly in simulations. By default, the model requires "
+        "the England maintenance-loan system, age 18+, and explicit higher-education evidence "
+        "rather than the age-based current_education fallback."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        in_england = person("maintenance_loan_in_england_system", period)
+        age = person("age", period)
+        higher_education = person("maintenance_loan_in_higher_education", period)
+        return in_england & (age >= 18) & higher_education

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_has_sponsor.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_has_sponsor.py
@@ -1,0 +1,29 @@
+from policyengine_uk.model_api import *
+
+
+class maintenance_loan_has_sponsor(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has maintenance loan sponsor"
+    documentation = "Whether the model detects a plausible sponsor in the household for maintenance loan purposes."
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        household = person.household
+        age = person("age", period)
+        in_higher_education = person("maintenance_loan_in_higher_education", period)
+        adult_index = person("adult_index", period)
+        is_adult = person("is_adult", period)
+        in_he = in_higher_education | person("in_HE", period)
+
+        sponsor_candidate = is_adult & np.logical_not(in_he) & (age >= 29)
+        head_candidate = sponsor_candidate & (adult_index == 1)
+        second_candidate = sponsor_candidate & (adult_index == 2)
+
+        head_age = household.max(head_candidate * age)
+        second_age = household.max(second_candidate * age)
+
+        head_eligible = (head_age >= age + 10) & (head_age <= age + 35)
+        second_eligible = (second_age >= age + 10) & (second_age <= age + 35)
+
+        return in_higher_education & (head_eligible | second_eligible)

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_household_income.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_household_income.py
@@ -1,10 +1,5 @@
 from policyengine_uk.model_api import *
-from policyengine_uk.variables.household.demographic.highest_education import (
-    EducationType,
-)
-from policyengine_uk.variables.gov.dfe.maintenance_loans.maintenance_loan_living_arrangement import (
-    MaintenanceLoanLivingArrangement,
-)
+import numpy as np
 
 
 class maintenance_loan_household_income(Variable):
@@ -14,31 +9,42 @@ class maintenance_loan_household_income(Variable):
     documentation = (
         "Student Finance England-style household income for maintenance loan assessment. "
         "This can be set explicitly in simulations. By default, the model uses a proxy: "
-        "students living with parents use older non-student household adults plus their own benefit-unit income; "
-        "students living away from home use benefit-unit adjusted net income."
+        "dependent students use sponsor income from a selected older household benefit unit, "
+        "plus their own benefit-unit income; otherwise the model uses benefit-unit adjusted net income."
     )
     definition_period = YEAR
     unit = GBP
 
     def formula(person, period, parameters):
-        arrangement = person("maintenance_loan_living_arrangement", period)
-        household = person.household
-
-        members_age = household.members("age", period)
-        members_education = household.members("current_education", period)
-        members_income = household.members("adjusted_net_income", period)
-
-        parent_proxy_income = household.sum(
-            ((members_age >= 30) & (members_education != EducationType.TERTIARY))
-            * members_income
-        ) + person.benunit.sum(person.benunit.members("adjusted_net_income", period))
-
+        in_higher_education = person("maintenance_loan_in_higher_education", period)
+        has_sponsor = person("maintenance_loan_has_sponsor", period)
+        sponsor_income = person("maintenance_loan_sponsor_income", period)
+        is_couple = person.benunit("is_couple", period)
+        is_household_head = person("is_household_head", period)
+        is_parent = person("is_parent", period)
+        tenure_holder = person.household.get_holder("tenure_type")
+        has_explicit_tenure = (
+            tenure_holder.get_array(period) is not None
+            or tenure_holder.get_array(period.last_year) is not None
+        )
+        is_renting = (
+            person.benunit("benunit_is_renting", period)
+            if has_explicit_tenure
+            else np.zeros_like(has_sponsor, dtype=bool)
+        )
         benunit_income = person.benunit.sum(
             person.benunit.members("adjusted_net_income", period)
         )
-
+        dependent_student_proxy = (
+            in_higher_education
+            & has_sponsor
+            & np.logical_not(is_couple)
+            & np.logical_not(is_household_head)
+            & np.logical_not(is_parent)
+            & np.logical_not(is_renting)
+        )
         return where(
-            arrangement == MaintenanceLoanLivingArrangement.LIVING_WITH_PARENTS,
-            parent_proxy_income,
+            dependent_student_proxy,
+            sponsor_income + benunit_income,
             benunit_income,
         )

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_in_england_system.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_in_england_system.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+
+class maintenance_loan_in_england_system(Variable):
+    value_type = bool
+    entity = Person
+    label = "In Student Finance England maintenance loan system"
+    documentation = (
+        "Whether the person should be treated as falling under the England maintenance-loan system. "
+        "This can be set explicitly in simulations. By default, the model proxies this from current household country."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        country = person.household("country", period)
+        return country == country.possible_values.ENGLAND

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_in_higher_education.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_in_higher_education.py
@@ -35,7 +35,9 @@ class maintenance_loan_in_higher_education(Variable):
         prior_in_he = person("in_HE", period.last_year)
 
         current_education_is_explicit = (
-            current_education != default_education if has_current_education else false_array
+            current_education != default_education
+            if has_current_education
+            else false_array
         )
         prior_current_education_is_explicit = (
             prior_current_education != default_education

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_in_higher_education.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_in_higher_education.py
@@ -1,0 +1,65 @@
+from policyengine_uk.model_api import *
+from policyengine_uk.variables.household.demographic.highest_education import (
+    EducationType,
+)
+
+
+class maintenance_loan_in_higher_education(Variable):
+    value_type = bool
+    entity = Person
+    label = "In higher education for maintenance loan purposes"
+    documentation = (
+        "Whether the person has explicit higher-education evidence for maintenance loan modelling. "
+        "Non-default current-year current_education takes precedence over in_HE; otherwise the model falls back "
+        "to current-year in_HE, then non-default prior-year current_education, then prior-year in_HE."
+    )
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        current_education_holder = person.get_holder("current_education")
+        in_he_holder = person.get_holder("in_HE")
+        age = person("age", period)
+        false_array = np.zeros_like(age, dtype=bool)
+        default_education = current_education_holder.variable.default_value
+
+        has_current_education = current_education_holder.get_array(period) is not None
+        has_current_in_he = in_he_holder.get_array(period) is not None
+        has_prior_current_education = (
+            current_education_holder.get_array(period.last_year) is not None
+        )
+        has_prior_in_he = in_he_holder.get_array(period.last_year) is not None
+
+        current_education = person("current_education", period)
+        prior_current_education = person("current_education", period.last_year)
+        current_in_he = person("in_HE", period)
+        prior_in_he = person("in_HE", period.last_year)
+
+        current_education_is_explicit = (
+            current_education != default_education if has_current_education else false_array
+        )
+        prior_current_education_is_explicit = (
+            prior_current_education != default_education
+            if has_prior_current_education
+            else false_array
+        )
+
+        current_education_is_he = current_education == EducationType.TERTIARY
+        prior_current_education_is_he = (
+            prior_current_education == EducationType.TERTIARY
+        )
+
+        return select(
+            [
+                current_education_is_explicit,
+                current_in_he if has_current_in_he else false_array,
+                prior_current_education_is_explicit,
+                prior_in_he if has_prior_in_he else false_array,
+            ],
+            [
+                current_education_is_he,
+                np.ones_like(age, dtype=bool),
+                prior_current_education_is_he,
+                np.ones_like(age, dtype=bool),
+            ],
+            default=false_array,
+        )

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_living_arrangement.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_living_arrangement.py
@@ -1,5 +1,6 @@
 from policyengine_uk.model_api import *
 from policyengine_uk.variables.household.demographic.geography import Region
+import numpy as np
 
 
 class MaintenanceLoanLivingArrangement(Enum):
@@ -22,14 +23,30 @@ class maintenance_loan_living_arrangement(Variable):
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        age = person("age", period)
+        in_higher_education = person("maintenance_loan_in_higher_education", period)
+        has_sponsor = person("maintenance_loan_has_sponsor", period)
         is_household_head = person("is_household_head", period)
-        household = person.household
-        region = household("region", period)
-        eldest_age_in_household = household.max(household.members("age", period))
+        is_couple = person.benunit("is_couple", period)
+        is_parent = person("is_parent", period)
+        tenure_holder = person.household.get_holder("tenure_type")
+        has_explicit_tenure = (
+            tenure_holder.get_array(period) is not None
+            or tenure_holder.get_array(period.last_year) is not None
+        )
+        is_renting = (
+            person.benunit("benunit_is_renting", period)
+            if has_explicit_tenure
+            else np.zeros_like(has_sponsor, dtype=bool)
+        )
+        region = person.household("region", period)
 
-        living_with_parents_proxy = ~is_household_head & (
-            eldest_age_in_household >= age + 15
+        living_with_parents_proxy = (
+            in_higher_education
+            & has_sponsor
+            & np.logical_not(is_household_head)
+            & np.logical_not(is_couple)
+            & np.logical_not(is_parent)
+            & np.logical_not(is_renting)
         )
         away_in_london = region == Region.LONDON
 

--- a/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_sponsor_income.py
+++ b/policyengine_uk/variables/gov/dfe/maintenance_loans/maintenance_loan_sponsor_income.py
@@ -1,0 +1,39 @@
+from policyengine_uk.model_api import *
+
+
+class maintenance_loan_sponsor_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Maintenance loan sponsor income"
+    documentation = (
+        "Proxy sponsor income used for maintenance loan assessment. "
+        "This captures the selected sponsor benefit unit's income."
+    )
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(person, period, parameters):
+        household = person.household
+        age = person("age", period)
+        in_higher_education = person("maintenance_loan_in_higher_education", period)
+        adult_index = person("adult_index", period)
+        is_adult = person("is_adult", period)
+        in_he = in_higher_education | person("in_HE", period)
+        benunit_income = person("maintenance_loan_candidate_benunit_income", period)
+
+        sponsor_candidate = is_adult & np.logical_not(in_he) & (age >= 29)
+        head_candidate = sponsor_candidate & (adult_index == 1)
+        second_candidate = sponsor_candidate & (adult_index == 2)
+
+        head_age = household.max(head_candidate * age)
+        second_age = household.max(second_candidate * age)
+        head_income = household.sum(head_candidate * benunit_income)
+        second_income = household.sum(second_candidate * benunit_income)
+
+        head_eligible = (head_age >= age + 10) & (head_age <= age + 35)
+        second_eligible = (second_age >= age + 10) & (second_age <= age + 35)
+
+        sponsor_income = where(second_eligible, second_income, head_income)
+        has_sponsor = in_higher_education & (head_eligible | second_eligible)
+
+        return where(has_sponsor, sponsor_income, 0)


### PR DESCRIPTION
## Summary
- split maintenance loan eligibility into explicit helper variables for England-system scope and higher-education evidence
- tighten the sponsor, living-arrangement, and assessed-household-income proxies using a fast two-candidate adult proxy plus sponsor benefit-unit income
- add focused policy and Python regression coverage for higher-education evidence precedence and sponsor-income edge cases

## Validation
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/maintenance_loans/maintenance_loan.yaml`
- `uv run pytest -q policyengine_uk/tests/test_maintenance_loan_proxies.py`
- full 2025 maintenance-loan chain on `enhanced_frs_2023_24.h5`: candidate benunit income `0.02s`, sponsor detection `0.05s`, sponsor income `0.01s`, household income `0.01s`, award `0.02s`

## Aggregate Impact
Measured on `enhanced_frs_2023_24.h5` at `2025`, comparing merged `#1586` against this branch on current weights.

- `maintenance_loan` mean: `143.9555 -> 162.5093` (`+18.5539`, `+12.9%`)
- `maintenance_loan` recipient mean: `8057.7370 -> 9096.2669` (`+1038.5298`, `+12.9%`)
- `maintenance_loan` recipient rate: unchanged at `1.78655%`
- `household_tax` mean: unchanged at `24904.1915`
- `hbai_household_net_income` mean: unchanged at `44999.9928`
- relative poverty AHC: unchanged at `21.4478%`
- relative poverty BHC: unchanged at `17.2909%`

## Caveat
- `maintenance_loan_in_england_system` still proxies Student Finance England membership from current household country, so cross-border domicile cases remain approximate.
