### PR TITLE
Allow manual docs deploy dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
   push:
     # Runs on pushes targeting the default branch
     branches: [main]
+  workflow_dispatch:
 env:
   # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
   # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` to the docs deploy workflow
- make the GitHub Pages deploy recoverable when GitHub misses a `main` push trigger

## Context
The `#1590` merge commit reached `main`, but GitHub never emitted a `PushEvent` for that merge, so no push-triggered workflows were created for it. This does not fix GitHub missing a push event, but it gives us a clean manual recovery path for the docs deploy workflow without requiring another merge.

I checked the current `versioning` workflow on `main` before opening this PR. The stale `changelog_entry.yaml` path issue had already been fixed there, so this PR stays narrowly scoped to deploy recovery.
