### PR TITLE
Add Tax-Free Childcare UK connection condition

### DIFF
--- a/changelog.d/1046.md
+++ b/changelog.d/1046.md
@@ -1,0 +1,1 @@
+Added the Tax-Free Childcare UK connection eligibility condition.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_program_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_program_eligible.yaml
@@ -7,6 +7,15 @@
   output:
     tax_free_childcare_program_eligible: True
 
+- name: Non eligible - does not meet UK connection requirement
+  period: 2025
+  input:
+    working_tax_credit: 0
+    child_tax_credit: 0
+    universal_credit: 0
+    tax_free_childcare_meets_uk_connection: false
+  output:
+    tax_free_childcare_program_eligible: False
 
 - name: Non eligible - receives benefits
   period: 2025

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_meets_uk_connection.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_meets_uk_connection.py
@@ -1,0 +1,14 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_meets_uk_connection(Variable):
+    value_type = bool
+    entity = BenUnit
+    label = "meets the Tax-Free Childcare UK connection requirement"
+    documentation = (
+        "Whether the family satisfies the Tax-Free Childcare requirement to be "
+        "treated as being in the United Kingdom."
+    )
+    definition_period = YEAR
+    default_value = True
+    reference = "The Childcare Payments (Eligibility) Regulations 2015 regs. 6-8"

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_program_eligible.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_program_eligible.py
@@ -14,4 +14,8 @@ class tax_free_childcare_program_eligible(Variable):
             period,
             p.disqualifying_benefits,
         )
-        return countable_programs == 0
+        meets_uk_connection = person.benunit(
+            "tax_free_childcare_meets_uk_connection",
+            period,
+        )
+        return (countable_programs == 0) & meets_uk_connection

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.1"
+version = "2.86.2"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Add `tax_free_childcare_meets_uk_connection`, a BenUnit-level Tax-Free Childcare eligibility input defaulting to true.
- Require the UK connection condition in `tax_free_childcare_program_eligible` alongside the existing disqualifying-benefits check.
- Add a boundary test showing a family with no disqualifying benefits is ineligible when the UK connection requirement is false.
- Sync the editable package version in `uv.lock` with `pyproject.toml`.

Closes #1046.

## Notes
- The issue cites the Childcare Payments (Eligibility) Regulations 2015. The UK-presence/connection condition is specified through regulations 6-8, so the new variable references those regulations.
- Defaulting this input to true preserves existing baseline behavior unless users or datasets explicitly model the UK connection requirement.

## Validation
- `uv run --python 3.13 ruff check policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_meets_uk_connection.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_program_eligible.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_meets_uk_connection.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_program_eligible.py`
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_program_eligible.yaml policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml -c policyengine_uk`
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare -c policyengine_uk`
