### PR TITLE
Add Childcare Grant model

### DIFF
--- a/changelog.d/childcare-grant.added.md
+++ b/changelog.d/childcare-grant.added.md
@@ -1,0 +1,1 @@
+- Add a first-pass Childcare Grant model for England full-time undergraduates.

--- a/policyengine_uk/parameters/gov/dfe/childcare_grant/coverage_rate.yaml
+++ b/policyengine_uk/parameters/gov/dfe/childcare_grant/coverage_rate.yaml
@@ -1,0 +1,11 @@
+description: Proportion of eligible childcare costs covered by Childcare Grant.
+values:
+  2025-01-01: 0.85
+  2026-01-01: 0.85
+metadata:
+  unit: /1
+  period: year
+  label: Childcare Grant coverage rate
+  reference:
+    - title: Childcare Grant - What you'll get
+      href: https://www.gov.uk/childcare-grant/what-youll-get

--- a/policyengine_uk/parameters/gov/dfe/childcare_grant/eligible_child/max_age/special_educational_needs.yaml
+++ b/policyengine_uk/parameters/gov/dfe/childcare_grant/eligible_child/max_age/special_educational_needs.yaml
@@ -1,0 +1,11 @@
+description: Maximum child age for Childcare Grant where the child has special educational needs.
+values:
+  2025-01-01: 17
+  2026-01-01: 17
+metadata:
+  unit: year
+  period: year
+  label: Childcare Grant child maximum age with special educational needs
+  reference:
+    - title: Childcare Grant - Eligibility
+      href: https://www.gov.uk/childcare-grant/eligibility

--- a/policyengine_uk/parameters/gov/dfe/childcare_grant/eligible_child/max_age/standard.yaml
+++ b/policyengine_uk/parameters/gov/dfe/childcare_grant/eligible_child/max_age/standard.yaml
@@ -1,0 +1,11 @@
+description: Maximum child age for Childcare Grant under the standard rule.
+values:
+  2025-01-01: 15
+  2026-01-01: 15
+metadata:
+  unit: year
+  period: year
+  label: Childcare Grant child maximum age
+  reference:
+    - title: Childcare Grant - Eligibility
+      href: https://www.gov.uk/childcare-grant/eligibility

--- a/policyengine_uk/parameters/gov/dfe/childcare_grant/income_limit/one_child.yaml
+++ b/policyengine_uk/parameters/gov/dfe/childcare_grant/income_limit/one_child.yaml
@@ -1,0 +1,11 @@
+description: Household income limit for Childcare Grant where the application covers one child.
+values:
+  2025-01-01: 20_107.23
+  2026-01-01: 20_107.23
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Childcare Grant income limit for one child
+  reference:
+    - title: Childcare Grant - Eligibility
+      href: https://www.gov.uk/childcare-grant/eligibility

--- a/policyengine_uk/parameters/gov/dfe/childcare_grant/income_limit/two_or_more_children.yaml
+++ b/policyengine_uk/parameters/gov/dfe/childcare_grant/income_limit/two_or_more_children.yaml
@@ -1,0 +1,11 @@
+description: Household income limit for Childcare Grant where the application covers two or more children.
+values:
+  2025-01-01: 28_914.47
+  2026-01-01: 28_914.47
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Childcare Grant income limit for two or more children
+  reference:
+    - title: Childcare Grant - Eligibility
+      href: https://www.gov.uk/childcare-grant/eligibility

--- a/policyengine_uk/parameters/gov/dfe/childcare_grant/weekly_maximum/one_child.yaml
+++ b/policyengine_uk/parameters/gov/dfe/childcare_grant/weekly_maximum/one_child.yaml
@@ -1,0 +1,11 @@
+description: Maximum weekly Childcare Grant amount for one child.
+values:
+  2025-01-01: 199.62
+  2026-01-01: 199.62
+metadata:
+  unit: currency-GBP
+  period: week
+  label: Childcare Grant weekly maximum for one child
+  reference:
+    - title: Childcare Grant - What you'll get
+      href: https://www.gov.uk/childcare-grant/what-youll-get

