### PR TITLE
Add Parents' Learning Allowance model

### DIFF
--- a/changelog.d/parents-learning-allowance.added.md
+++ b/changelog.d/parents-learning-allowance.added.md
@@ -1,0 +1,1 @@
+Add a first-pass Parents' Learning Allowance model.

--- a/policyengine_uk/parameters/gov/dfe/parents_learning_allowance/income_limit.yaml
+++ b/policyengine_uk/parameters/gov/dfe/parents_learning_allowance/income_limit.yaml
@@ -1,0 +1,11 @@
+description: Household-income cutoff published for Parents' Learning Allowance eligibility.
+values:
+  2025-01-01: 18_957.98
+  2026-01-01: 18_957.98
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Parents' Learning Allowance household-income limit
+  reference:
+    - title: Parents' Learning Allowance eligibility
+      href: https://www.gov.uk/parents-learning-allowance/eligibility

--- a/policyengine_uk/parameters/gov/dfe/parents_learning_allowance/maximum.yaml
+++ b/policyengine_uk/parameters/gov/dfe/parents_learning_allowance/maximum.yaml
@@ -1,0 +1,13 @@
+description: Maximum Parents' Learning Allowance for full-time undergraduate students with dependent children.
+values:
+  2025-01-01: 2_024
+  2026-01-01: 2_024
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Parents' Learning Allowance maximum amount
+  reference:
+    - title: Support with living and other costs 2026 to 2027 academic year
+      href: https://www.gov.uk/government/publications/tuition-fees-and-student-support-2026-to-2027-academic-year/support-with-living-and-other-costs-2026-to-2027-academic-year
+    - title: Explanatory Memorandum to the Education (Student Support) (Amendment) Regulations 2025
+      href: https://www.legislation.gov.uk/uksi/2025/162/pdfs/uksiem_20250162_en_001.pdf

--- a/policyengine_uk/programs.yaml
+++ b/policyengine_uk/programs.yaml
@@ -360,6 +360,18 @@ programs:
     verified_start_year: 2025
     notes: First-pass full-time undergraduate England model using explicit full-time, SEN, and childcare-support inputs plus maintenance-loan proxies; childcare_expenses are treated as out-of-pocket spend net of free hours
 
+  - id: parents_learning_allowance
+    name: Parents' Learning Allowance
+    full_name: Student Finance England Parents' Learning Allowance
+    category: Benefits
+    agency: DfE
+    status: partial
+    coverage: England
+    variable: parents_learning_allowance
+    parameter_prefix: gov.dfe.parents_learning_allowance
+    verified_start_year: 2025
+    notes: First-pass England model using the published maximum amount and household-income cutoff, with higher-education evidence as the default course proxy and an explicit override for edge cases such as 120-credit or teacher-training routes
+
   - id: bursary_fund_16_to_19
     name: 16 to 19 Bursary Fund
     full_name: 16 to 19 Bursary Fund

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/parents_learning_allowance/parents_learning_allowance.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/parents_learning_allowance/parents_learning_allowance.yaml
@@ -1,0 +1,165 @@
+- name: Parents' Learning Allowance pays the maximum at zero assessed income
+  period: 2025
+  input:
+    people:
+      student:
+        age: 22
+        is_parent: true
+        parents_learning_allowance_course_eligible: true
+        parents_learning_allowance_household_income: 0
+      child:
+        age: 4
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    parents_learning_allowance_eligible: [true, false]
+    parents_learning_allowance: [2_024, 0]
+
+- name: Parents' Learning Allowance still pays the maximum just below the cutoff
+  period: 2025
+  input:
+    people:
+      student:
+        age: 24
+        is_parent: true
+        parents_learning_allowance_course_eligible: true
+        parents_learning_allowance_household_income: 18_957.97
+      child:
+        age: 7
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    parents_learning_allowance_eligible: [true, false]
+    parents_learning_allowance: [2_024, 0]
+
+- name: Parents' Learning Allowance is nil at the published cutoff
+  period: 2025
+  input:
+    people:
+      student:
+        age: 21
+        is_parent: true
+        parents_learning_allowance_course_eligible: true
+        parents_learning_allowance_household_income: 18_957.98
+      child:
+        age: 3
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    parents_learning_allowance_eligible: [false, false]
+    parents_learning_allowance: [0, 0]
+
+- name: Parents' Learning Allowance uses the maintenance-loan income proxy by default
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      student:
+        age: 20
+        is_parent: true
+        current_education: TERTIARY
+      child:
+        age: 2
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    maintenance_loan_in_higher_education: [true, false]
+    maintenance_loan_eligible: [true, false]
+    parents_learning_allowance_course_eligible: [true, false]
+    parents_learning_allowance_household_income: [0, 0]
+    parents_learning_allowance_eligible: [true, false]
+    parents_learning_allowance: [2_024, 0]
+
+- name: Parents' Learning Allowance allows an explicit course-eligibility override
+  period: 2025
+  input:
+    people:
+      student:
+        age: 30
+        is_parent: true
+        parents_learning_allowance_course_eligible: true
+        parents_learning_allowance_household_income: 10_000
+      child:
+        age: 5
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    maintenance_loan_eligible: [false, false]
+    parents_learning_allowance_eligible: [true, false]
+    parents_learning_allowance: [2_024, 0]
+
+- name: Parents' Learning Allowance excludes non-parents even with children present
+  period: 2025
+  input:
+    people:
+      student:
+        age: 22
+        is_parent: false
+        parents_learning_allowance_course_eligible: true
+        parents_learning_allowance_household_income: 0
+      child:
+        age: 4
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: ENGLAND
+  output:
+    parents_learning_allowance_eligible: [false, false]
+    parents_learning_allowance: [0, 0]
+
+- name: Parents' Learning Allowance excludes households outside England
+  period: 2025
+  input:
+    people:
+      student:
+        age: 23
+        is_parent: true
+        parents_learning_allowance_course_eligible: true
+        parents_learning_allowance_household_income: 0
+      child:
+        age: 1
+        is_child: true
+    benunits:
+      benunit:
+        members: ["student", "child"]
+    households:
+      household:
+        members: ["student", "child"]
+        country: WALES
+  output:
+    parents_learning_allowance_eligible: [false, false]
+    parents_learning_allowance: [0, 0]

