### PR TITLE
Add Travel Grant

### DIFF
--- a/changelog.d/travel-grant.added.md
+++ b/changelog.d/travel-grant.added.md
@@ -1,0 +1,1 @@
+Add a first-pass Travel Grant model.

--- a/policyengine_uk/parameters/gov/dfe/travel_grant/income_reduction/rate.yaml
+++ b/policyengine_uk/parameters/gov/dfe/travel_grant/income_reduction/rate.yaml
@@ -1,0 +1,11 @@
+description: Travel Grant reduction rate per pound of household income above the published threshold.
+values:
+  2025-01-01: 0.1145475372279496
+  2026-01-01: 0.1145475372279496
+metadata:
+  unit: /1
+  period: year
+  label: Travel Grant income reduction rate
+  reference:
+    - title: "Travel grants for students studying abroad or on placements (England): What you'll get"
+      href: https://www.gov.uk/travel-grants-students-england/what-youll-get

--- a/policyengine_uk/parameters/gov/dfe/travel_grant/income_reduction/threshold.yaml
+++ b/policyengine_uk/parameters/gov/dfe/travel_grant/income_reduction/threshold.yaml
@@ -1,0 +1,11 @@
+description: Household-income threshold above which Travel Grant is reduced.
+values:
+  2025-01-01: 39_796
+  2026-01-01: 39_796
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Travel Grant income reduction threshold
+  reference:
+    - title: "Travel grants for students studying abroad or on placements (England): What you'll get"
+      href: https://www.gov.uk/travel-grants-students-england/what-youll-get

--- a/policyengine_uk/parameters/gov/dfe/travel_grant/initial_contribution.yaml
+++ b/policyengine_uk/parameters/gov/dfe/travel_grant/initial_contribution.yaml
@@ -1,0 +1,11 @@
+description: Initial travel-cost contribution the student must meet before Travel Grant reimbursement begins.
+values:
+  2025-01-01: 303
+  2026-01-01: 303
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Travel Grant initial contribution
+  reference:
+    - title: "Travel grants for students studying abroad or on placements (England): What you'll get"
+      href: https://www.gov.uk/travel-grants-students-england/what-youll-get

--- a/policyengine_uk/programs.yaml
+++ b/policyengine_uk/programs.yaml
@@ -375,6 +375,7 @@ programs:
   - id: adult_dependants_grant
     name: Adult Dependants' Grant
     full_name: Student Finance England Adult Dependants' Grant
+
     category: Benefits
     agency: DfE
     status: partial
@@ -383,6 +384,18 @@ programs:
     parameter_prefix: gov.dfe.adult_dependants_grant
     verified_start_year: 2025
     notes: First-pass England model using the published maximum amount and household-income tests, with automatic 25-plus couple detection and explicit inputs for under-25 spouse/civil-partner and non-partner adult dependant cases
