### PR TITLE
Add UC carer element to extended childcare exemptions

### DIFF
--- a/changelog.d/1032.md
+++ b/changelog.d/1032.md
@@ -1,0 +1,1 @@
+- Added Universal Credit carer element to extended childcare entitlement work-requirement exemptions.

--- a/policyengine_uk/parameters/gov/dfe/extended_childcare_entitlement/disability_criteria.yaml
+++ b/policyengine_uk/parameters/gov/dfe/extended_childcare_entitlement/disability_criteria.yaml
@@ -1,4 +1,4 @@
-description: The Department for Education exempts participants in these programs from work requirements of extended childcare entitlement. 
+description: The Department for Education exempts participants in these programs from work requirements of extended childcare entitlement.
 metadata:
   reference:
     - title: The Childcare Regulations 2022 - Regulation 11A
@@ -9,6 +9,7 @@ metadata:
 values:
   2015-09-01:
     - carers_allowance  # 11A(1)(a): Carer's allowance under Section 70 of Social Security Contributions and Benefits Act 1992
+    - uc_carer_element  # 11A(1)(c): Universal Credit carer element under Regulation 29 of the Universal Credit Regulations 2013
     - esa_contrib  # 11A(1)(e): Employment and support allowance under Welfare Reform Act 2007
     - incapacity_benefit  # 11A(1)(g): Long-term or short-term incapacity benefit under Social Security Contributions and Benefits Act
     - sda  # 11A(1)(h): Severe disablement allowance under Section 68 of Social Security Contributions and Benefits Act

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/extended_childcare_entitlement/extended_childcare_entitlement_work_condition.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/extended_childcare_entitlement/extended_childcare_entitlement_work_condition.yaml
@@ -61,6 +61,29 @@
   output:
     extended_childcare_entitlement_work_condition: [1, 1, 0]
 
+- name: Couple with children, one working one with Carer's Allowance - eligible
+  period: 2025
+  input:
+    people:
+      parent1:
+        age: 40
+        in_work: true
+        is_parent: true
+      parent2:
+        age: 38
+        in_work: false
+        is_parent: true
+        carers_allowance: 1
+      child:
+        age: 4
+        is_parent: false
+    benunits:
+      benunit:
+        members: [parent1, parent2, child]
+        family_type: COUPLE_WITH_CHILDREN
+  output:
+    extended_childcare_entitlement_work_condition: [1, 1, 0]
+
 - name: Couple with children one working one not - ineligible
   period: 2025
   input:

--- a/policyengine_uk/variables/gov/dfe/extended_childcare_entitlement/conditions/extended_childcare_entitlement_work_condition.py
+++ b/policyengine_uk/variables/gov/dfe/extended_childcare_entitlement/conditions/extended_childcare_entitlement_work_condition.py
@@ -13,13 +13,31 @@ class extended_childcare_entitlement_work_condition(Variable):
         benunit = person.benunit
         in_work = person("in_work", period)
 
-        # Get disability status
         p = parameters(period).gov.dfe.extended_childcare_entitlement
-        eligible_based_on_disability = add(person, period, p.disability_criteria) > 0
+        disability_criteria = list(p.disability_criteria)
+        person_disability_criteria = [
+            variable
+            for variable in disability_criteria
+            if person.entity.get_variable(variable).entity.is_person
+        ]
+        group_disability_criteria = [
+            variable
+            for variable in disability_criteria
+            if not person.entity.get_variable(variable).entity.is_person
+        ]
 
-        # Adjust eligibility based on the summed UC Carer Element: 11A(1)(c)
-        eligible_based_on_disability_or_carer = eligible_based_on_disability | (
-            benunit("uc_carer_element", period) > 0
+        eligible_based_on_person_disability = (
+            add(person, period, person_disability_criteria) > 0
+            if person_disability_criteria
+            else False
+        )
+        eligible_based_on_group_disability = (
+            add(benunit, period, group_disability_criteria) > 0
+            if group_disability_criteria
+            else False
+        )
+        eligible_based_on_disability = (
+            eligible_based_on_person_disability | eligible_based_on_group_disability
         )
 
         # Count parents in benefit unit
@@ -32,7 +50,7 @@ class extended_childcare_entitlement_work_condition(Variable):
         all_parents_working = benunit.all(in_work | ~person("is_parent", period))
         some_parents_working = benunit.any(in_work & person("is_parent", period))
         any_parent_disability_eligible = benunit.any(
-            eligible_based_on_disability_or_carer & person("is_parent", period)
+            eligible_based_on_disability & person("is_parent", period)
         )
 
         # Work condition for couples - either both working or one working with other disabled or receiving UC Carer Element

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.8"
+version = "2.86.9"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Add `uc_carer_element` to the extended childcare entitlement disability criteria parameter list.
- Update the work-condition formula to evaluate mixed person-level and benefit-unit-level criteria from that list.
- Add a regression test for Carer's Allowance while retaining the UC carer element test.

Closes #1032.

## Tests
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/extended_childcare_entitlement -c policyengine_uk`
- `uv run --python 3.13 ruff check policyengine_uk/variables/gov/dfe/extended_childcare_entitlement/conditions/extended_childcare_entitlement_work_condition.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/gov/dfe/extended_childcare_entitlement/conditions/extended_childcare_entitlement_work_condition.py`