### PR TITLE
Update targeted childcare tax credit criteria

### DIFF
--- a/changelog.d/1065.md
+++ b/changelog.d/1065.md
@@ -1,0 +1,1 @@
+- Updated targeted childcare entitlement tax credit criteria to match historical and current regulations.

--- a/policyengine_uk/parameters/gov/dfe/targeted_childcare_entitlement/income_limit/tax_credits.yaml
+++ b/policyengine_uk/parameters/gov/dfe/targeted_childcare_entitlement/income_limit/tax_credits.yaml
@@ -1,15 +1,12 @@
-description: The Department for Education qualifies recipients of the Working Tax Credit or Child Tax Credit for targeted childcare entitlement if their income does not exceed this threshold.
+description: The Department for Education applies this income threshold to tax credit routes into targeted childcare entitlement.
 metadata:
-  unit: currency-GBP  
+  unit: currency-GBP
   period: year
-  label: Income limit for tax credit recipients to access benefit-targeted free childcare
+  label: Targeted childcare entitlement tax credit income limit
   reference:
-    - title: The Local Authority (Duty to Secure Early Years Provision Free of Charge) Regulations 2014, part 1.2.b
+    - title: The Local Authority (Duty to Secure Early Years Provision Free of Charge) Regulations 2014
       href: https://www.legislation.gov.uk/uksi/2014/2147/regulation/1/made
-      # In part 1.2.b of regulation 2014, they mentioned "Part 1 of the Tax Credits Act 2002(8)" for tax credit criteria. Part 1.1 of the Tax Credits Act 2002(8) explains that tax credit is known as child tax credit and working tax credit. 
-    - title: Tax Credits Act 2002(8) - part 1
-      href: https://www.legislation.gov.uk/ukpga/2002/21/section/1
-    - title: 15 hours free education and childcare for 2-year-olds
-      href: https://www.gov.uk/help-with-childcare-costs/free-childcare-2-year-olds-claim-benefits?step-by-step-nav=f237ec8e-e82c-4ffa-8fba-2a88a739783b
+    - title: The Local Authority (Duty to Secure Early Years Provision Free of Charge) (Amendment) Regulations 2018
+      href: https://www.legislation.gov.uk/uksi/2018/146/regulation/2/made
 values:
   2014-01-01: 16_190

--- a/policyengine_uk/parameters/gov/dfe/targeted_childcare_entitlement/qualifying_criteria.yaml
+++ b/policyengine_uk/parameters/gov/dfe/targeted_childcare_entitlement/qualifying_criteria.yaml
@@ -1,12 +1,21 @@
 description: The Department for Education designates these variables that determine qualification for targeted childcare entitlement beyond qualifying benefits.
 metadata:
   reference:
-    - title: Documenation for free education and childcare for 2-year-olds
-      href: https://www.gov.uk/help-with-childcare-costs/free-childcare-2-year-olds
+    - title: The Local Authority (Duty to Secure Early Years Provision Free of Charge) Regulations 2014
+      href: https://www.legislation.gov.uk/uksi/2014/2147/regulation/1
+    - title: The Local Authority (Duty to Secure Early Years Provision Free of Charge) (Amendment) Regulations 2018
+      href: https://www.legislation.gov.uk/uksi/2018/146/regulation/2/made
+    - title: Free education and childcare for 2 year olds if you get extra support
+      href: https://www.gov.uk/help-with-childcare-costs/free-childcare-2-year-olds-extra-support
   period: year
   unit: program
   label: Qualifying criteria for targeted childcare entitlement
 values:
   2014-01-01:
+    - meets_working_tax_credit_criteria_for_targeted_childcare_entitlement
+  2018-01-01:
     - meets_universal_credit_criteria_for_targeted_childcare_entitlement