+
+  - id: travel_grant
+    name: Travel Grant
+    full_name: Student Finance England Travel Grant
+    category: Benefits
+    agency: DfE
+    status: partial
+    coverage: England
+    variable: travel_grant
+    parameter_prefix: gov.dfe.travel_grant
+    verified_start_year: 2025
+    notes: First-pass England model using the published initial contribution and household-income reduction formula, with explicit placement and eligible-expense inputs because the survey does not observe reimbursable travel costs
 
   - id: bursary_fund_16_to_19
     name: 16 to 19 Bursary Fund

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/travel_grant/travel_grant.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/travel_grant/travel_grant.yaml
@@ -1,0 +1,120 @@
+- name: Travel Grant reimburses overseas placement expenses above the initial contribution
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      student:
+        age: 21
+        travel_grant_abroad_placement: true
+        travel_grant_eligible_expenses: 1_000
+        travel_grant_household_income: 30_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    travel_grant_eligible: [true]
+    travel_grant: [697]
+
+- name: Travel Grant applies the published household-income reduction above the threshold
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      student:
+        age: 22
+        travel_grant_abroad_placement: true
+        travel_grant_eligible_expenses: 1_000
+        travel_grant_household_income: 39_804.73
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    travel_grant: [696]
+
+- name: Travel Grant is nil when expenses do not exceed the initial contribution
+  period: 2025
+  input:
+    people:
+      student:
+        age: 20
+        travel_grant_abroad_placement: true
+        travel_grant_eligible_expenses: 303
+        travel_grant_household_income: 0
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    travel_grant_eligible: [true]
+    travel_grant: [0]
+
+- name: Travel Grant clinical placements require income-assessed support
+  period: 2025
+  input:
+    people:
+      student:
+        age: 24
+        travel_grant_clinical_placement: true
+        travel_grant_eligible_expenses: 800
+        travel_grant_income_assessed_support: false
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    travel_grant_eligible: [false]
+    travel_grant: [0]
+
+- name: Travel Grant excludes UK clinical placements with means-tested NHS bursaries
+  period: 2025
+  input:
+    people:
+      student:
+        age: 24
+        travel_grant_clinical_placement: true
+        travel_grant_eligible_expenses: 800
+        travel_grant_income_assessed_support: true
+        travel_grant_receives_means_tested_nhs_bursary: true
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    travel_grant_eligible: [false]
+    travel_grant: [0]
+
+- name: Travel Grant excludes households outside England
+  period: 2025
+  input:
+    people:
+      student:
+        age: 21
+        travel_grant_abroad_placement: true
+        travel_grant_eligible_expenses: 1_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: WALES
+  output:
+    travel_grant_eligible: [false]
+    travel_grant: [0]

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant.py
@@ -1,0 +1,30 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant(Variable):
+    value_type = float
+    entity = Person
+    label = "Travel Grant"
+    documentation = (
+        "Student Finance England Travel Grant. "
+        "This first-pass model reimburses eligible travel expenses above the published initial contribution, "
+        "reduced for household income above the published threshold. Placement status and eligible expenses "
+        "must be provided explicitly because they are not recoverable from the survey."
+    )
+    definition_period = YEAR
+    quantity_type = FLOW
+    unit = GBP
+    defined_for = "travel_grant_eligible"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.dfe.travel_grant
+        expenses = person("travel_grant_eligible_expenses", period)
+        household_income = person("travel_grant_household_income", period)
+        income_reduction = (
+            max_(
+                0,
+                household_income - p.income_reduction.threshold,
+            )
+            * p.income_reduction.rate
+        )
+        return max_(0, expenses - p.initial_contribution - income_reduction)

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_abroad_placement.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_abroad_placement.py
@@ -1,0 +1,14 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant_abroad_placement(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has an eligible study or work placement abroad for Travel Grant"
+    documentation = (
+        "Whether the student is on an eligible overseas study or work placement for Travel Grant purposes. "
+        "This must be set explicitly in simulations."
+    )
+    definition_period = YEAR
+    default_value = False
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_clinical_placement.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_clinical_placement.py
@@ -1,0 +1,14 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant_clinical_placement(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has an eligible UK clinical placement for Travel Grant"
+    documentation = (
+        "Whether the student is on an essential medical or dental clinical placement in the UK for Travel Grant purposes. "
+        "This must be set explicitly in simulations."
+    )
+    definition_period = YEAR
+    default_value = False
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_eligible.py
@@ -1,0 +1,32 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Travel Grant"
+    documentation = (
+        "Whether the person is eligible for Student Finance England Travel Grant. "
+        "This first-pass model uses explicit placement inputs, the published England coverage rule, "
+        "the clinical-placement NHS-bursary exclusion, and a maintenance-loan proxy for income-assessed support."
+    )
+    definition_period = YEAR
+    defined_for = "would_claim_travel_grant"
+
+    def formula(person, period, parameters):
+        country = person.household("country", period)
+        in_england = country == country.possible_values.ENGLAND
+
+        abroad_placement = person("travel_grant_abroad_placement", period)
+        clinical_placement = person("travel_grant_clinical_placement", period)
+        receives_nhs_bursary = person(
+            "travel_grant_receives_means_tested_nhs_bursary", period
+        )
+        income_assessed_support = person("travel_grant_income_assessed_support", period)
+        expenses = person("travel_grant_eligible_expenses", period)
+
+        clinical_path = (
+            clinical_placement & income_assessed_support & ~receives_nhs_bursary
+        )
+
+        return in_england & (abroad_placement | clinical_path) & (expenses > 0)

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_eligible_expenses.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_eligible_expenses.py
@@ -1,0 +1,15 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant_eligible_expenses(Variable):
+    value_type = float
+    entity = Person
+    label = "Eligible expenses for Travel Grant"
+    documentation = (
+        "Eligible travel, visa, insurance, and related Travel Grant expenses. "
+        "This must be set explicitly in simulations."
+    )
+    definition_period = YEAR
+    unit = GBP
+    default_value = 0
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_household_income.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_household_income.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant_household_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Travel Grant household income"
+    documentation = (
+        "Household income used for Travel Grant assessment. This can be set explicitly in simulations. "
+        "By default, the model uses the maintenance-loan assessed household-income proxy."
+    )
+    definition_period = YEAR
+    unit = GBP
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("maintenance_loan_household_income", period)

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_income_assessed_support.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_income_assessed_support.py
@@ -1,0 +1,16 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant_income_assessed_support(Variable):
+    value_type = bool
+    entity = Person
+    label = "Receives income-assessed student support for Travel Grant"
+    documentation = (
+        "Whether the student receives income-assessed student support for Travel Grant purposes. "
+        "This can be set explicitly in simulations. By default, the model uses maintenance-loan eligibility as a proxy."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("maintenance_loan_eligible", period)

--- a/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_receives_means_tested_nhs_bursary.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/travel_grant_receives_means_tested_nhs_bursary.py
@@ -1,0 +1,11 @@
+from policyengine_uk.model_api import *
+
+
+class travel_grant_receives_means_tested_nhs_bursary(Variable):
+    value_type = bool
+    entity = Person
+    label = "Receives a means-tested NHS bursary for Travel Grant purposes"
+    documentation = "Whether the student receives a means-tested NHS bursary or award, which blocks Travel Grant for UK clinical placements."
+    definition_period = YEAR
+    default_value = False
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/travel_grant/would_claim_travel_grant.py
+++ b/policyengine_uk/variables/gov/dfe/travel_grant/would_claim_travel_grant.py
@@ -1,0 +1,10 @@
+from policyengine_uk.model_api import *
+
+
+class would_claim_travel_grant(Variable):
+    value_type = bool
+    entity = Person
+    label = "Would claim Travel Grant"
+    documentation = "Whether this person would claim Travel Grant if eligible."
+    definition_period = YEAR
+    default_value = True

--- a/policyengine_uk/variables/gov/gov_spending.py
+++ b/policyengine_uk/variables/gov/gov_spending.py
@@ -49,6 +49,7 @@ class gov_spending(Variable):
         "childcare_grant",
         "parents_learning_allowance",
         "adult_dependants_grant",
+        "travel_grant",
         "bursary_fund_16_to_19",
         "dfe_education_spending",
         "dft_subsidy_spending",

--- a/policyengine_uk/variables/household/income/hbai_benefits.py
+++ b/policyengine_uk/variables/household/income/hbai_benefits.py
@@ -39,6 +39,7 @@ class hbai_benefits(Variable):
         "childcare_grant",
         "parents_learning_allowance",
         "adult_dependants_grant",
+        "travel_grant",
         "bursary_fund_16_to_19",
         "healthy_start_vouchers",
     ]

--- a/policyengine_uk/variables/household/income/household_benefits.py
+++ b/policyengine_uk/variables/household/income/household_benefits.py
@@ -48,6 +48,7 @@ class household_benefits(Variable):
         "childcare_grant",
         "parents_learning_allowance",
         "adult_dependants_grant",
+        "travel_grant",
         "bursary_fund_16_to_19",
         "nhs_spending",
         "dfe_education_spending",


### PR DESCRIPTION
## Summary
- add a first-pass England Travel Grant model
- parameterize the published initial contribution and income-based reduction formula
- wire Travel Grant into program metadata and aggregate benefit/spending totals

## Model shape
This is intentionally a partial model.

- the published reimbursement formula is modeled directly
- overseas placement status, UK clinical placement status, eligible expenses, and NHS-bursary overlap are explicit inputs
- household income defaults to the maintenance-loan assessed-income proxy
- clinical placements require income-assessed support, proxied from maintenance-loan eligibility unless overridden
- baseline enhanced FRS output is zero by design because reimbursable travel costs are not observed in the survey

## Validation
- `uvx ruff check policyengine_uk/variables/gov/dfe/travel_grant policyengine_uk/variables/gov/gov_spending.py policyengine_uk/variables/household/income/household_benefits.py policyengine_uk/variables/household/income/hbai_benefits.py`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/travel_grant/travel_grant.yaml`

## Baseline aggregate on current enhanced FRS
Using `/Users/maxghenis/PolicyEngine/policyengine-uk-data/policyengine_uk_data/storage/enhanced_frs_2023_24.h5` at `2025`:
- recipients: `0`
- spend: `£0`

Part of #460.