--- a/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance.py
+++ b/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance.py
@@ -1,0 +1,21 @@
+from policyengine_uk.model_api import *
+
+
+class parents_learning_allowance(Variable):
+    value_type = float
+    entity = Person
+    label = "Parents' Learning Allowance"
+    documentation = (
+        "Student Finance England Parents' Learning Allowance for students with dependent children. "
+        "GOV.UK publishes the maximum award and the household-income cutoff, but not a simple public award curve. "
+        "This first-pass model therefore pays the published maximum amount to eligible students rather than "
+        "inventing a taper."
+    )
+    definition_period = YEAR
+    quantity_type = FLOW
+    unit = GBP
+    defined_for = "parents_learning_allowance_eligible"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.dfe.parents_learning_allowance
+        return p.maximum

--- a/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_course_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_course_eligible.py
@@ -1,0 +1,18 @@
+from policyengine_uk.model_api import *
+
+
+class parents_learning_allowance_course_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Study-pattern eligible for Parents' Learning Allowance"
+    documentation = (
+        "Whether the person is on a course or study pattern that can qualify for Parents' Learning Allowance. "
+        "This can be set explicitly in simulations. By default, the model proxies this from higher-education "
+        "evidence rather than maintenance-loan eligibility, so England-specific finance rules are applied separately "
+        "and simulations can still override the variable for 120-credit or teacher-training cases."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("maintenance_loan_in_higher_education", period)

--- a/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_dependent_children.py
+++ b/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_dependent_children.py
@@ -1,0 +1,15 @@
+from policyengine_uk.model_api import *
+
+
+class parents_learning_allowance_dependent_children(Variable):
+    value_type = int
+    entity = BenUnit
+    label = "Dependent children for Parents' Learning Allowance"
+    documentation = (
+        "Number of children in the student's benefit unit counted as dependent children for the first-pass "
+        "Parents' Learning Allowance model."
+    )
+    definition_period = YEAR
+
+    def formula(benunit, period, parameters):
+        return benunit.sum(benunit.members("is_child", period))

--- a/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_eligible.py
@@ -1,0 +1,33 @@
+from policyengine_uk.model_api import *
+
+
+class parents_learning_allowance_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Parents' Learning Allowance"
+    documentation = (
+        "Whether the person is eligible for Parents' Learning Allowance under the England student-finance scheme. "
+        "This is a first-pass model using the published household-income cutoff and an explicit course-eligibility "
+        "override, with the maintenance-loan pathway as the default proxy."
+    )
+    definition_period = YEAR
+    defined_for = "would_claim_parents_learning_allowance"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.dfe.parents_learning_allowance
+        country = person.household("country", period)
+        in_england = country == country.possible_values.ENGLAND
+        is_parent = person("is_parent", period)
+        dependent_children = person.benunit(
+            "parents_learning_allowance_dependent_children", period
+        )
+        course_eligible = person("parents_learning_allowance_course_eligible", period)
+        household_income = person("parents_learning_allowance_household_income", period)
+
+        return (
+            in_england
+            & is_parent
+            & (dependent_children > 0)
+            & course_eligible
+            & (household_income < p.income_limit)
+        )

--- a/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_household_income.py
+++ b/policyengine_uk/variables/gov/dfe/parents_learning_allowance/parents_learning_allowance_household_income.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+
+class parents_learning_allowance_household_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Parents' Learning Allowance household income"
+    documentation = (
+        "Household income used for Parents' Learning Allowance assessment. This can be set explicitly in simulations. "
+        "By default, the model uses the maintenance-loan assessed household-income proxy."
+    )
+    definition_period = YEAR
+    unit = GBP
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("maintenance_loan_household_income", period)

--- a/policyengine_uk/variables/gov/dfe/parents_learning_allowance/would_claim_parents_learning_allowance.py
+++ b/policyengine_uk/variables/gov/dfe/parents_learning_allowance/would_claim_parents_learning_allowance.py
@@ -1,0 +1,12 @@
+from policyengine_uk.model_api import *
+
+
+class would_claim_parents_learning_allowance(Variable):
+    value_type = bool
+    entity = Person
+    label = "Would claim Parents' Learning Allowance"
+    documentation = (
+        "Whether this person would claim Parents' Learning Allowance if eligible."
+    )
+    definition_period = YEAR
+    default_value = True

--- a/policyengine_uk/variables/gov/gov_spending.py
+++ b/policyengine_uk/variables/gov/gov_spending.py
@@ -47,6 +47,7 @@ class gov_spending(Variable):
         "targeted_childcare_entitlement",
         "care_to_learn",
         "childcare_grant",
+        "parents_learning_allowance",
         "bursary_fund_16_to_19",
         "dfe_education_spending",
         "dft_subsidy_spending",

--- a/policyengine_uk/variables/household/income/hbai_benefits.py
+++ b/policyengine_uk/variables/household/income/hbai_benefits.py
@@ -37,6 +37,7 @@ class hbai_benefits(Variable):
         "winter_fuel_allowance",
         "tax_free_childcare",
         "childcare_grant",
+        "parents_learning_allowance",
         "bursary_fund_16_to_19",
         "healthy_start_vouchers",
     ]