-    - meets_tax_credit_criteria_for_targeted_childcare_entitlement
+    - meets_child_tax_credit_criteria_for_targeted_childcare_entitlement
+    - working_tax_credit_run_on
+  2026-01-01:
+    - meets_universal_credit_criteria_for_targeted_childcare_entitlement

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/meets_child_tax_credit_criteria_for_targeted_childcare_entitlement.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/meets_child_tax_credit_criteria_for_targeted_childcare_entitlement.yaml
@@ -1,0 +1,42 @@
+- name: Child Tax Credit without Working Tax Credit qualifies from the 2018 amendment
+  period: 2019
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        child_tax_credit: 1
+        tax_credits_applicable_income: 16_190
+  output:
+    meets_child_tax_credit_criteria_for_targeted_childcare_entitlement: true
+
+- name: Child Tax Credit with Working Tax Credit does not meet the 2018 criterion
+  period: 2019
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        child_tax_credit: 1
+        working_tax_credit: 1
+        tax_credits_applicable_income: 16_190
+  output:
+    meets_child_tax_credit_criteria_for_targeted_childcare_entitlement: false
+
+- name: Child Tax Credit over the income limit does not qualify
+  period: 2019
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        child_tax_credit: 1
+        tax_credits_applicable_income: 16_191
+  output:
+    meets_child_tax_credit_criteria_for_targeted_childcare_entitlement: false

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/meets_tax_credit_criteria_for_targeted_childcare_entitlement.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/meets_tax_credit_criteria_for_targeted_childcare_entitlement.yaml
@@ -1,0 +1,38 @@
+- name: Tax credit criteria include Working Tax Credit before the 2018 amendment
+  period: 2017
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        meets_working_tax_credit_criteria_for_targeted_childcare_entitlement: true
+  output:
+    meets_tax_credit_criteria_for_targeted_childcare_entitlement: true
+
+- name: Tax credit criteria include Child Tax Credit after the 2018 amendment
+  period: 2019
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        meets_child_tax_credit_criteria_for_targeted_childcare_entitlement: true
+  output:
+    meets_tax_credit_criteria_for_targeted_childcare_entitlement: true
+
+- name: Tax credit criteria are inactive from 2026
+  period: 2026
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        meets_child_tax_credit_criteria_for_targeted_childcare_entitlement: true
+  output:
+    meets_tax_credit_criteria_for_targeted_childcare_entitlement: false

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/meets_working_tax_credit_criteria_for_targeted_childcare_entitlement.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/meets_working_tax_credit_criteria_for_targeted_childcare_entitlement.yaml
@@ -1,0 +1,41 @@
+- name: Working Tax Credit qualifies before the 2018 amendment
+  period: 2017
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        working_tax_credit: 1
+        tax_credits_applicable_income: 16_190
+  output:
+    meets_working_tax_credit_criteria_for_targeted_childcare_entitlement: true
+
+- name: Child Tax Credit does not meet the original Working Tax Credit criterion
+  period: 2017
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        child_tax_credit: 1
+        tax_credits_applicable_income: 16_190
+  output:
+    meets_working_tax_credit_criteria_for_targeted_childcare_entitlement: false
+
+- name: Working Tax Credit over the income limit does not qualify
+  period: 2017
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        working_tax_credit: 1
+        tax_credits_applicable_income: 16_191
+  output:
+    meets_working_tax_credit_criteria_for_targeted_childcare_entitlement: false

