### PR TITLE
Exclude high-value council tax surcharge under abolish_council_tax (#1670)

### DIFF
--- a/changelog.d/1670.md
+++ b/changelog.d/1670.md
@@ -1,0 +1,1 @@
+- Exclude `high_value_council_tax_surcharge` from `household_tax` and `gov_tax` when `gov.contrib.abolish_council_tax` is in force, since the surcharge is defined on top of council tax bands.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/council_tax/high_value_council_tax_surcharge.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/council_tax/high_value_council_tax_surcharge.yaml
@@ -49,3 +49,17 @@
     high_value_council_tax_surcharge: 0
     household_tax: 0
     gov_tax: 0
+- name: Abolishing council tax also drops the high-value surcharge from aggregates
+  period: 2028
+  input:
+    gov.contrib.abolish_council_tax: true
+    region: LONDON
+    main_residence_value: 2_554_326.811538164
+    main_residential_property_purchased: 0
+    council_tax: 1_500
+    household_owns_tv: false
+    gov.hmrc.stamp_duty.property_sale_rate: 0
+  output:
+    high_value_council_tax_surcharge: 2_500
+    household_tax: 0
+    gov_tax: 0

--- a/policyengine_uk/variables/gov/gov_tax.py
+++ b/policyengine_uk/variables/gov/gov_tax.py
@@ -41,7 +41,9 @@ class gov_tax(Variable):
         abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
         if abolish_council_tax:
             variables = [
-                variable for variable in variables if variable != "council_tax"
+                variable
+                for variable in variables
+                if variable not in ["council_tax", "high_value_council_tax_surcharge"]
             ]
 
         return add(household, period, variables)

--- a/policyengine_uk/variables/gov/hmrc/household_tax.py
+++ b/policyengine_uk/variables/gov/hmrc/household_tax.py
@@ -43,7 +43,11 @@ class household_tax(Variable):
             return add(
                 household,
                 period,
-                [tax for tax in HOUSEHOLD_TAX_VARIABLES if tax not in ["council_tax"]],
+                [
+                    tax
+                    for tax in HOUSEHOLD_TAX_VARIABLES
+                    if tax not in ["council_tax", "high_value_council_tax_surcharge"]
+                ],
             )
         else:
             return add(household, period, HOUSEHOLD_TAX_VARIABLES)


### PR DESCRIPTION
## Summary
- Closes #1670.
- `high_value_council_tax_surcharge` is a top-up on top of council tax bands (England-only, from 2028), so when `gov.contrib.abolish_council_tax` is in force it should disappear together with `council_tax`. Both `household_tax` and `gov_tax` only filtered out `council_tax`, leaving the surcharge in the aggregates.
- Extends both filters to also exclude `high_value_council_tax_surcharge`.
- Adds a YAML test case in the existing high-value surcharge fixture covering the abolish-CT path.

## Test plan
- [x] `python -m pytest policyengine_uk/tests/microsimulation/test_abolish_council_tax_reform.py -v`
- [x] `policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/council_tax/high_value_council_tax_surcharge.yaml -c policyengine_uk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)