### PR TITLE
Handle looked-after children in Tax-Free Childcare

### DIFF
--- a/changelog.d/1048.md
+++ b/changelog.d/1048.md
@@ -1,0 +1,1 @@
+- Added Tax-Free Childcare looked-after-child eligibility handling.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/is_child_receiving_tax_free_childcare.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/is_child_receiving_tax_free_childcare.yaml
@@ -57,3 +57,13 @@
       tax_free_childcare: 900
   output:
     is_child_receiving_tax_free_childcare: true
+
+- name: Looked-after child with positive TFC amount - ineligible
+  period: 2025
+  input:
+    person:
+      tax_free_childcare_child_age_eligible: true
+      is_looked_after_by_local_authority: true
+      tax_free_childcare: 2_000
+  output:
+    is_child_receiving_tax_free_childcare: false

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare.yaml
@@ -3,7 +3,7 @@
   period: 2025
   input:
     tax_free_childcare_eligible: true
-    is_parent: false
+    tax_free_childcare_qualifying_child: true
     is_disabled_for_benefits: false
     childcare_expenses: 8_000 
   output:
@@ -13,7 +13,7 @@
   period: 2025
   input:
     tax_free_childcare_eligible: true
-    is_parent: false
+    tax_free_childcare_qualifying_child: true
     is_disabled_for_benefits: false
     childcare_expenses: 10_000 
   output:
@@ -23,7 +23,7 @@
   period: 2025
   input:
     tax_free_childcare_eligible: true
-    is_parent: false
+    tax_free_childcare_qualifying_child: true
     is_disabled_for_benefits: true
     childcare_expenses: 16_000  
   output:
@@ -33,7 +33,7 @@
   period: 2025
   input:
     tax_free_childcare_eligible: true
-    is_parent: false
+    tax_free_childcare_qualifying_child: true
     is_disabled_for_benefits: true
     childcare_expenses: 25_000 
   output:
@@ -63,7 +63,7 @@
   period: 2025
   input:
     tax_free_childcare_eligible: true
-    is_parent: false
+    tax_free_childcare_qualifying_child: true
     is_disabled_for_benefits: false
     childcare_expenses: 1_000 
   output:
@@ -73,9 +73,19 @@
   period: 2025
   input:
     tax_free_childcare_eligible: true
-    is_parent: false
+    tax_free_childcare_qualifying_child: true
     is_disabled_for_benefits: false
     childcare_expenses: 10_000
     tax_free_childcare_uses_qualifying_provider: false
+  output:
+    tax_free_childcare: 0
+
+- name: Looked-after child gets no support
+  period: 2025
+  input:
+    tax_free_childcare_eligible: true
+    tax_free_childcare_child_age_eligible: true
+    is_looked_after_by_local_authority: true
+    childcare_expenses: 8_000
   output:
     tax_free_childcare: 0

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.yaml
@@ -2,17 +2,17 @@
 - name: All conditions met
   period: 2025
   input:
-    tax_free_childcare_child_age_eligible: true
+    tax_free_childcare_qualifying_child: true
     tax_free_childcare_meets_income_requirements: true
     tax_free_childcare_program_eligible: true
     tax_free_childcare_work_condition: true
   output:
     tax_free_childcare_eligible: true
 
-- name: Fails age condition only
+- name: Fails qualifying child condition only
   period: 2025
   input:
-    tax_free_childcare_child_age_eligible: false
+    tax_free_childcare_qualifying_child: false
     tax_free_childcare_meets_income_requirements: true
     tax_free_childcare_program_eligible: true
     tax_free_childcare_work_condition: true
@@ -22,7 +22,7 @@
 - name: Fails income condition only
   period: 2025
   input:
-    tax_free_childcare_child_age_eligible: true
+    tax_free_childcare_qualifying_child: true
     tax_free_childcare_meets_income_requirements: false
     tax_free_childcare_program_eligible: true
     tax_free_childcare_work_condition: true
@@ -33,7 +33,7 @@
 - name: Fails work condition only
   period: 2025
   input:
-    tax_free_childcare_child_age_eligible: true
+    tax_free_childcare_qualifying_child: true
     tax_free_childcare_meets_income_requirements: true
     tax_free_childcare_program_eligible: true
     tax_free_childcare_work_condition: false
@@ -43,9 +43,20 @@
 - name: Fails all conditions
   period: 2025
   input:
-    tax_free_childcare_child_age_eligible: false
+    tax_free_childcare_qualifying_child: false
     tax_free_childcare_meets_income_requirements: false
     tax_free_childcare_program_eligible: false
     tax_free_childcare_work_condition: false