--- a/policyengine_uk/parameters/gov/dfe/childcare_grant/weekly_maximum/two_or_more_children.yaml
+++ b/policyengine_uk/parameters/gov/dfe/childcare_grant/weekly_maximum/two_or_more_children.yaml
@@ -1,0 +1,11 @@
+description: Maximum weekly Childcare Grant amount for two or more children.
+values:
+  2025-01-01: 342.24
+  2026-01-01: 342.24
+metadata:
+  unit: currency-GBP
+  period: week
+  label: Childcare Grant weekly maximum for two or more children
+  reference:
+    - title: Childcare Grant - What you'll get
+      href: https://www.gov.uk/childcare-grant/what-youll-get

--- a/policyengine_uk/programs.yaml
+++ b/policyengine_uk/programs.yaml
@@ -358,7 +358,7 @@ programs:
     variable: childcare_grant
     parameter_prefix: gov.dfe.childcare_grant
     verified_start_year: 2025
-    notes: First-pass full-time undergraduate England model using explicit full-time and childcare-support inputs plus maintenance-loan proxies
+    notes: First-pass full-time undergraduate England model using explicit full-time, SEN, and childcare-support inputs plus maintenance-loan proxies; childcare_expenses are treated as out-of-pocket spend net of free hours
 
   # --- DCMS programs ---
   - id: tv_licence

--- a/policyengine_uk/programs.yaml
+++ b/policyengine_uk/programs.yaml
@@ -348,6 +348,18 @@ programs:
     verified_end_year: 2025
     notes: Universal (15h), extended (30h), and targeted entitlements; parameters need expansion for later years
 
+  - id: childcare_grant
+    name: Childcare Grant
+    full_name: Student Finance England Childcare Grant
+    category: Benefits
+    agency: DfE
+    status: partial
+    coverage: England
+    variable: childcare_grant
+    parameter_prefix: gov.dfe.childcare_grant
+    verified_start_year: 2025
+    notes: First-pass full-time undergraduate England model using explicit full-time and childcare-support inputs plus maintenance-loan proxies
+
   # --- DCMS programs ---
   - id: tv_licence
     name: TV Licence

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/childcare_grant/childcare_grant.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/childcare_grant/childcare_grant.yaml
@@ -146,6 +146,31 @@
   output:
     childcare_grant: [0, 0]
 
+- name: Childcare Grant does not treat disability as SEN by default
+  period: 2025
+  input:
+    people:
+      student:
+        age: 24
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 4_000
+      child:
+        age: 16
+        is_child: true
+        is_disabled_for_benefits: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_child_eligible: [false, false]
+    childcare_grant: [0, 0]
+
 - name: Childcare Grant is incompatible with UC childcare element
   period: 2025
   input:
