### PR TITLE
Add Disabled Students' Allowance

### DIFF
--- a/changelog.d/disabled-students-allowance.added.md
+++ b/changelog.d/disabled-students-allowance.added.md
@@ -1,0 +1,1 @@
+Add a first-pass Disabled Students' Allowance model for England higher-education students.

--- a/policyengine_uk/parameters/gov/dfe/disabled_students_allowance/maximum.yaml
+++ b/policyengine_uk/parameters/gov/dfe/disabled_students_allowance/maximum.yaml
@@ -1,0 +1,11 @@
+description: Maximum Disabled Students' Allowance for higher-education students in England.
+values:
+  2025-01-01: 27_783
+  2026-01-01: 27_783
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Disabled Students' Allowance maximum amount
+  reference:
+    - title: Help if you're a student with a learning difficulty, health problem or disability
+      href: https://www.gov.uk/disabled-students-allowance-dsa

--- a/policyengine_uk/programs.yaml
+++ b/policyengine_uk/programs.yaml
@@ -397,6 +397,18 @@ programs:
     verified_start_year: 2025
     notes: First-pass England model using the published initial contribution and household-income reduction formula, with explicit placement and eligible-expense inputs because the survey does not observe reimbursable travel costs
 
+  - id: disabled_students_allowance
+    name: Disabled Students' Allowance
+    full_name: Student Finance England Disabled Students' Allowance
+    category: Benefits
+    agency: DfE
+    status: partial
+    coverage: England
+    variable: disabled_students_allowance
+    parameter_prefix: gov.dfe.disabled_students_allowance
+    verified_start_year: 2025
+    notes: First-pass England model using the published annual cap, higher-education evidence as the default course proxy, a narrow qualifying-condition proxy with explicit override, and explicit disability-related study support costs
+
   - id: bursary_fund_16_to_19
     name: 16 to 19 Bursary Fund
     full_name: 16 to 19 Bursary Fund

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/disabled_students_allowance/disabled_students_allowance.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/disabled_students_allowance/disabled_students_allowance.yaml
@@ -1,0 +1,102 @@
+- name: Disabled Students' Allowance reimburses eligible support needs below the cap
+  period: 2025
+  input:
+    people:
+      student:
+        age: 20
+        current_education: TERTIARY
+        is_disabled_for_benefits: true
+        disabled_students_allowance_eligible_expenses: 12_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    disabled_students_allowance_course_eligible: [true]
+    disabled_students_allowance_has_qualifying_condition: [true]
+    disabled_students_allowance_eligible: [true]
+    disabled_students_allowance: [12_000]
+
+- name: Disabled Students' Allowance is capped at the published annual maximum
+  period: 2025
+  input:
+    people:
+      student:
+        age: 24
+        current_education: TERTIARY
+        is_disabled_for_benefits: true
+        disabled_students_allowance_eligible_expenses: 30_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    disabled_students_allowance: [27_783]
+
+- name: Disabled Students' Allowance excludes equivalent support from another scheme
+  period: 2025
+  input:
+    people:
+      student:
+        age: 22
+        current_education: TERTIARY
+        is_disabled_for_benefits: true
+        disabled_students_allowance_eligible_expenses: 5_000
+        disabled_students_allowance_receives_equivalent_support: true
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    disabled_students_allowance_eligible: [false]
+    disabled_students_allowance: [0]
+
+- name: Disabled Students' Allowance default qualifying-condition proxy is narrow
+  period: 2025
+  input:
+    people:
+      student:
+        age: 21
+        current_education: TERTIARY
+        disabled_students_allowance_eligible_expenses: 4_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    disabled_students_allowance_has_qualifying_condition: [false]
+    disabled_students_allowance_eligible: [false]
+    disabled_students_allowance: [0]
+
+- name: Disabled Students' Allowance accepts explicit condition and course overrides
+  period: 2025
+  input:
+    people:
+      student:
+        age: 21
+        current_education: POST_SECONDARY
+        disabled_students_allowance_has_qualifying_condition: true
+        disabled_students_allowance_course_eligible: true
+        disabled_students_allowance_eligible_expenses: 4_000
+    benunits:
+      benunit:
+        members: ["student"]
+    households:
+      household:
+        members: ["student"]
+        country: ENGLAND
+  output:
+    disabled_students_allowance_eligible: [true]
+    disabled_students_allowance: [4_000]

