### PR TITLE
Add Rural Fuel Duty Relief Scheme

### DIFF
--- a/changelog.d/676.md
+++ b/changelog.d/676.md
@@ -1,0 +1,1 @@
+Add the Rural Fuel Duty Relief Scheme.

--- a/policyengine_uk/parameters/gov/hmrc/fuel_duty/rural_fuel_duty_relief.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/fuel_duty/rural_fuel_duty_relief.yaml
@@ -1,0 +1,11 @@
+description: Per-litre reduction in fuel duty applied to petrol and diesel purchased in eligible rural areas under the Rural Fuel Duty Relief Scheme.
+values:
+  2012-03-01: 0.05
+metadata:
+  unit: currency-GBP
+  label: Rural Fuel Duty Relief rate
+  reference:
+    - title: Rural fuel duty relief scheme - Notice 2001
+      href: https://www.gov.uk/guidance/rural-duty-relief-scheme-notice-2001
+    - title: Hydrocarbon Oil (Mileage Allowance for Rural Petrol Filling Stations) Regulations 2011 (SI 2011/2935)
+      href: https://www.legislation.gov.uk/uksi/2011/2935/contents/made

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/fuel_duty/rural_fuel_duty_relief.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/fuel_duty/rural_fuel_duty_relief.yaml
@@ -1,0 +1,56 @@
+- name: Household outside the Rural Fuel Duty Relief area pays the full fuel duty rate
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 40
+    benunits:
+      benunit:
+        members: [adult]
+    households:
+      household:
+        members: [adult]
+        petrol_litres: 1_000
+        diesel_litres: 0
+        in_rural_fuel_duty_relief_area: false
+  output:
+    fuel_duty: 529.5
+
+- name: Household inside the Rural Fuel Duty Relief area receives the 5p/L reduction
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 40
+    benunits:
+      benunit:
+        members: [adult]
+    households:
+      household:
+        members: [adult]
+        petrol_litres: 1_000
+        diesel_litres: 0
+        in_rural_fuel_duty_relief_area: true
+  output:
+    fuel_duty: 479.5
+
+- name: Rural relief applies to both petrol and diesel litres
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 40
+    benunits:
+      benunit:
+        members: [adult]
+    households:
+      household:
+        members: [adult]
+        petrol_litres: 600
+        diesel_litres: 400
+        in_rural_fuel_duty_relief_area: true
+  output:
+    fuel_duty: 479.5

--- a/policyengine_uk/variables/gov/hmrc/fuel_duty/fuel_duty.py
+++ b/policyengine_uk/variables/gov/hmrc/fuel_duty/fuel_duty.py
@@ -12,4 +12,8 @@ class fuel_duty(Variable):
         fd = parameters(period).gov.hmrc.fuel_duty
         petrol_litres = household("petrol_litres", period.this_year) / MONTHS_IN_YEAR
         diesel_litres = household("diesel_litres", period.this_year) / MONTHS_IN_YEAR
-        return fd.petrol_and_diesel * (petrol_litres + diesel_litres)
+        in_relief_area = household("in_rural_fuel_duty_relief_area", period.this_year)
+        effective_rate = (
+            fd.petrol_and_diesel - in_relief_area * fd.rural_fuel_duty_relief
+        )
+        return effective_rate * (petrol_litres + diesel_litres)

--- a/policyengine_uk/variables/input/consumption/in_rural_fuel_duty_relief_area.py
+++ b/policyengine_uk/variables/input/consumption/in_rural_fuel_duty_relief_area.py
@@ -1,0 +1,15 @@
+from policyengine_uk.model_api import *
+
+
+class in_rural_fuel_duty_relief_area(Variable):
+    label = "In Rural Fuel Duty Relief scheme area"
+    documentation = (
+        "Whether the household is located in a postcode eligible for the Rural "
+        "Fuel Duty Relief Scheme, which provides a flat per-litre reduction on "
+        "petrol and diesel purchased from registered retailers."
+    )
+    entity = Household
+    definition_period = YEAR
+    value_type = bool
+    default_value = False
+    reference = "https://www.gov.uk/guidance/rural-duty-relief-scheme-notice-2001"


### PR DESCRIPTION
## Summary
- Implements the Rural Fuel Duty Relief Scheme (closes #676).
- Adds a new `in_rural_fuel_duty_relief_area` household-level input (bool, default False) so that households in eligible postcodes — Inner/Outer Hebrides, Northern Isles, Islands in the Clyde, Isles of Scilly, and listed parts of Cumbria, Devon and Northumberland — can be flagged.
- When flagged, `fuel_duty` is computed at `petrol_and_diesel - rural_fuel_duty_relief` (5p/L from 2012-03-01) instead of the headline rate. Applies to both petrol and diesel litres.
- New parameter `gov.hmrc.fuel_duty.rural_fuel_duty_relief` with HMRC Notice 2001 + SI 2011/2935 references.

## Scope notes
- This is the calculator-side change only. The flag defaults to `False` so household microsim aggregates are unchanged unless data assigns the flag (no FRS postcode info available today). Useful immediately for the household calculator and for reforms that toggle eligibility.
- No change to incidence assumptions — only the effective per-litre rate.

## Test plan
- [x] Added 3 YAML cases (`policyengine_uk/tests/policy/baseline/gov/hmrc/fuel_duty/rural_fuel_duty_relief.yaml`):
  - Non-relief household → full rate.
  - In-relief household, petrol only → 5p/L reduction.
  - In-relief household, mixed petrol + diesel → 5p/L reduction on combined litres.
- [x] Full local policy suite: `policyengine-core test policyengine_uk/tests/policy -c policyengine_uk` → 1004 passed.
- [x] `ruff format` + `ruff check` on touched files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)