### PR TITLE
Add Tax-Free Childcare declaration periods

### DIFF
--- a/changelog.d/1047.md
+++ b/changelog.d/1047.md
@@ -1,0 +1,1 @@
+- Added Tax-Free Childcare eligible declaration period handling.

--- a/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/declaration_periods_per_year.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/declaration_periods_per_year.yaml
@@ -1,0 +1,10 @@
+description: HMRC assesses Tax-Free Childcare eligibility over this many declaration periods per year.
+metadata:
+  period: year
+  unit: declaration_period
+  label: Tax-Free Childcare declaration periods per year
+  reference:
+    - title: The Childcare Payments (Eligibility) Regulations 2015 - Regulation 9(4)
+      href: https://www.legislation.gov.uk/uksi/2015/448/regulation/9
+values:
+  2015-01-01: 4

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare.yaml
@@ -89,3 +89,25 @@
     childcare_expenses: 8_000
   output:
     tax_free_childcare: 0
+
+- name: Two eligible declaration periods halve standard child cap
+  period: 2025
+  input:
+    tax_free_childcare_eligible: true
+    tax_free_childcare_qualifying_child: true
+    tax_free_childcare_eligible_declaration_periods: 2
+    is_disabled_for_benefits: false
+    childcare_expenses: 10_000
+  output:
+    tax_free_childcare: 1_000
+
+- name: One eligible declaration period quarters disabled child cap
+  period: 2025
+  input:
+    tax_free_childcare_eligible: true
+    tax_free_childcare_qualifying_child: true
+    tax_free_childcare_eligible_declaration_periods: 1
+    is_disabled_for_benefits: true
+    childcare_expenses: 25_000
+  output:
+    tax_free_childcare: 1_000

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligible_declaration_periods.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_eligible_declaration_periods.yaml
@@ -1,0 +1,13 @@
+- name: Eligible benefit unit defaults to all declaration periods
+  period: 2025
+  input:
+    tax_free_childcare_eligible: true
+  output:
+    tax_free_childcare_eligible_declaration_periods: 4
+
+- name: Ineligible benefit unit defaults to no declaration periods
+  period: 2025
+  input:
+    tax_free_childcare_eligible: false
+  output:
+    tax_free_childcare_eligible_declaration_periods: 0

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py
@@ -12,7 +12,8 @@ class tax_free_childcare(Variable):
 
     def formula(person, period, parameters):
         # Get parameters
-        p = parameters(period).gov.hmrc.tax_free_childcare.contribution
+        tax_free_childcare = parameters(period).gov.hmrc.tax_free_childcare
+        p = tax_free_childcare.contribution
 
         # Calculate per-person amounts
         is_disabled = person("is_disabled_for_benefits", period)
@@ -33,9 +34,21 @@ class tax_free_childcare(Variable):
         contribution = (eligible_childcare_expense * p.rate) / (1 - p.rate)
 
         # Cap the contribution at the maximum amounts
+        eligible_periods = person.benunit(
+            "tax_free_childcare_eligible_declaration_periods",
+            period,
+        )
+        eligible_periods = min_(
+            max_(eligible_periods, 0),
+            tax_free_childcare.declaration_periods_per_year,
+        )
+        eligible_fraction = (
+            eligible_periods / tax_free_childcare.declaration_periods_per_year
+        )
         max_amount = (
             where(qualifies_for_higher_amount, p.disabled_child, p.standard_child)
             * is_qualifying_child
+            * eligible_fraction
         )
 
         return min_(contribution, max_amount)

--- a/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligible_declaration_periods.py
+++ b/policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligible_declaration_periods.py
@@ -1,0 +1,14 @@
+from policyengine_uk.model_api import *
+
+
+class tax_free_childcare_eligible_declaration_periods(Variable):
+    value_type = int
+    entity = BenUnit
+    label = "Tax-Free Childcare eligible declaration periods"
+    definition_period = YEAR
+    reference = "https://www.legislation.gov.uk/uksi/2015/448/regulation/9"
+
+    def formula(benunit, period, parameters):
+        p = parameters(period).gov.hmrc.tax_free_childcare
+        eligible = benunit("tax_free_childcare_eligible", period)
+        return eligible * p.declaration_periods_per_year

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.7"
+version = "2.86.8"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Add a Tax-Free Childcare declaration-periods-per-year parameter.
- Add `tax_free_childcare_eligible_declaration_periods`, defaulting to 4 periods when eligible and 0 otherwise.
- Scale per-child annual contribution caps by eligible declaration periods so partial-year eligibility can be modeled.

Closes #1047.

## Notes
- This is an annual-model proxy for quarterly reassessment: users can supply the number of eligible declaration periods in the year. It preserves current full-year results by default.

## Tests
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare -c policyengine_uk`
- `uv run --python 3.13 ruff check policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligible_declaration_periods.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare.py policyengine_uk/variables/gov/hmrc/tax_free_childcare/tax_free_childcare_eligible_declaration_periods.py`