### PR TITLE
Document council_tax_less_benefit as a public-facing convenience variable (#1671)

### DIFF
--- a/changelog.d/1671.md
+++ b/changelog.d/1671.md
@@ -1,0 +1,1 @@
+- Document `council_tax_less_benefit` as a public-facing convenience variable used by downstream consumers (`policyengine-app`, `council-tax-ctr-map`, `policyengine-uk-data` calibration targets) rather than the core model itself, so future audits do not flag it as dead code.

--- a/policyengine_uk/variables/household/consumption/council_tax_less_benefit.py
+++ b/policyengine_uk/variables/household/consumption/council_tax_less_benefit.py
@@ -3,7 +3,13 @@ from policyengine_uk.model_api import *
 
 class council_tax_less_benefit(Variable):
     label = "Council Tax (less CTB)"
-    documentation = "Council Tax minus the Council Tax Benefit"
+    documentation = (
+        "Council Tax minus Council Tax Benefit / CTR. Kept as a public "
+        "convenience variable for downstream consumers (e.g. policyengine-app, "
+        "council-tax-ctr-map, policyengine-uk-data calibration targets) that "
+        "need the net council tax bill on a single line; not consumed inside "
+        "the core model itself."
+    )
     entity = Household
     definition_period = YEAR
     value_type = float


### PR DESCRIPTION
## Summary
- Closes #1671.
- Audit confirms the variable is unused inside `policyengine_uk/` itself (sole reference is the definition file), matching the report in #1671.
- However, a GitHub code search across `PolicyEngine/*` shows it is heavily used by sibling repos:
  - `policyengine-app` (`src/data/countries.js`) — surfaces it in country metadata
  - `council-tax-ctr-map` — both the Modal backend and the Next.js frontend depend on it for the CTR explorer
  - `policyengine-uk-data` — calibration targets and tests for council tax loss / OBR targets use it as the per-household net council tax signal
  - `structural-reforms-demo`
- That makes option 1 from the issue (\"Keep as a public-facing convenience variable, document it as such\") the right call.
- Updates the docstring to spell out the public-facing role so future audits don't flag it again.

## Test plan
- [x] No model-level behaviour change; existing council tax tests still pass via the unchanged `council_tax` and `council_tax_benefit` variables it composes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)