@@ -259,6 +284,31 @@
         age: 5
         is_child: true
         tax_free_childcare: 1_000
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant excludes nanny-provided care from 2026 onward
+  period: 2026
+  input:
+    people:
+      student:
+        age: 22
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 6_000
+        childcare_grant_provider_is_nanny: true
+      child:
+        age: 5
+        is_child: true
     benunits:
       benunit:
         members: ["student", "child"]

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/childcare_grant/childcare_grant.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/childcare_grant/childcare_grant.yaml
@@ -1,0 +1,299 @@
+- name: Childcare Grant reimburses 85 percent below one-child cap
+  period: 2025
+  input:
+    people:
+      student:
+        age: 21
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 5_000
+      child:
+        age: 4
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_eligible: [true, false]
+    childcare_grant: [4_250, 0]
+
+- name: Childcare Grant is capped at the one-child weekly maximum
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      student:
+        age: 20
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 20_000
+      child:
+        age: 3
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant: [10_380.24, 0]
+
+- name: Childcare Grant uses the two-or-more-children cap
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      student:
+        age: 23
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 25_000
+      child_1:
+        age: 6
+        is_child: true
+      child_2:
+        age: 8
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child_1", "child_2"]
+    households:
+      household:
+        members: ["student", "child_1", "child_2"]
+        country: ENGLAND
+  output:
+    childcare_grant: [17_796.48, 0, 0]
+
+- name: Childcare Grant income limit is strict for one child
+  period: 2025
+  input:
+    people:
+      student:
+        age: 19
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 5_000
+        childcare_grant_household_income: 20_107.23
+      child:
+        age: 2
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant permits children under 17 with special educational needs
+  period: 2025
+  input:
+    people:
+      student:
+        age: 24
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 4_000
+      child:
+        age: 16
+        is_child: true
+        childcare_grant_child_has_special_educational_needs: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_child_eligible: [false, true]
+    childcare_grant: [3_400, 0]
+
+- name: Childcare Grant excludes 16 year olds without special educational needs
+  period: 2025
+  input:
+    people:
+      student:
+        age: 24
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 4_000
+      child:
+        age: 16
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant is incompatible with UC childcare element
+  period: 2025
+  input:
+    people:
+      student:
+        age: 21
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 6_000
+      child:
+        age: 4
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+        uc_childcare_work_condition: true
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    uc_childcare_element: [5_100]
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant is incompatible with Postgraduate Loan support
+  period: 2025
+  input:
+    people:
+      student:
+        age: 25
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 6_000
+        childcare_grant_receives_postgraduate_loan: true
+      child:
+        age: 5
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant is incompatible with NHS childcare support
+  period: 2025
+  input:
+    people:
+      student:
+        age: 22
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 6_000
+        childcare_grant_receives_nhs_childcare_support: true
+      child:
+        age: 5
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant excludes part-time students by default
+  period: 2025
+  input:
+    people:
+      student:
+        age: 22
+        is_parent: true
+        current_education: TERTIARY
+        childcare_expenses: 6_000
+      child:
+        age: 5
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant is incompatible with Tax-Free Childcare
+  period: 2025
+  input:
+    people:
+      student:
+        age: 22
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 6_000
+      child:
+        age: 5
+        is_child: true
+        tax_free_childcare: 1_000
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]
+
+- name: Childcare Grant is incompatible with WTC childcare element
+  period: 2025
+  input:
+    people:
+      student:
+        age: 22
+        is_parent: true
+        current_education: TERTIARY
+        childcare_grant_full_time_student: true
+        childcare_expenses: 6_000
+        employment_income: 10_000
+        hours_worked: 1_040
+        working_tax_credit_reported: 1
+      child:
+        age: 5
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    WTC_childcare_element: [4_200]
+    childcare_grant_eligible: [false, false]
+    childcare_grant: [0, 0]

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant.py
@@ -1,0 +1,28 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant(Variable):
+    value_type = float
+    entity = Person
+    label = "Childcare Grant"
+    documentation = (
+        "Student Finance England Childcare Grant for full-time undergraduates with dependent children. "
+        "The model reimburses 85% of annual childcare expenses, capped by the official weekly maxima."
+    )
+    definition_period = YEAR
+    unit = GBP
+    defined_for = "childcare_grant_eligible"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.dfe.childcare_grant
+        eligible_children = person.benunit("childcare_grant_eligible_children", period)
+        childcare_expenses = person("childcare_expenses", period)
+
+        weekly_cap = where(
+            eligible_children == 1,
+            p.weekly_maximum.one_child,
+            p.weekly_maximum.two_or_more_children,
+        )
+        annual_cap = weekly_cap * WEEKS_IN_YEAR
+        covered_expenses = childcare_expenses * p.coverage_rate
+        return min_(covered_expenses, annual_cap)

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant.py
@@ -7,7 +7,9 @@ class childcare_grant(Variable):
     label = "Childcare Grant"
     documentation = (
         "Student Finance England Childcare Grant for full-time undergraduates with dependent children. "
-        "The model reimburses 85% of annual childcare expenses, capped by the official weekly maxima."
+        "The model reimburses 85% of annual out-of-pocket childcare expenses, capped by the official "
+        "weekly maxima. `childcare_expenses` should therefore exclude any hours already covered by free "
+        "childcare entitlements."
     )
     definition_period = YEAR
     unit = GBP

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_child_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_child_eligible.py
@@ -1,0 +1,18 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_child_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Child is eligible for Childcare Grant"
+    documentation = (
+        "Whether the child satisfies the Childcare Grant child-age condition."
+    )
+    definition_period = YEAR
+    defined_for = "is_child"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.dfe.childcare_grant.eligible_child.max_age
+        has_sen = person("childcare_grant_child_has_special_educational_needs", period)
+        max_age = where(has_sen, p.special_educational_needs, p.standard)
+        return person("age", period) < max_age

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_child_has_special_educational_needs.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_child_has_special_educational_needs.py
@@ -1,0 +1,16 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_child_has_special_educational_needs(Variable):
+    value_type = bool
+    entity = Person
+    label = "Child has special educational needs for Childcare Grant"
+    documentation = (
+        "Whether the child should be treated as having special educational needs for Childcare Grant age rules. "
+        "This can be set explicitly in simulations. By default it uses the disability-for-benefits proxy."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("is_disabled_for_benefits", period)

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_child_has_special_educational_needs.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_child_has_special_educational_needs.py
@@ -7,10 +7,9 @@ class childcare_grant_child_has_special_educational_needs(Variable):
     label = "Child has special educational needs for Childcare Grant"
     documentation = (
         "Whether the child should be treated as having special educational needs for Childcare Grant age rules. "
-        "This can be set explicitly in simulations. By default it uses the disability-for-benefits proxy."
+        "This must currently be set explicitly in simulations because the core model "
+        "does not expose a reliable special-educational-needs proxy."
     )
     definition_period = YEAR
     set_input = set_input_dispatch_by_period
-
-    def formula(person, period, parameters):
-        return person("is_disabled_for_benefits", period)
+    default_value = False

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible.py
@@ -1,0 +1,66 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Childcare Grant"
+    documentation = (
+        "Whether the person is eligible for Childcare Grant under the England full-time undergraduate scheme. "
+        "This is a first-pass model using existing student-finance and childcare-support proxies."
+    )
+    definition_period = YEAR
+    defined_for = "would_claim_childcare_grant"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.dfe.childcare_grant
+
+        in_england = person.household("country", period) == person.household(
+            "country", period
+        ).possible_values.ENGLAND
+        is_parent = person("is_parent", period)
+        is_full_time_student = person("childcare_grant_full_time_student", period)
+        student_finance_eligible = person(
+            "childcare_grant_student_finance_eligible", period
+        )
+        receives_postgraduate_loan = person(
+            "childcare_grant_receives_postgraduate_loan", period
+        )
+        uses_qualifying_provider = person(
+            "childcare_grant_uses_qualifying_provider", period
+        )
+
+        benunit = person.benunit
+        eligible_children = benunit("childcare_grant_eligible_children", period)
+        household_income = person("childcare_grant_household_income", period)
+        income_limit = where(
+            eligible_children == 1,
+            p.income_limit.one_child,
+            p.income_limit.two_or_more_children,
+        )
+
+        tax_free_childcare = benunit.sum(benunit.members("tax_free_childcare", period))
+        wtc_childcare = benunit("WTC_childcare_element", period)
+        uc_childcare = benunit("uc_childcare_element", period)
+        nhs_childcare_support = benunit.any(
+            benunit.members("childcare_grant_receives_nhs_childcare_support", period)
+        )
+
+        has_incompatible_support = (
+            (tax_free_childcare > 0)
+            | (wtc_childcare > 0)
+            | (uc_childcare > 0)
+            | nhs_childcare_support
+        )
+
+        return (
+            in_england
+            & is_parent
+            & (eligible_children > 0)
+            & is_full_time_student
+            & student_finance_eligible
+            & ~receives_postgraduate_loan
+            & (household_income < income_limit)
+            & ~has_incompatible_support
+            & uses_qualifying_provider
+        )

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible.py
@@ -15,9 +15,10 @@ class childcare_grant_eligible(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.dfe.childcare_grant
 
-        in_england = person.household("country", period) == person.household(
-            "country", period
-        ).possible_values.ENGLAND
+        in_england = (
+            person.household("country", period)
+            == person.household("country", period).possible_values.ENGLAND
+        )
         is_parent = person("is_parent", period)
         is_full_time_student = person("childcare_grant_full_time_student", period)
         student_finance_eligible = person(

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible_children.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible_children.py
@@ -5,9 +5,7 @@ class childcare_grant_eligible_children(Variable):
     value_type = int
     entity = BenUnit
     label = "Number of eligible children for Childcare Grant"
-    documentation = (
-        "Number of children in the student's benefit unit who satisfy the Childcare Grant child-age rule."
-    )
+    documentation = "Number of children in the student's benefit unit who satisfy the Childcare Grant child-age rule."
     definition_period = YEAR
 
     def formula(benunit, period, parameters):

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible_children.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_eligible_children.py
@@ -1,0 +1,14 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_eligible_children(Variable):
+    value_type = int
+    entity = BenUnit
+    label = "Number of eligible children for Childcare Grant"
+    documentation = (
+        "Number of children in the student's benefit unit who satisfy the Childcare Grant child-age rule."
+    )
+    definition_period = YEAR
+
+    def formula(benunit, period, parameters):
+        return benunit.sum(benunit.members("childcare_grant_child_eligible", period))

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_full_time_student.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_full_time_student.py
@@ -1,0 +1,15 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_full_time_student(Variable):
+    value_type = bool
+    entity = Person
+    label = "Full-time student for Childcare Grant"
+    documentation = (
+        "Whether the person is studying full-time for Childcare Grant purposes. "
+        "This must currently be set explicitly in simulations because the core model "
+        "does not yet expose a reliable full-time higher-education status proxy."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+    default_value = False

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_household_income.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_household_income.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_household_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Childcare Grant household income"
+    documentation = (
+        "Household income used for Childcare Grant assessment. This can be set explicitly in simulations. "
+        "By default it uses the maintenance loan household income proxy."
+    )
+    definition_period = YEAR
+    unit = GBP
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("maintenance_loan_household_income", period)

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_provider_is_nanny.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_provider_is_nanny.py
@@ -1,0 +1,15 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_provider_is_nanny(Variable):
+    value_type = bool
+    entity = Person
+    label = "Childcare provider is a nanny for Childcare Grant"
+    documentation = (
+        "Whether the childcare provider is a nanny for Childcare Grant purposes. "
+        "This can be set explicitly in simulations and is used to enforce the "
+        "2026-27 onward exclusion of nanny-provided care."
+    )
+    definition_period = YEAR
+    default_value = False
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_receives_nhs_childcare_support.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_receives_nhs_childcare_support.py
@@ -1,0 +1,14 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_receives_nhs_childcare_support(Variable):
+    value_type = bool
+    entity = Person
+    label = "Receives NHS childcare support for Childcare Grant purposes"
+    documentation = (
+        "Whether the person or their partner receives childcare-cost support from the NHS, "
+        "which makes them ineligible for Childcare Grant."
+    )
+    definition_period = YEAR
+    default_value = False
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_receives_postgraduate_loan.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_receives_postgraduate_loan.py
@@ -1,0 +1,13 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_receives_postgraduate_loan(Variable):
+    value_type = bool
+    entity = Person
+    label = "Receives Postgraduate Loan for Childcare Grant purposes"
+    documentation = (
+        "Whether the person is receiving a Postgraduate Loan, which makes them ineligible for Childcare Grant."
+    )
+    definition_period = YEAR
+    default_value = False
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_receives_postgraduate_loan.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_receives_postgraduate_loan.py
@@ -5,9 +5,7 @@ class childcare_grant_receives_postgraduate_loan(Variable):
     value_type = bool
     entity = Person
     label = "Receives Postgraduate Loan for Childcare Grant purposes"
-    documentation = (
-        "Whether the person is receiving a Postgraduate Loan, which makes them ineligible for Childcare Grant."
-    )
+    documentation = "Whether the person is receiving a Postgraduate Loan, which makes them ineligible for Childcare Grant."
     definition_period = YEAR
     default_value = False
     set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_student_finance_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_student_finance_eligible.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_student_finance_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for income-assessed student finance for Childcare Grant"
+    documentation = (
+        "Whether the person gets, or is eligible for, income-assessed undergraduate student finance "
+        "for Childcare Grant purposes. This can be set explicitly in simulations. By default it uses "
+        "the maintenance loan eligibility proxy. Full-time status is modeled separately."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("maintenance_loan_eligible", period)

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_uses_qualifying_provider.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_uses_qualifying_provider.py
@@ -7,9 +7,13 @@ class childcare_grant_uses_qualifying_provider(Variable):
     label = "Uses a qualifying childcare provider for Childcare Grant"
     documentation = (
         "Whether the student's childcare provider satisfies Childcare Grant rules. "
-        "This can be set explicitly in simulations and should be set false where care is provided by a nanny "
-        "from academic year 2026 to 2027 onward."
+        "This can be set explicitly in simulations. By default the model excludes "
+        "nanny-provided care from 2026 onward."
     )
     definition_period = YEAR
-    default_value = True
     set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        provider_is_nanny = person("childcare_grant_provider_is_nanny", period)
+        nanny_disallowed = period.start.year >= 2026
+        return ~(nanny_disallowed & provider_is_nanny)

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_uses_qualifying_provider.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/childcare_grant_uses_qualifying_provider.py
@@ -1,0 +1,15 @@
+from policyengine_uk.model_api import *
+
+
+class childcare_grant_uses_qualifying_provider(Variable):
+    value_type = bool
+    entity = Person
+    label = "Uses a qualifying childcare provider for Childcare Grant"
+    documentation = (
+        "Whether the student's childcare provider satisfies Childcare Grant rules. "
+        "This can be set explicitly in simulations and should be set false where care is provided by a nanny "
+        "from academic year 2026 to 2027 onward."
+    )
+    definition_period = YEAR
+    default_value = True
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/childcare_grant/would_claim_childcare_grant.py
+++ b/policyengine_uk/variables/gov/dfe/childcare_grant/would_claim_childcare_grant.py
@@ -1,0 +1,10 @@
+from policyengine_uk.model_api import *
+
+
+class would_claim_childcare_grant(Variable):
+    value_type = bool
+    entity = Person
+    label = "Would claim Childcare Grant"
+    documentation = "Whether this person would claim Childcare Grant if eligible."
+    definition_period = YEAR
+    default_value = True

--- a/policyengine_uk/variables/gov/gov_spending.py
+++ b/policyengine_uk/variables/gov/gov_spending.py
@@ -46,6 +46,7 @@ class gov_spending(Variable):
         "universal_childcare_entitlement",
         "targeted_childcare_entitlement",
         "care_to_learn",
+        "childcare_grant",
         "dfe_education_spending",
         "dft_subsidy_spending",
         "nhs_spending",

--- a/policyengine_uk/variables/household/income/hbai_benefits.py
+++ b/policyengine_uk/variables/household/income/hbai_benefits.py
@@ -36,5 +36,6 @@ class hbai_benefits(Variable):
         "cost_of_living_support_payment",
         "winter_fuel_allowance",
         "tax_free_childcare",
+        "childcare_grant",
         "healthy_start_vouchers",
     ]

--- a/policyengine_uk/variables/household/income/household_benefits.py
+++ b/policyengine_uk/variables/household/income/household_benefits.py
@@ -45,6 +45,7 @@ class household_benefits(Variable):
         "universal_childcare_entitlement",
         "targeted_childcare_entitlement",
         "care_to_learn",
+        "childcare_grant",
         "nhs_spending",
         "dfe_education_spending",
         "dft_subsidy_spending",


### PR DESCRIPTION
## Summary
- add a first-pass England Childcare Grant model with parameters, eligibility, and amount logic
- wire Childcare Grant into aggregate benefit/spending outputs and program metadata
- add focused policy coverage for caps, income limits, age rules, and incompatibilities

## Testing
- uvx ruff check policyengine_uk/variables/gov/dfe/childcare_grant policyengine_uk/variables/gov/gov_spending.py policyengine_uk/variables/household/income/household_benefits.py policyengine_uk/variables/household/income/hbai_benefits.py
- uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/childcare_grant/childcare_grant.yaml