### PR TITLE
Suppress warnings in validation notebook (#587)

### DIFF
--- a/changelog.d/587.md
+++ b/changelog.d/587.md
@@ -1,0 +1,1 @@
+- Suppress Python warnings at the top of the validation notebook so re-executions don't surface pandas/plotly deprecation noise in the docs build.

--- a/docs/book/validation/validation.ipynb
+++ b/docs/book/validation/validation.ipynb
@@ -1789,6 +1789,9 @@
     }
    ],
    "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
     "from policyengine_uk import Microsimulation\n",
     "\n",
     "sim = Microsimulation()\n",


### PR DESCRIPTION
## Summary
- Closes #587.
- The 2022 report described an \"Aggregates in full\" section on the openfisca-uk docs that has been rewritten away entirely; the current `docs/book/validation/validation.ipynb` is a single hide-input cell that renders one Plotly figure and ships with clean saved outputs (no stream warnings).
- However, `_config.yml` has `execute_notebooks: off`, so cleanliness today depends entirely on what's checked into the .ipynb. Add an explicit `warnings.filterwarnings(\"ignore\")` at the top of the notebook so a future re-run (e.g. the FutureWarning from `pd.concat([df, pd.DataFrame(...)])` inside the loop) doesn't leak back into the docs.

## Test plan
- [x] Diff is three new source lines at the top of the only code cell; no output cells changed.
- [ ] Local jupyter-book build of `docs/book/validation/validation.ipynb` (the docs build job will exercise this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)