### PR TITLE
Treat qualifying leave as work for Tax-Free Childcare

### DIFF
--- a/changelog.d/1044.md
+++ b/changelog.d/1044.md
@@ -1,0 +1,1 @@
+- Added Tax-Free Childcare temporary absence from work handling.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_treated_as_in_work.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_treated_as_in_work.yaml
@@ -1,0 +1,54 @@
+- name: Person in work is treated as in work
+  period: 2025
+  input:
+    in_work: true
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
+- name: Person on qualifying leave is treated as in work
+  period: 2025
+  input:
+    in_work: false
+    tax_free_childcare_on_qualifying_leave: true
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
+- name: Person receiving statutory sick pay is treated as in work
+  period: 2025
+  input:
+    in_work: false
+    statutory_sick_pay: 100
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
+- name: Person receiving maternity allowance is treated as in work
+  period: 2025
+  input:
+    in_work: false
+    maternity_allowance: 100
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
+- name: Person receiving statutory maternity pay is treated as in work
+  period: 2025
+  input:
+    in_work: false
+    statutory_maternity_pay: 100
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
+- name: Person receiving statutory paternity pay is treated as in work
+  period: 2025
+  input:
+    in_work: false
+    statutory_paternity_pay: 100
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
+- name: Person with no work or temporary absence condition is not treated as in work
+  period: 2025
+  input:
+    in_work: false
+    tax_free_childcare_on_qualifying_leave: false
+  output:
+    tax_free_childcare_treated_as_in_work: false

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_work_condition.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_work_condition.yaml
@@ -165,3 +165,55 @@
        members: [person]
   output:
    tax_free_childcare_work_condition: false
+
+- name: Single adult on qualifying parenting leave - eligible
+  period: 2025
+  input:
+   people:
+     person:
+       is_adult: true
+       in_work: false
+       tax_free_childcare_on_qualifying_leave: true
+   benunits:
+     benunit:
+       members: [person]
+  output:
+   tax_free_childcare_work_condition: true
+
+- name: Couple one working one on qualifying parenting leave - eligible
+  period: 2025
+  input:
+   people:
+     person:
+       is_adult: true
+       is_parent: true
+       in_work: true
+     spouse:
+       is_adult: true
+       is_parent: true
+       in_work: false
+       tax_free_childcare_on_qualifying_leave: true
+   benunits:
+     benunit:
+       members: [person, spouse]
+  output:
+   tax_free_childcare_work_condition: true
+
+- name: Couple one working one receiving statutory maternity pay - eligible
+  period: 2025
+  input:
+   people:
+     person:
+       is_adult: true
+       is_parent: true
+       in_work: true
+     spouse:
+       is_adult: true
+       is_parent: true
+       in_work: false
+       statutory_maternity_pay: 100
+   benunits:
+     benunit:
+       members: [person, spouse]
+  output:
+   tax_free_childcare_work_condition: true

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_qualifying_leave.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_qualifying_leave.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_on_qualifying_leave(Variable):
+    value_type = bool
+    entity = Person
+    label = "on qualifying leave for tax-free childcare"
+    documentation = (
+        "Whether this person is on qualifying sickness, parenting, annual, "
+        "parental bereavement, or neonatal care leave for Tax-Free Childcare."
+    )
+    definition_period = YEAR
+    default_value = False
+    reference = [
+        "https://www.legislation.gov.uk/uksi/2015/448/regulation/12",
+        "https://www.legislation.gov.uk/uksi/2015/448/regulation/14",
+    ]

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py
@@ -1,0 +1,32 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_treated_as_in_work(Variable):
+    value_type = bool
+    entity = Person
+    label = "treated as in work for tax-free childcare"
+    definition_period = YEAR
+    reference = [
+        "https://www.legislation.gov.uk/uksi/2015/448/regulation/12",
+        "https://www.legislation.gov.uk/uksi/2015/448/regulation/14",
+    ]
+
+    def formula(person, period, parameters):
+        statutory_temporary_absence_pay = (
+            add(
+                person,
+                period,
+                [
+                    "statutory_sick_pay",
+                    "maternity_allowance",
+                    "statutory_maternity_pay",
+                    "statutory_paternity_pay",
+                ],
+            )
+            > 0
+        )
+        return (
+            person("in_work", period)
+            | person("tax_free_childcare_on_qualifying_leave", period)
+            | statutory_temporary_absence_pay
+        )

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_work_condition.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_work_condition.py
@@ -11,8 +11,10 @@ class tax_free_childcare_work_condition(Variable):
         benunit = person.benunit
         is_adult = person("is_adult", period)
 
-        # Basic work status
-        in_work = person("in_work", period)
+        treated_as_in_work = person(
+            "tax_free_childcare_treated_as_in_work",
+            period,
+        )
 
         # Get disability parameters and check eligibility
         p_gc_disability = parameters(
@@ -33,14 +35,14 @@ class tax_free_childcare_work_condition(Variable):
         # Build conditions
         # Single adult conditions
         is_single = person.benunit("is_single", period)
-        single_working = is_single & in_work
+        single_working = is_single & treated_as_in_work
 
         # Couple conditions
         is_couple = person.benunit("is_couple", period)
         benunit_has_condition = benunit.any(eligible_based_on_disability & is_adult)
-        benunit_has_worker = benunit.any(in_work & is_adult)
+        benunit_has_worker = benunit.any(treated_as_in_work & is_adult)
         couple_both_working = is_couple & benunit.all(
-            in_work | ~person("is_parent", period)
+            treated_as_in_work | ~person("is_parent", period)
         )
         couple_one_working_one_disabled = (
             is_couple & benunit_has_worker & benunit_has_condition

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.4"
+version = "2.86.5"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Add `tax_free_childcare_on_qualifying_leave` for qualifying leave periods not represented by existing income variables.
- Add `tax_free_childcare_treated_as_in_work`, treating raw work, qualifying leave, statutory sick pay, maternity allowance, statutory maternity pay, and statutory paternity pay as work for Tax-Free Childcare.
- Route `tax_free_childcare_work_condition` through the new treated-as-in-work helper for single and couple conditions.

Closes #1044.

## Notes
- The issue references regulations 8-10, but current legislation.gov.uk has temporary absence/parenting leave treatment in regulation 12, with the work requirement cross-reference in regulation 14.
- This does not add distinct statutory adoption/shared parental pay income variables; the new qualifying-leave input covers those leave states until those incomes are modeled directly.

## Tests
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare -c policyengine_uk`
- `uv run --python 3.13 ruff check policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_qualifying_leave.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_work_condition.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_qualifying_leave.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_work_condition.py`