### PR TITLE
Add PIP points-based assessment scaffold (#1069)

### DIFF
--- a/changelog.d/1069.md
+++ b/changelog.d/1069.md
@@ -1,0 +1,1 @@
+- Add `pip_dl_points` and `pip_m_points` person-level inputs and points-threshold parameters under `gov.dwp.pip.{daily_living,mobility}.points_thresholds`, and derive `pip_dl_category` and `pip_m_category` from points when the category is not provided as input.

--- a/policyengine_uk/parameters/gov/dwp/pip/daily_living/points_thresholds/enhanced.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/daily_living/points_thresholds/enhanced.yaml
@@ -1,0 +1,9 @@
+description: A claimant scoring at least this many points across the Schedule 1 Part 2 daily living activities qualifies for the enhanced rate of the PIP daily living component.
+values:
+  2013-04-08: 12
+metadata:
+  unit: integer
+  label: PIP daily living enhanced rate points threshold
+  reference:
+    - title: Social Security (Personal Independence Payment) Regulations 2013, reg. 5(2)(b)
+      href: https://www.legislation.gov.uk/uksi/2013/377/regulation/5

--- a/policyengine_uk/parameters/gov/dwp/pip/daily_living/points_thresholds/standard.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/daily_living/points_thresholds/standard.yaml
@@ -1,0 +1,11 @@
+description: A claimant scoring at least this many points across the Schedule 1 Part 2 daily living activities qualifies for the standard rate of the PIP daily living component.
+values:
+  2013-04-08: 8
+metadata:
+  unit: integer
+  label: PIP daily living standard rate points threshold
+  reference:
+    - title: Social Security (Personal Independence Payment) Regulations 2013, reg. 5(2)(a)
+      href: https://www.legislation.gov.uk/uksi/2013/377/regulation/5
+    - title: PIP assessment guide for assessment providers — Part 2 (Daily Living)
+      href: https://www.gov.uk/government/publications/personal-independence-payment-assessment-guide-for-assessment-providers

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/points_thresholds/enhanced.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/points_thresholds/enhanced.yaml
@@ -1,0 +1,9 @@
+description: A claimant scoring at least this many points across the Schedule 1 Part 3 mobility activities qualifies for the enhanced rate of the PIP mobility component.
+values:
+  2013-04-08: 12
+metadata:
+  unit: integer
+  label: PIP mobility enhanced rate points threshold
+  reference:
+    - title: Social Security (Personal Independence Payment) Regulations 2013, reg. 6(2)(b)
+      href: https://www.legislation.gov.uk/uksi/2013/377/regulation/6

--- a/policyengine_uk/parameters/gov/dwp/pip/mobility/points_thresholds/standard.yaml
+++ b/policyengine_uk/parameters/gov/dwp/pip/mobility/points_thresholds/standard.yaml
@@ -1,0 +1,9 @@
+description: A claimant scoring at least this many points across the Schedule 1 Part 3 mobility activities qualifies for the standard rate of the PIP mobility component.
+values:
+  2013-04-08: 8
+metadata:
+  unit: integer
+  label: PIP mobility standard rate points threshold
+  reference:
+    - title: Social Security (Personal Independence Payment) Regulations 2013, reg. 6(2)(a)
+      href: https://www.legislation.gov.uk/uksi/2013/377/regulation/6

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pip_points.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pip_points.yaml
@@ -1,0 +1,73 @@
+- name: PIP daily living — zero points yields no award
+  period: 2025
+  input:
+    pip_dl_points: 0
+    pip_m_points: 0
+  output:
+    pip_dl_category: NONE
+    pip_m_category: NONE
+    pip_dl: 0
+    pip_m: 0
+
+- name: PIP daily living — 7 points is below the standard threshold
+  period: 2025
+  input:
+    pip_dl_points: 7
+  output:
+    pip_dl_category: NONE
+    pip_dl: 0
+
+- name: PIP daily living — 8 points hits the standard threshold
+  period: 2025
+  absolute_error_margin: 0.05
+  input:
+    pip_dl_points: 8
+  output:
+    pip_dl_category: STANDARD
+    pip_dl: 3842.28
+
+- name: PIP daily living — 11 points stays at standard
+  period: 2025
+  absolute_error_margin: 0.05
+  input:
+    pip_dl_points: 11
+  output:
+    pip_dl_category: STANDARD
+    pip_dl: 3842.28
+
+- name: PIP daily living — 12 points hits the enhanced threshold
+  period: 2025
+  absolute_error_margin: 0.05
+  input:
+    pip_dl_points: 12
+  output:
+    pip_dl_category: ENHANCED
+    pip_dl: 5740.80
+
+- name: PIP mobility — 8 points hits the standard threshold
+  period: 2025
+  absolute_error_margin: 0.05
+  input:
+    pip_m_points: 8
+  output:
+    pip_m_category: STANDARD
+    pip_m: 1517.88
+
+- name: PIP mobility — 12 points hits the enhanced threshold
+  period: 2025
+  absolute_error_margin: 0.05
+  input:
+    pip_m_points: 12
+  output:
+    pip_m_category: ENHANCED
+    pip_m: 4006.08
+
+- name: PIP — input category overrides points-derived category
+  period: 2025
+  absolute_error_margin: 0.05
+  input:
+    pip_dl_points: 0
+    pip_dl_category: ENHANCED
+  output:
+    pip_dl_category: ENHANCED
+    pip_dl: 5740.80

--- a/policyengine_uk/variables/input/pip_dl_category.py
+++ b/policyengine_uk/variables/input/pip_dl_category.py
@@ -4,9 +4,25 @@ from policyengine_uk.variables.gov.dwp.pip.pip import PIPCategory
 
 class pip_dl_category(Variable):
     label = "PIP (daily living) category"
-    documentation = "If you receive the daily living component of the Personal Independence Payment, you will be in one of the following categories: Standard or Enhanced. If not, select None. Survey reported amounts should be converted to this category in the data pipeline."
+    documentation = "If you receive the daily living component of the Personal Independence Payment, you will be in one of the following categories: Standard or Enhanced. If not, select None. Survey reported amounts should be converted to this category in the data pipeline. When not provided as input, the category is derived from `pip_dl_points` against the points thresholds in `gov.dwp.pip.daily_living.points_thresholds`."
     entity = Person
     definition_period = YEAR
     value_type = Enum
     possible_values = PIPCategory
     default_value = PIPCategory.NONE
+
+    def formula(person, period, parameters):
+        points = person("pip_dl_points", period)
+        thresholds = parameters(period).gov.dwp.pip.daily_living.points_thresholds
+        return select(
+            [
+                points >= thresholds.enhanced,
+                points >= thresholds.standard,
+                points < thresholds.standard,
+            ],
+            [
+                PIPCategory.ENHANCED,
+                PIPCategory.STANDARD,
+                PIPCategory.NONE,
+            ],
+        )

--- a/policyengine_uk/variables/input/pip_dl_points.py
+++ b/policyengine_uk/variables/input/pip_dl_points.py
@@ -1,0 +1,10 @@
+from policyengine_uk.model_api import *
+
+
+class pip_dl_points(Variable):
+    label = "PIP daily living points"
+    documentation = "Total descriptor points scored across the ten Schedule 1 Part 2 daily living activities. Used to derive `pip_dl_category` when the category is not provided as input."
+    entity = Person
+    definition_period = YEAR
+    value_type = int
+    default_value = 0

--- a/policyengine_uk/variables/input/pip_m_category.py
+++ b/policyengine_uk/variables/input/pip_m_category.py
@@ -4,9 +4,25 @@ from policyengine_uk.variables.gov.dwp.pip.pip import PIPCategory
 
 class pip_m_category(Variable):
     label = "PIP (mobility) category"
-    documentation = "If you receive the mobility component of the Personal Independence Payment, you will be in one of the following categories: Standard or Enhanced. If not, select None. Survey reported amounts should be converted to this category in the data pipeline."
+    documentation = "If you receive the mobility component of the Personal Independence Payment, you will be in one of the following categories: Standard or Enhanced. If not, select None. Survey reported amounts should be converted to this category in the data pipeline. When not provided as input, the category is derived from `pip_m_points` against the points thresholds in `gov.dwp.pip.mobility.points_thresholds`."
     entity = Person
     definition_period = YEAR
     value_type = Enum
     possible_values = PIPCategory
     default_value = PIPCategory.NONE
+
+    def formula(person, period, parameters):
+        points = person("pip_m_points", period)
+        thresholds = parameters(period).gov.dwp.pip.mobility.points_thresholds
+        return select(
+            [
+                points >= thresholds.enhanced,
+                points >= thresholds.standard,
+                points < thresholds.standard,
+            ],
+            [
+                PIPCategory.ENHANCED,
+                PIPCategory.STANDARD,
+                PIPCategory.NONE,
+            ],
+        )

--- a/policyengine_uk/variables/input/pip_m_points.py
+++ b/policyengine_uk/variables/input/pip_m_points.py
@@ -1,0 +1,10 @@
+from policyengine_uk.model_api import *
+
+
+class pip_m_points(Variable):
+    label = "PIP mobility points"
+    documentation = "Total descriptor points scored across the two Schedule 1 Part 3 mobility activities. Used to derive `pip_m_category` when the category is not provided as input."
+    entity = Person
+    definition_period = YEAR
+    value_type = int
+    default_value = 0


### PR DESCRIPTION
## Summary

First slice of the PIP points-based assessment from Schedule 1, Parts 2 and 3 of the [Social Security (PIP) Regulations 2013](https://www.legislation.gov.uk/uksi/2013/377/regulation/5).

- Adds `gov.dwp.pip.{daily_living,mobility}.points_thresholds.{standard,enhanced}` parameters (8 / 12 points per the regulations).
- Adds person-level integer inputs `pip_dl_points` and `pip_m_points`.
- Adds formulas to the existing `pip_dl_category` and `pip_m_category` enums that derive the category from points. OpenFisca treats inputs as authoritative over formulas, so the existing FRS-supplied categories continue to win and baseline microsim runs are unaffected.

This is intentionally a small, non-breaking foundation. Per-activity descriptor inputs (10 daily living + 2 mobility) and an FRS imputation step that decomposes existing category awards into descriptor scores are left for follow-up PRs — they are heavier and need data review.

Refs #1069.

## Test plan

- [x] `policyengine-core test policyengine_uk/tests/policy/baseline/gov/dwp/pip_points.yaml -c policyengine_uk` — 8 cases pass (zero points → NONE; 7 → NONE; 8 → STANDARD; 11 → STANDARD; 12 → ENHANCED; mobility same; input-category-overrides-points).
- [x] Existing PIP-touching tests still pass (`LHA.yaml`, `uc_non_dep_deduction_exempt.yaml`, `bursary_fund_16_to_19.yaml`).
- [ ] Reviewer: confirm the input-overrides-formula assumption holds for the FRS pipeline (no PIP category derived from `pip_*_points` should leak into baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)