### PR TITLE
Add explicit Tax-Free Childcare leave inputs

### DIFF
--- a/changelog.d/1044-explicit-leave.md
+++ b/changelog.d/1044-explicit-leave.md
@@ -1,0 +1,1 @@
+- Added explicit Tax-Free Childcare adoption and shared parental leave work-condition inputs.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_treated_as_in_work.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_treated_as_in_work.yaml
@@ -13,6 +13,22 @@
   output:
     tax_free_childcare_treated_as_in_work: true
 
+- name: Person on adoption leave is treated as in work
+  period: 2025
+  input:
+    in_work: false
+    tax_free_childcare_on_adoption_leave: true
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
+- name: Person on shared parental leave is treated as in work
+  period: 2025
+  input:
+    in_work: false
+    tax_free_childcare_on_shared_parental_leave: true
+  output:
+    tax_free_childcare_treated_as_in_work: true
+
 - name: Person receiving statutory sick pay is treated as in work
   period: 2025
   input:
@@ -50,5 +66,7 @@
   input:
     in_work: false
     tax_free_childcare_on_qualifying_leave: false
+    tax_free_childcare_on_adoption_leave: false
+    tax_free_childcare_on_shared_parental_leave: false
   output:
     tax_free_childcare_treated_as_in_work: false

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_work_condition.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_work_condition.yaml
@@ -217,3 +217,41 @@
        members: [person, spouse]
   output:
    tax_free_childcare_work_condition: true
+
+- name: Couple one working one on adoption leave - eligible
+  period: 2025
+  input:
+   people:
+     person:
+       is_adult: true
+       is_parent: true
+       in_work: true
+     spouse:
+       is_adult: true
+       is_parent: true
+       in_work: false
+       tax_free_childcare_on_adoption_leave: true
+   benunits:
+     benunit:
+       members: [person, spouse]
+  output:
+   tax_free_childcare_work_condition: true
+
+- name: Couple one working one on shared parental leave - eligible
+  period: 2025
+  input:
+   people:
+     person:
+       is_adult: true
+       is_parent: true
+       in_work: true
+     spouse:
+       is_adult: true
+       is_parent: true
+       in_work: false
+       tax_free_childcare_on_shared_parental_leave: true
+   benunits:
+     benunit:
+       members: [person, spouse]
+  output:
+   tax_free_childcare_work_condition: true

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_adoption_leave.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_adoption_leave.py
@@ -1,0 +1,10 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_on_adoption_leave(Variable):
+    value_type = bool
+    entity = Person
+    label = "on adoption leave for tax-free childcare"
+    definition_period = YEAR
+    default_value = False
+    reference = "https://www.legislation.gov.uk/uksi/2015/448/regulation/12"

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_shared_parental_leave.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_shared_parental_leave.py
@@ -1,0 +1,10 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_on_shared_parental_leave(Variable):
+    value_type = bool
+    entity = Person
+    label = "on shared parental leave for tax-free childcare"
+    definition_period = YEAR
+    default_value = False
+    reference = "https://www.legislation.gov.uk/uksi/2015/448/regulation/12"

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py
@@ -28,5 +28,7 @@ class tax_free_childcare_treated_as_in_work(Variable):
         return (
             person("in_work", period)
             | person("tax_free_childcare_on_qualifying_leave", period)
+            | person("tax_free_childcare_on_adoption_leave", period)
+            | person("tax_free_childcare_on_shared_parental_leave", period)
             | statutory_temporary_absence_pay
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.5"
+version = "2.86.6"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Add explicit Tax-Free Childcare inputs for adoption leave and shared parental leave.
- Treat those explicit leave states as work in `tax_free_childcare_treated_as_in_work`.
- Add direct treated-as-in-work tests and couple work-condition tests for both leave states.

Follow-up to #1600 / #1044 based on review feedback.

## Tests
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare -c policyengine_uk`
- `uv run --python 3.13 ruff check policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_adoption_leave.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_shared_parental_leave.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_adoption_leave.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_on_shared_parental_leave.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/conditions/tax_free_childcare_treated_as_in_work.py`