--- a/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance.py
+++ b/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance.py
@@ -1,0 +1,24 @@
+from policyengine_uk.model_api import *
+
+
+class disabled_students_allowance(Variable):
+    value_type = float
+    entity = Person
+    label = "Disabled Students' Allowance"
+    documentation = (
+        "Student Finance England Disabled Students' Allowance. "
+        "The published rules provide an annual cap, but actual awards depend on an "
+        "individual needs assessment rather than a public formula. This first-pass "
+        "model therefore treats `disabled_students_allowance_eligible_expenses` as "
+        "the assessed annual study-related support need, net of any required personal "
+        "computer contribution and excluding ordinary student costs."
+    )
+    definition_period = YEAR
+    quantity_type = FLOW
+    unit = GBP
+    defined_for = "disabled_students_allowance_eligible"
+
+    def formula(person, period, parameters):
+        expenses = person("disabled_students_allowance_eligible_expenses", period)
+        maximum = parameters(period).gov.dfe.disabled_students_allowance.maximum
+        return min_(expenses, maximum)

--- a/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_course_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_course_eligible.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+
+class disabled_students_allowance_course_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Course is eligible for Disabled Students' Allowance"
+    documentation = (
+        "Whether the person's course is eligible for Disabled Students' Allowance. "
+        "This can be set explicitly in simulations. By default, the model uses the "
+        "existing higher-education evidence proxy from the maintenance-loan model."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("maintenance_loan_in_higher_education", period)

--- a/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_eligible.py
+++ b/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_eligible.py
@@ -1,0 +1,35 @@
+from policyengine_uk.model_api import *
+
+
+class disabled_students_allowance_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Disabled Students' Allowance"
+    documentation = (
+        "Whether the person is eligible for Student Finance England Disabled "
+        "Students' Allowance. This first-pass model uses the published England "
+        "coverage rule, a higher-education default course proxy, a narrow "
+        "qualifying-condition proxy with explicit override, and an explicit "
+        "equivalent-support exclusion."
+    )
+    definition_period = YEAR
+    defined_for = "would_claim_disabled_students_allowance"
+
+    def formula(person, period, parameters):
+        in_england = person("maintenance_loan_in_england_system", period)
+        course_eligible = person("disabled_students_allowance_course_eligible", period)
+        qualifying_condition = person(
+            "disabled_students_allowance_has_qualifying_condition", period
+        )
+        receives_equivalent_support = person(
+            "disabled_students_allowance_receives_equivalent_support", period
+        )
+        expenses = person("disabled_students_allowance_eligible_expenses", period)
+
+        return (
+            in_england
+            & course_eligible
+            & qualifying_condition
+            & ~receives_equivalent_support
+            & (expenses > 0)
+        )

--- a/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_eligible_expenses.py
+++ b/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_eligible_expenses.py
@@ -1,0 +1,18 @@
+from policyengine_uk.model_api import *
+
+
+class disabled_students_allowance_eligible_expenses(Variable):
+    value_type = float
+    entity = Person
+    label = "Eligible Disabled Students' Allowance expenses"
+    documentation = (
+        "Annual study-related disability support costs that Disabled Students' "
+        "Allowance can reimburse. This should exclude ordinary student costs, any "
+        "support already provided by another funding source, and any personal "
+        "computer contribution the student must pay themselves."
+    )
+    definition_period = YEAR
+    unit = GBP
+    quantity_type = FLOW
+    default_value = 0
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_has_qualifying_condition.py
+++ b/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_has_qualifying_condition.py
@@ -1,0 +1,19 @@
+from policyengine_uk.model_api import *
+
+
+class disabled_students_allowance_has_qualifying_condition(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has a qualifying condition for Disabled Students' Allowance"
+    documentation = (
+        "Whether the person has a disability, long-term health condition, mental "
+        "health condition, or specific learning difficulty that can qualify for "
+        "Disabled Students' Allowance. This can be set explicitly in simulations. "
+        "By default, the model uses observed disability-benefit receipt or explicit "
+        "blindness input, which is narrower than the full legal concept."
+    )
+    definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+
+    def formula(person, period, parameters):
+        return person("is_disabled_for_benefits", period) | person("is_blind", period)

--- a/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_receives_equivalent_support.py
+++ b/policyengine_uk/variables/gov/dfe/disabled_students_allowance/disabled_students_allowance_receives_equivalent_support.py
@@ -1,0 +1,16 @@
+from policyengine_uk.model_api import *
+
+
+class disabled_students_allowance_receives_equivalent_support(Variable):
+    value_type = bool
+    entity = Person
+    label = "Receives equivalent support that excludes Disabled Students' Allowance"
+    documentation = (
+        "Whether the person receives equivalent disability-related study support "
+        "from another funding source, such as an NHS Disabled Students' Allowance "
+        "or social work bursary, and is therefore excluded from Student Finance "
+        "England Disabled Students' Allowance."
+    )
+    definition_period = YEAR
+    default_value = False
+    set_input = set_input_dispatch_by_period

--- a/policyengine_uk/variables/gov/dfe/disabled_students_allowance/would_claim_disabled_students_allowance.py
+++ b/policyengine_uk/variables/gov/dfe/disabled_students_allowance/would_claim_disabled_students_allowance.py
@@ -1,0 +1,12 @@
+from policyengine_uk.model_api import *
+
+
+class would_claim_disabled_students_allowance(Variable):
+    value_type = bool
+    entity = Person
+    label = "Would claim Disabled Students' Allowance"
+    documentation = (
+        "Whether this person would claim Disabled Students' Allowance if eligible."
+    )
+    definition_period = YEAR
+    default_value = True

--- a/policyengine_uk/variables/gov/gov_spending.py
+++ b/policyengine_uk/variables/gov/gov_spending.py
@@ -50,6 +50,7 @@ class gov_spending(Variable):
         "parents_learning_allowance",
         "adult_dependants_grant",
         "travel_grant",
+        "disabled_students_allowance",
         "bursary_fund_16_to_19",
         "dfe_education_spending",
         "dft_subsidy_spending",

--- a/policyengine_uk/variables/household/income/hbai_benefits.py
+++ b/policyengine_uk/variables/household/income/hbai_benefits.py
@@ -40,6 +40,7 @@ class hbai_benefits(Variable):
         "parents_learning_allowance",
         "adult_dependants_grant",
         "travel_grant",
+        "disabled_students_allowance",
         "bursary_fund_16_to_19",
         "healthy_start_vouchers",
     ]

--- a/policyengine_uk/variables/household/income/household_benefits.py
+++ b/policyengine_uk/variables/household/income/household_benefits.py
@@ -49,6 +49,7 @@ class household_benefits(Variable):
         "parents_learning_allowance",
         "adult_dependants_grant",
         "travel_grant",
+        "disabled_students_allowance",
         "bursary_fund_16_to_19",
         "nhs_spending",
         "dfe_education_spending",


### PR DESCRIPTION
## Summary
- add a first-pass Student Finance England Disabled Students' Allowance model
- use the published annual cap with explicit eligible-cost input rather than inventing a hidden award curve
- add a narrow default qualifying-condition proxy with explicit override, and wire DSA into program metadata and benefit aggregates

## Policy shape
This is intentionally a partial model.

GOV.UK publishes the annual DSA cap and the main eligibility rules, but actual awards depend on an individual needs assessment rather than a public formula. So this PR models:
- England coverage via the existing Student Finance England proxy
- default course eligibility via higher-education evidence, with explicit override
- default qualifying-condition evidence via disability-benefit receipt or explicit blindness input, with explicit override for broader DSA-qualifying conditions
- explicit equivalent-support exclusion
- explicit annual eligible study-support costs, capped at the published annual maximum

It does **not** try to invent a synthetic average award curve.

## Validation
Local checks passed:
- `uvx ruff check policyengine_uk/variables/gov/dfe/disabled_students_allowance policyengine_uk/variables/gov/gov_spending.py policyengine_uk/variables/household/income/household_benefits.py policyengine_uk/variables/household/income/hbai_benefits.py`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/disabled_students_allowance/disabled_students_allowance.yaml`

Focused policy tests cover:
- reimbursement below the cap
- cap at the published annual maximum
- equivalent-support exclusion
- the intentionally narrow default condition proxy
- explicit course and condition overrides

## Current baseline
On the local `enhanced_frs_2023_24` check at `2025`:
- `disabled_students_allowance` spend: `£0`
- positive recipients: `0`
- course-eligible share: `2.29%`
- default qualifying-condition proxy share: `7.34%`
- overlap share: `0.088%`

That zero baseline is expected here because the amount side is explicit-cost driven and the survey does not observe DSA needs-assessment costs. So this PR adds the correct policy surface, but it is not calibration-ready on its own yet.
