### PR TITLE
Test equivalisation factors and read scale from parameters (#307)

### DIFF
--- a/changelog.d/307.md
+++ b/changelog.d/307.md
@@ -1,0 +1,1 @@
+- Add YAML tests for `household_equivalisation_bhc` and `household_equivalisation_ahc` covering the HBAI modified-OECD scale examples (single adult through couple-with-children), and refactor both formulas to read the scale weights from the existing `household.demographic.equiv.{bhc,ahc}` parameters instead of hard-coded constants.

--- a/policyengine_uk/tests/policy/baseline/household/demographic/equivalisation.yaml
+++ b/policyengine_uk/tests/policy/baseline/household/demographic/equivalisation.yaml
@@ -1,0 +1,121 @@
+- name: Equivalisation factor — single adult (HBAI modified OECD scale, BHC)
+  period: 2025
+  absolute_error_margin: 0.001
+  input:
+    people:
+      adult:
+        age: 40
+    benunits:
+      benunit:
+        members: [adult]
+    households:
+      household:
+        members: [adult]
+  output:
+    household_equivalisation_bhc: 0.67
+    household_equivalisation_ahc: 0.58
+
+- name: Equivalisation factor — couple, no children
+  period: 2025
+  absolute_error_margin: 0.001
+  input:
+    people:
+      adult1:
+        age: 40
+      adult2:
+        age: 40
+    benunits:
+      benunit:
+        members: [adult1, adult2]
+    households:
+      household:
+        members: [adult1, adult2]
+  output:
+    household_equivalisation_bhc: 1.00
+    household_equivalisation_ahc: 1.00
+
+- name: Equivalisation factor — couple with one young child (under 14)
+  period: 2025
+  absolute_error_margin: 0.001
+  input:
+    people:
+      adult1:
+        age: 40
+      adult2:
+        age: 40
+      child:
+        age: 5
+    benunits:
+      benunit:
+        members: [adult1, adult2, child]
+    households:
+      household:
+        members: [adult1, adult2, child]
+  output:
+    household_equivalisation_bhc: 1.20
+    household_equivalisation_ahc: 1.20
+
+- name: Equivalisation factor — couple with one older child (14+)
+  period: 2025
+  absolute_error_margin: 0.001
+  input:
+    people:
+      adult1:
+        age: 40
+      adult2:
+        age: 40
+      child:
+        age: 15
+    benunits:
+      benunit:
+        members: [adult1, adult2, child]
+    households:
+      household:
+        members: [adult1, adult2, child]
+  output:
+    household_equivalisation_bhc: 1.33
+    household_equivalisation_ahc: 1.42
+
+- name: Equivalisation factor — couple with one young and one older child
+  period: 2025
+  absolute_error_margin: 0.001
+  input:
+    people:
+      adult1:
+        age: 40
+      adult2:
+        age: 40
+      young_child:
+        age: 8
+      older_child:
+        age: 16
+    benunits:
+      benunit:
+        members: [adult1, adult2, young_child, older_child]
+    households:
+      household:
+        members: [adult1, adult2, young_child, older_child]
+  output:
+    household_equivalisation_bhc: 1.53
+    household_equivalisation_ahc: 1.62
+
+- name: Equivalisation factor — lone parent with two young children
+  period: 2025
+  absolute_error_margin: 0.001
+  input:
+    people:
+      adult:
+        age: 35
+      child1:
+        age: 6
+      child2:
+        age: 9
+    benunits:
+      benunit:
+        members: [adult, child1, child2]
+    households:
+      household:
+        members: [adult, child1, child2]
+  output:
+    household_equivalisation_bhc: 1.07
+    household_equivalisation_ahc: 0.98

--- a/policyengine_uk/variables/household/demographic/household_equivalisation_ahc.py
+++ b/policyengine_uk/variables/household/demographic/household_equivalisation_ahc.py
@@ -1,5 +1,4 @@
 from policyengine_uk.model_api import *
-from policyengine_uk.variables.household.demographic.geography import Region
 
 
 class household_equivalisation_ahc(Variable):
@@ -9,6 +8,7 @@ class household_equivalisation_ahc(Variable):
     definition_period = YEAR
 
     def formula(household, period, parameters):
+        scale = parameters(period).household.demographic.equiv.ahc
         count_other_adults = max_(
             household.sum(household.members("is_adult", period)) - 1, 0
         )
@@ -19,8 +19,8 @@ class household_equivalisation_ahc(Variable):
             household.members("is_older_child", period)
         )
         return (
-            0.58
-            + 0.42 * count_other_adults
-            + 0.42 * count_older_children
-            + 0.2 * count_young_children
+            scale.first_adult
+            + scale.second_adult * count_other_adults
+            + scale.child_over_14 * count_older_children
+            + scale.child_under_14 * count_young_children
         )

--- a/policyengine_uk/variables/household/demographic/household_equivalisation_bhc.py
+++ b/policyengine_uk/variables/household/demographic/household_equivalisation_bhc.py
@@ -1,5 +1,4 @@
 from policyengine_uk.model_api import *
-from policyengine_uk.variables.household.demographic.geography import Region
 
 
 class household_equivalisation_bhc(Variable):
@@ -9,6 +8,7 @@ class household_equivalisation_bhc(Variable):
     definition_period = YEAR
 
     def formula(household, period, parameters):
+        scale = parameters(period).household.demographic.equiv.bhc
         count_other_adults = max_(
             household.sum(household.members("is_adult", period)) - 1, 0
         )
@@ -19,8 +19,8 @@ class household_equivalisation_bhc(Variable):
             household.members("is_older_child", period)
         )
         return (
-            0.67
-            + 0.33 * count_other_adults
-            + 0.33 * count_older_children
-            + 0.2 * count_young_children
+            scale.first_adult
+            + scale.second_adult * count_other_adults
+            + scale.child_over_14 * count_older_children
+            + scale.child_under_14 * count_young_children
         )


### PR DESCRIPTION
## Summary

Closes #307. Adds YAML coverage for the two equivalisation formulas against the worked examples in the [HBAI quality and methodology report](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/691919/households-below-average-income-quality-methodology-2016-2017.pdf#page=22). Six test cases covering the modified-OECD scale: single adult, couple, couple with one young child (<14), couple with one older child (14+), couple with both, and lone parent with two young children.

While writing the tests I noticed `household_equivalisation_bhc` and `household_equivalisation_ahc` were hard-coding the scale weights (0.67/0.33/0.2 and 0.58/0.42/0.2) even though matching parameter files already exist under `household/demographic/equiv/{bhc,ahc}/{first_adult,second_adult,child_over_14,child_under_14}.yaml`. Wired the formulas to read those parameters — values match exactly so behaviour is unchanged, but the scale is now reform-tunable and the magic numbers are gone.

## Test plan

- [x] `policyengine-core test policyengine_uk/tests/policy/baseline/household/demographic/equivalisation.yaml -c policyengine_uk` — 6 cases pass.
- [x] Full policy suite still passes — `policyengine-core test policyengine_uk/tests/policy -c policyengine_uk` reports **1006 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)