--- a/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/targeted_childcare_entitlement_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement/targeted_childcare_entitlement_eligible.yaml
@@ -1,0 +1,111 @@
+- name: Working Tax Credit route qualifies before the 2018 amendment
+  period: 2017
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        income_support: 0
+        jsa_income: 0
+        esa_income: 0
+        guarantee_credit: 0
+        meets_working_tax_credit_criteria_for_targeted_childcare_entitlement: true
+        extended_childcare_entitlement_eligible: false
+  output:
+    targeted_childcare_entitlement_eligible: true
+
+- name: Ordinary Working Tax Credit no longer qualifies after the 2018 amendment
+  period: 2019
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        income_support: 0
+        jsa_income: 0
+        esa_income: 0
+        guarantee_credit: 0
+        meets_working_tax_credit_criteria_for_targeted_childcare_entitlement: true
+        meets_universal_credit_criteria_for_targeted_childcare_entitlement: false
+        extended_childcare_entitlement_eligible: false
+  output:
+    targeted_childcare_entitlement_eligible: false
+
+- name: Working Tax Credit run-on qualifies after the 2018 amendment
+  period: 2019
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        income_support: 0
+        jsa_income: 0
+        esa_income: 0
+        guarantee_credit: 0
+        meets_universal_credit_criteria_for_targeted_childcare_entitlement: false
+        working_tax_credit_run_on: true
+        extended_childcare_entitlement_eligible: false
+  output:
+    targeted_childcare_entitlement_eligible: true
+
+- name: Child Tax Credit without Working Tax Credit qualifies after the 2018 amendment
+  period: 2019
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        income_support: 0
+        jsa_income: 0
+        esa_income: 0
+        guarantee_credit: 0
+        meets_universal_credit_criteria_for_targeted_childcare_entitlement: false
+        meets_child_tax_credit_criteria_for_targeted_childcare_entitlement: true
+        extended_childcare_entitlement_eligible: false
+  output:
+    targeted_childcare_entitlement_eligible: true
+
+- name: Child Tax Credit no longer qualifies from 2026
+  period: 2026
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        income_support: 0
+        jsa_income: 0
+        esa_income: 0
+        guarantee_credit: 0
+        meets_universal_credit_criteria_for_targeted_childcare_entitlement: false
+        meets_child_tax_credit_criteria_for_targeted_childcare_entitlement: true
+        extended_childcare_entitlement_eligible: false
+  output:
+    targeted_childcare_entitlement_eligible: false
+
+- name: Universal Credit still qualifies from 2026
+  period: 2026
+  input:
+    people:
+      person:
+        age: 30
+    benunits:
+      benunit:
+        members: [person]
+        income_support: 0
+        jsa_income: 0
+        esa_income: 0
+        guarantee_credit: 0
+        meets_universal_credit_criteria_for_targeted_childcare_entitlement: true
+        extended_childcare_entitlement_eligible: false
+  output:
+    targeted_childcare_entitlement_eligible: true

--- a/policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_child_tax_credit_criteria_for_targeted_childcare_entitlement.py
+++ b/policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_child_tax_credit_criteria_for_targeted_childcare_entitlement.py
@@ -1,0 +1,24 @@
+from policyengine_uk.model_api import *
+
+
+class meets_child_tax_credit_criteria_for_targeted_childcare_entitlement(Variable):
+    value_type = bool
+    entity = BenUnit
+    label = "meets Child Tax Credit criteria for targeted childcare entitlement"
+    definition_period = YEAR
+    reference = (
+        "The Local Authority (Duty to Secure Early Years Provision Free of Charge) "
+        "(Amendment) Regulations 2018, regulation 2(a)(i)"
+    )
+
+    def formula(benunit, period, parameters):
+        p = parameters(period).gov.dfe.targeted_childcare_entitlement
+        child_tax_credit = benunit("child_tax_credit", period) > 0
+        working_tax_credit = benunit("working_tax_credit", period) > 0
+        applicable_income = benunit("tax_credits_applicable_income", period)
+
+        return (
+            child_tax_credit
+            & ~working_tax_credit
+            & (applicable_income <= p.income_limit.tax_credits)
+        )

--- a/policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_tax_credit_criteria_for_targeted_childcare_entitlement.py
+++ b/policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_tax_credit_criteria_for_targeted_childcare_entitlement.py
@@ -9,17 +9,16 @@ class meets_tax_credit_criteria_for_targeted_childcare_entitlement(Variable):
 
     def formula(benunit, period, parameters):
         p = parameters(period).gov.dfe.targeted_childcare_entitlement
