### PR TITLE
Align Tax-Free Childcare UC disqualification

### DIFF
--- a/changelog.d/1056.md
+++ b/changelog.d/1056.md
@@ -1,0 +1,1 @@
+- Updated Tax-Free Childcare Universal Credit disqualification to include awards reduced to nil.

--- a/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/disqualifying_benefits.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/tax_free_childcare/disqualifying_benefits.yaml
@@ -1,8 +1,10 @@
-description: HMRC limits Tax-Free Childcare to benefit units that do not receive any of these programs.
+description: HMRC limits Tax-Free Childcare to benefit units without these tax credit awards or Universal Credit payable amounts.
 metadata:
-  reference: 
-  - title: The Childcare Payments (Eligibility) Regulations 2015 - Part 16 and 18
-    href: https://www.legislation.gov.uk/ukdsi/2015/9780111127063
+  reference:
+  - title: Childcare Payments Act 2014 - Section 11
+    href: https://www.legislation.gov.uk/ukpga/2014/28/section/11
+  - title: Childcare Payments Act 2014 - Section 30
+    href: https://www.legislation.gov.uk/ukpga/2014/28/section/30
   period: year
   unit: program
   label: Tax-free childcare disqualifying benefits
@@ -10,4 +12,4 @@ values:
   2015-01-01:
     - working_tax_credit
     - child_tax_credit
-    - universal_credit
+    - universal_credit_pre_benefit_cap

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_program_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_program_eligible.yaml
@@ -3,7 +3,7 @@
   input:
     working_tax_credit: 0
     child_tax_credit: 0
-    universal_credit: 0
+    universal_credit_pre_benefit_cap: 0
   output:
     tax_free_childcare_program_eligible: True
 
@@ -12,7 +12,7 @@
   input:
     working_tax_credit: 0
     child_tax_credit: 0
-    universal_credit: 0
+    universal_credit_pre_benefit_cap: 0
     tax_free_childcare_meets_uk_connection: false
   output:
     tax_free_childcare_program_eligible: False
@@ -22,7 +22,7 @@
   input:
     working_tax_credit: 1
     child_tax_credit: 0
-    universal_credit: 0
+    universal_credit_pre_benefit_cap: 0
   output:
     tax_free_childcare_program_eligible: False
 
@@ -32,7 +32,7 @@
   input:
     working_tax_credit: 1
     child_tax_credit: 1
-    universal_credit: 0
+    universal_credit_pre_benefit_cap: 0
   output:
     tax_free_childcare_program_eligible: False
 
@@ -42,6 +42,16 @@
   input:
     working_tax_credit: 1
     child_tax_credit: 1
-    universal_credit: 1
+    universal_credit_pre_benefit_cap: 1
+  output:
+    tax_free_childcare_program_eligible: False
+
+- name: Non eligible - Universal Credit payable before reduction to nil
+  period: 2025
+  input:
+    working_tax_credit: 0
+    child_tax_credit: 0
+    universal_credit: 0
+    universal_credit_pre_benefit_cap: 1
   output:
     tax_free_childcare_program_eligible: False

--- a/uv.lock
+++ b/uv.lock
@@ -1383,7 +1383,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.86.9"
+version = "2.86.11"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Change the Tax-Free Childcare UC disqualification proxy from final `universal_credit` to `universal_credit_pre_benefit_cap`, matching the Act's rule that UC counts as payable even when reduced to nil.
- Update the disqualifying-benefits parameter references from the draft SI to current Childcare Payments Act sections.
- Add a regression test for UC payable before a nil final award.

Closes #1056.

## Audit note for #1056
- Universal childcare entitlement has no qualifying-benefit condition to switch.
- Extended childcare uses specified-benefit entitlement/award amounts for the work-condition exemption; #1604 moved UC carer element into that list.
- Tax-Free Childcare is claim/award-based rather than pure eligibility-based; this PR tightens UC to the payable-before-nil-reduction concept in section 11.

## Tests
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare/tax_free_childcare_program_eligible.yaml -c policyengine_uk`
- `uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/tax_free_childcare -c policyengine_uk`