### PR TITLE
Clarify Tax-Free Childcare age thresholds

### DIFF
--- a/changelog.d/1042.md
+++ b/changelog.d/1042.md
@@ -1,0 +1,1 @@
+Clarified that Tax-Free Childcare age parameters are exclusive upper thresholds.

--- a/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/age/disability.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/age/disability.yaml
@@ -1,4 +1,4 @@
-description: HMRC extends the tax-free childcare program eligibility to children with disabilities up to this age threshold.
+description: HMRC limits the tax-free childcare program disability age eligibility to children younger than this age threshold.
 metadata:
   unit: year
   period: year

--- a/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/age/standard.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/age/standard.yaml
@@ -1,4 +1,4 @@
-description: HMRC extends the tax-free childcare program eligibility to children up to this age threshold.
+description: HMRC limits the tax-free childcare program standard age eligibility to children younger than this age threshold.
 metadata:
   unit: year
   period: year

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_age_child_condition.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_age_child_condition.yaml
@@ -6,7 +6,7 @@
   output:
     tax_free_childcare_child_age_eligible: true
 
-- name: Over standard age limit and not disabled - ineligible
+- name: At standard age limit and not disabled - ineligible
   period: 2025
   input:
     age: 12
@@ -22,7 +22,7 @@
   output:
     tax_free_childcare_child_age_eligible: true
 
-- name: Over disability age limit and disabled - ineligible
+- name: At disability age limit and disabled - ineligible
   period: 2025
   input:
     age: 17

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.0"
+version = "2.86.1"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Clarify the Tax-Free Childcare standard and disability age parameters as exclusive upper thresholds, matching the `age < age_limit` formula.
- Rename the boundary tests to state that children at ages 12 and 17 are ineligible under the respective thresholds.
- Sync the editable package version in `uv.lock` with `pyproject.toml`.

Closes #1042.

## Validation
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_age_child_condition.yaml -c policyengine_uk`
- `uvx ruff format --check .`