--- a/policyengine_uk/variables/household/income/household_benefits.py
+++ b/policyengine_uk/variables/household/income/household_benefits.py
@@ -46,6 +46,7 @@ class household_benefits(Variable):
         "targeted_childcare_entitlement",
         "care_to_learn",
         "childcare_grant",
+        "parents_learning_allowance",
         "bursary_fund_16_to_19",
         "nhs_spending",
         "dfe_education_spending",


### PR DESCRIPTION
## Summary
- add a first-pass Student Finance England Parents' Learning Allowance model
- add published 2025/26 and 2026/27 maximum-amount and household-income-cutoff parameters
- wire the new grant into spending, household-benefit, HBAI-benefit, and program coverage aggregates

## Model boundary
This is a partial model.

The public GOV.UK pages publish:
- the household-income cutoff
- the maximum annual amount
- the fact that awards range between £50 and the maximum

But they do not publish a simple public award curve. Rather than inventing a taper, this branch pays the published maximum amount to eligible students and makes that proxy explicit in the variable documentation and program notes.

The default course-eligibility proxy uses higher-education evidence, with an explicit override available for 120-credit and ITT edge cases.

## Testing
- `uvx ruff check policyengine_uk/variables/gov/dfe/parents_learning_allowance policyengine_uk/variables/gov/gov_spending.py policyengine_uk/variables/household/income/hbai_benefits.py policyengine_uk/variables/household/income/household_benefits.py`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/parents_learning_allowance/parents_learning_allowance.yaml`
