### PR TITLE
Remove inferred is_parent formula

### DIFF
--- a/changelog.d/1031.md
+++ b/changelog.d/1031.md
@@ -1,0 +1,1 @@
+Removed the inferred `is_parent` formula so datasets provide parent status directly.

--- a/policyengine_uk/tests/policy/baseline/household/demographic/is_parent.yaml
+++ b/policyengine_uk/tests/policy/baseline/household/demographic/is_parent.yaml
@@ -1,0 +1,34 @@
+- name: is_parent is not inferred from family composition
+  period: 2024
+  input:
+    people:
+      adult:
+        age: 35
+      child:
+        age: 5
+    benunits:
+      benunit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+  output:
+    is_parent: [false, false]
+
+- name: is_parent can be provided as an input
+  period: 2024
+  input:
+    people:
+      adult:
+        age: 35
+        is_parent: true
+      child:
+        age: 5
+    benunits:
+      benunit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+  output:
+    is_parent: [true, false]

--- a/policyengine_uk/variables/household/demographic/is_parent.py
+++ b/policyengine_uk/variables/household/demographic/is_parent.py
@@ -6,25 +6,4 @@ class is_parent(Variable):
     entity = Person
     label = "Whether this person is a parent in their benefit unit"
     definition_period = YEAR
-
-    def formula(person, period, parameters):
-        benunit = person.benunit
-        age = person("age", period)
-        family_type = benunit("family_type", period)
-
-        # Find two oldest members
-        benunit_ages = benunit.members("age", period)
-        adult_index = person("adult_index", period)
-
-        # Get family types enum
-        family_types = family_type.possible_values
-
-        # For lone parents (FamilyType.LONE_PARENT), only the eldest is parent
-        is_lone_parent = (family_type == family_types.LONE_PARENT) & (adult_index == 1)
-
-        # For couples with children (FamilyType.COUPLE_WITH_CHILDREN), two eldest are parents
-        is_couple_parent = (family_type == family_types.COUPLE_WITH_CHILDREN) & (
-            (adult_index == 1) | (adult_index == 2)
-        )
-
-        return is_lone_parent | is_couple_parent
+    default_value = False

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.75.3"
+version = "2.86.0"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Remove the `is_parent` formula that inferred parent status from `family_type` and household-level `adult_index`.
- Keep `is_parent` as an input/default-only variable with `default_value = False`, now that `policyengine-uk-data` assigns it from FRS microdata in PolicyEngine/policyengine-uk-data#343.
- Add a focused policy test proving parent status is no longer inferred from family composition and can still be supplied as input.
- Sync the editable package version in `uv.lock` with `pyproject.toml`.

Closes #1031.

## Validation
- `uv run --python 3.13 ruff check policyengine_uk/variables/household/demographic/is_parent.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/household/demographic/is_parent.py`
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/household/demographic/is_parent.yaml -c policyengine_uk`
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/care_to_learn/care_to_learn_eligible.yaml policyengine_uk/tests/policy/baseline/gov/dfe/extended_childcare_entitlement/extended_childcare_entitlement_work_condition.yaml policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare -c policyengine_uk`
