### PR TITLE
Flesh out fuel duty documentation page (#747)

### DIFF
--- a/changelog.d/747.md
+++ b/changelog.d/747.md
@@ -1,0 +1,1 @@
+- Flesh out the fuel duty documentation page with the household-level computation formula, a section on Rural Fuel Duty Relief, and statutory references; fix the chart title typo (`giesel` -> `diesel`).

--- a/docs/book/programs/gov/hmrc/fuel-duty.ipynb
+++ b/docs/book/programs/gov/hmrc/fuel-duty.ipynb
@@ -7,15 +7,28 @@
    "source": [
     "# Fuel duty\n",
     "\n",
-    "Fuel duty is a tax levied on the sale of fuels, mainly petrol and diesel used in vehicles or used for heating. PolicyEngine models fuel duty imposed on the purchases of petrol and diesel for vehicles only.\n",
+    "Fuel duty is a per-litre excise duty on petrol and diesel. PolicyEngine UK models fuel duty on vehicle fuel only (i.e. petrol and diesel for road transport), not fuel used for heating or other purposes.\n",
     "\n",
-    "Fuel duty parameters can be found in `policyengine_uk/parameters/gov/hmrc/fuel_duty` and logic in `policyengine_uk/variables/gov/hmrc/fuel_duty`.\n",
+    "Parameters live in `policyengine_uk/parameters/gov/hmrc/fuel_duty/` and the household-level liability is computed in `policyengine_uk/variables/gov/hmrc/fuel_duty/fuel_duty.py`.\n",
     "\n",
-    "## Fuel Duty Rate\n",
+    "## How PolicyEngine computes fuel duty\n",
     "\n",
-    "Fuel duty is levied per unit of petrol or diesel sold. The UK government usually updates rates in Spring or Autumn Budgets alongside other tax reforms. In March 2022, the UK government announced a 5 pence cut in fuel duty rates for 12 months and the cut was further extended to March 2024. Before this reduction, the rates of fuel duty had been frozen at £0.5795 per litre of petrol and diesel since April 2013. \n",
+    "For each household we compute\n",
     "\n",
-    "The table and graph of historical rates on petrol and diesel for fuel duty since April 2010 show below:"
+    "```\n",
+    "fuel_duty = (petrol_and_diesel_rate - rural_relief * in_relief_area) * (petrol_litres + diesel_litres)\n",
+    "```\n",
+    "\n",
+    "where\n",
+    "\n",
+    "- `petrol_litres` and `diesel_litres` are the household's annual road-fuel volumes (split into monthly values by the variable),\n",
+    "- `petrol_and_diesel_rate` is the headline UK fuel duty rate (£/litre),\n",
+    "- `rural_fuel_duty_relief` is the per-litre discount applied in eligible rural areas, and\n",
+    "- `in_rural_fuel_duty_relief_area` is an input that flags households in eligible postcodes.\n",
+    "\n",
+    "## Headline fuel duty rate\n",
+    "\n",
+    "The UK government usually updates the headline rate at Spring or Autumn budgets. The rate was frozen at £0.5795/litre between April 2011 and March 2022, when a 5p cut was introduced. That cut has since been extended at successive budgets. The table and chart below show the historical headline rate from PolicyEngine's parameter file."
    ]
   },
   {
@@ -1059,7 +1072,7 @@
     "    df,\n",
     "    x=\"Date of change\",\n",
     "    y=\"Fuel duty rate (£/litre)\",\n",
-    "    title=\"Fuel duty rate on petrol and giesel\",\n",
+    "    title=\"Fuel duty rate on petrol and diesel\",\n",
     "    color_discrete_sequence=[\"#2C6496\"],\n",
     ").update_layout(\n",
     "    yaxis_title=\"Fuel duty rate per litre\",\n",
@@ -1071,6 +1084,28 @@
     "    width=800,\n",
     "    template=\"plotly_white\",\n",
     ").update_xaxes(tickangle=45, tickfont={\"size\": 10}).update_traces(line_shape=\"hv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rural Fuel Duty Relief\n",
+    "\n",
+    "The Rural Fuel Duty Relief Scheme grants a 5p/litre discount on retail petrol and diesel sold in eligible remote postcodes (parts of the Highlands, Western Isles, Orkney, Shetland, the Isles of Scilly and a handful of others). PolicyEngine models this through the `in_rural_fuel_duty_relief_area` input flag at the household level; the discount is then subtracted from the headline rate inside the `fuel_duty` formula.\n",
+    "\n",
+    "The relief rate itself is stored in `policyengine_uk/parameters/gov/hmrc/fuel_duty/rural_fuel_duty_relief.yaml` and has been £0.05/litre since the scheme's introduction in March 2012."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- HMRC, [Hydrocarbon Oil Duties Act 1979](https://www.legislation.gov.uk/ukpga/1979/5/contents) - the primary statute establishing fuel duty.\n",
+    "- HMRC, [Rural fuel duty relief scheme - Notice 2001](https://www.gov.uk/guidance/rural-duty-relief-scheme-notice-2001).\n",
+    "- Hydrocarbon Oil (Mileage Allowance for Rural Petrol Filling Stations) [Regulations 2011 (SI 2011/2935)](https://www.legislation.gov.uk/uksi/2011/2935/contents/made)."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Closes #747.
- `docs/book/programs/gov/hmrc/fuel-duty.ipynb` existed as a stub: a one-paragraph intro plus a historical-rate chart. The stub left out how PolicyEngine actually computes household-level fuel duty, never mentioned Rural Fuel Duty Relief, and pointed at no legislation.
- Updates the page to cover:
  - the per-household formula `(petrol_and_diesel_rate - rural_relief * in_relief_area) * (petrol_litres + diesel_litres)`, with pointers to the variable and parameter files,
  - a section on Rural Fuel Duty Relief and the `in_rural_fuel_duty_relief_area` input flag added in #676,
  - statutory/HMRC references (Hydrocarbon Oil Duties Act 1979, Notice 2001, SI 2011/2935).
- Also fixes the chart title typo \"giesel\" -> \"diesel\".

## Test plan
- [x] Notebook still valid JSON, opens in Jupyter; saved outputs unchanged.
- [ ] Docs build job renders the new sections cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)