+  output:
+    tax_free_childcare_eligible: false
+
+- name: Fails because child is looked after by a local authority
+  period: 2025
+  input:
+    tax_free_childcare_child_age_eligible: true
+    is_looked_after_by_local_authority: true
+    tax_free_childcare_meets_income_requirements: true
+    tax_free_childcare_program_eligible: true
+    tax_free_childcare_work_condition: true
   output:
     tax_free_childcare_eligible: false

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_qualifying_child.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_qualifying_child.yaml
@@ -1,0 +1,35 @@
+- name: Age-eligible non-parent child is qualifying
+  period: 2025
+  input:
+    tax_free_childcare_child_age_eligible: true
+    is_parent: false
+    is_looked_after_by_local_authority: false
+  output:
+    tax_free_childcare_qualifying_child: true
+
+- name: Parent is not a qualifying child
+  period: 2025
+  input:
+    tax_free_childcare_child_age_eligible: true
+    is_parent: true
+    is_looked_after_by_local_authority: false
+  output:
+    tax_free_childcare_qualifying_child: false
+
+- name: Looked-after child is not qualifying
+  period: 2025
+  input:
+    tax_free_childcare_child_age_eligible: true
+    is_parent: false
+    is_looked_after_by_local_authority: true
+  output:
+    tax_free_childcare_qualifying_child: false
+
+- name: Age-ineligible child is not qualifying
+  period: 2025
+  input:
+    tax_free_childcare_child_age_eligible: false
+    is_parent: false
+    is_looked_after_by_local_authority: false
+  output:
+    tax_free_childcare_qualifying_child: false

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_qualifying_child.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_qualifying_child.py
@@ -1,0 +1,24 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_qualifying_child(Variable):
+    value_type = bool
+    entity = Person
+    label = "qualifying child for tax-free childcare"
+    definition_period = YEAR
+    reference = [
+        "https://www.legislation.gov.uk/uksi/2015/448/regulation/4",
+        "https://www.legislation.gov.uk/uksi/2015/448/regulation/5",
+    ]
+
+    def formula(person, period, parameters):
+        meets_age_condition = person(
+            "tax_free_childcare_child_age_eligible",
+            period,
+        )
+        is_parent = person("is_parent", period)
+        looked_after_by_local_authority = person(
+            "is_looked_after_by_local_authority",
+            period,
+        )
+        return meets_age_condition & ~is_parent & ~looked_after_by_local_authority

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/is_child_receiving_tax_free_childcare.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/is_child_receiving_tax_free_childcare.py
@@ -8,13 +8,13 @@ class is_child_receiving_tax_free_childcare(Variable):
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        # Check if child meets the age condition
-        meets_age_condition = person("tax_free_childcare_child_age_eligible", period)
+        # Check if child is qualifying for tax-free childcare
+        is_qualifying_child = person("tax_free_childcare_qualifying_child", period)
 
         # Check if tax-free childcare contribution is greater than 0
         tfc_amount = person("tax_free_childcare", period)
 
         # Child is eligible if:
-        # 1. Meets the age condition AND
+        # 1. Child is qualifying AND
         # 2. Tax-free childcare amount > 0
-        return meets_age_condition & (tfc_amount > 0)
+        return is_qualifying_child & (tfc_amount > 0)

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py
@@ -15,9 +15,9 @@ class tax_free_childcare(Variable):
         p = parameters(period).gov.hmrc.tax_free_childcare.contribution
 
         # Calculate per-person amounts
-        is_parent = person("is_parent", period)
         is_disabled = person("is_disabled_for_benefits", period)
         is_blind = person("is_blind", period)
+        is_qualifying_child = person("tax_free_childcare_qualifying_child", period)
 
         # Person gets higher amount if either disabled or blind
         qualifies_for_higher_amount = is_disabled | is_blind
@@ -35,7 +35,7 @@ class tax_free_childcare(Variable):
         # Cap the contribution at the maximum amounts
         max_amount = (
             where(qualifies_for_higher_amount, p.disabled_child, p.standard_child)
-            * ~is_parent
+            * is_qualifying_child
         )
 
         return min_(contribution, max_amount)

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.py
@@ -9,8 +9,8 @@ class tax_free_childcare_eligible(Variable):
     defined_for = "would_claim_tfc"
 
     def formula(benunit, period, parameters):
-        meets_age_condition = benunit.any(
-            benunit.members("tax_free_childcare_child_age_eligible", period),
+        has_qualifying_child = benunit.any(
+            benunit.members("tax_free_childcare_qualifying_child", period),
         )
 
         meets_income_condition = benunit.all(
@@ -24,7 +24,7 @@ class tax_free_childcare_eligible(Variable):
 
         return np.logical_and.reduce(
             [
-                meets_age_condition,
+                has_qualifying_child,
                 meets_income_condition,
                 childcare_eligible,
                 work_eligible,

--- a/policyengine_uk/variables/household/demographic/is_looked_after_by_local_authority.py
+++ b/policyengine_uk/variables/household/demographic/is_looked_after_by_local_authority.py
@@ -1,0 +1,10 @@
+from policyengine_uk.model_api import *
+
+
+class is_looked_after_by_local_authority(Variable):
+    value_type = bool
+    entity = Person
+    label = "looked after by a local authority"
+    definition_period = YEAR
+    default_value = False
+    reference = "https://www.legislation.gov.uk/uksi/2015/448/regulation/4"

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.3"
+version = "2.86.4"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Add a default-false `is_looked_after_by_local_authority` person input, referenced to Childcare Payments (Eligibility) Regulations 2015 regulation 4.
- Add `tax_free_childcare_qualifying_child`, combining the existing age rule with non-parent and looked-after-child exclusions.
- Use qualifying-child status for Tax-Free Childcare eligibility, per-child payment caps, and receiving-status detection.

Closes #1048.

## Notes
- The issue referenced regulation 16, but current legislation.gov.uk has the foster/looked-after-child responsibility rule in regulation 4 and the age qualifying-child rule in regulation 5.
- Baseline behavior is unchanged unless the new looked-after-child input is supplied, except that per-child payment caps now depend on the explicit qualifying-child condition rather than just `~is_parent`.

## Tests
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare -c policyengine_uk`
- `uv run --python 3.13 ruff check policyengine_uk/variables/household/demographic/is_looked_after_by_local_authority.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_qualifying_child.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/is_child_receiving_tax_free_childcare.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/household/demographic/is_looked_after_by_local_authority.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_qualifying_child.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligibility.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/is_child_receiving_tax_free_childcare.py`