-
-        tax_credits = add(benunit, period, ["child_tax_credit", "working_tax_credit"])
-
-        tax_credits_applicable_income = benunit("tax_credits_applicable_income", period)
-
-        # Check Tax Credits eligibility
-        # Legislation source for total (applicable) income limit:The Local Authority Regulations 2014, part 1.2.b
-        # https://www.legislation.gov.uk/uksi/2014/2147/regulation/1/made
-
-        # Reference for applicable income: The Tax Credits (Definition and Calculation of Income) Regulations 2002 s. 3
-
-        return (tax_credits > 0) & (
-            tax_credits_applicable_income <= p.income_limit.tax_credits
-        )
+        tax_credit_criteria = [
+            "meets_working_tax_credit_criteria_for_targeted_childcare_entitlement",
+            "meets_child_tax_credit_criteria_for_targeted_childcare_entitlement",
+            "working_tax_credit_run_on",
+        ]
+        active_tax_credit_criteria = [
+            variable
+            for variable in tax_credit_criteria
+            if variable in p.qualifying_criteria
+        ]
+        if not active_tax_credit_criteria:
+            return False
+        return add(benunit, period, active_tax_credit_criteria) > 0

--- a/policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_working_tax_credit_criteria_for_targeted_childcare_entitlement.py
+++ b/policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_working_tax_credit_criteria_for_targeted_childcare_entitlement.py
@@ -1,0 +1,19 @@
+from policyengine_uk.model_api import *
+
+
+class meets_working_tax_credit_criteria_for_targeted_childcare_entitlement(Variable):
+    value_type = bool
+    entity = BenUnit
+    label = "meets Working Tax Credit criteria for targeted childcare entitlement"
+    definition_period = YEAR
+    reference = (
+        "The Local Authority (Duty to Secure Early Years Provision Free of Charge) "
+        "Regulations 2014, regulation 1(2)(b)"
+    )
+
+    def formula(benunit, period, parameters):
+        p = parameters(period).gov.dfe.targeted_childcare_entitlement
+        working_tax_credit = benunit("working_tax_credit", period) > 0
+        applicable_income = benunit("tax_credits_applicable_income", period)
+
+        return working_tax_credit & (applicable_income <= p.income_limit.tax_credits)

--- a/policyengine_uk/variables/gov/dwp/working_tax_credit_run_on.py
+++ b/policyengine_uk/variables/gov/dwp/working_tax_credit_run_on.py
@@ -1,0 +1,13 @@
+from policyengine_uk.model_api import *
+
+
+class working_tax_credit_run_on(Variable):
+    value_type = bool
+    entity = BenUnit
+    label = "Working Tax Credit run-on"
+    documentation = "Whether this benefit unit receives Working Tax Credit run-on."
+    definition_period = YEAR
+    reference = (
+        "The Local Authority (Duty to Secure Early Years Provision Free of Charge) "
+        "(Amendment) Regulations 2018, regulation 2(a)(i)"
+    )


### PR DESCRIPTION
## Summary
- Replace the all-tax-credits targeted childcare shortcut with time-varying criteria from the regulations.
- Keep the original Working Tax Credit route before the 2018 amendment, switch to Child Tax Credit-without-WTC plus Working Tax Credit run-on from 2018, and remove tax credit routes from 2026.
- Add unit tests for each tax credit route and the targeted childcare eligibility parameter timeline.

Closes #1065.

## Legal check
- 2014 regulation: Working Tax Credit with annual income not exceeding £16,190.
- 2018 amendment: Child Tax Credit where the parent is not also entitled to Working Tax Credit, plus Working Tax Credit run-on; Universal Credit also enters from this amendment.
- Current 2026 regulation/GOV.UK guidance: tax credit routes are no longer listed.

## Tests
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/dfe/targeted_childcare_entitlement -c policyengine_uk`
- `uv run --python 3.13 ruff check policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_tax_credit_criteria_for_targeted_childcare_entitlement.py policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_child_tax_credit_criteria_for_targeted_childcare_entitlement.py policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_working_tax_credit_criteria_for_targeted_childcare_entitlement.py policyengine_uk/variables/gov/dwp/working_tax_credit_run_on.py`
- `uv run --python 3.13 ruff format --check policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_tax_credit_criteria_for_targeted_childcare_entitlement.py policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_child_tax_credit_criteria_for_targeted_childcare_entitlement.py policyengine_uk/variables/gov/dfe/targeted_childcare_entitlement/meets_working_tax_credit_criteria_for_targeted_childcare_entitlement.py policyengine_uk/variables/gov/dwp/working_tax_credit_run_on.py`