### PR TITLE
Date Marriage Allowance take-up from policy introduction (#623)

### DIFF
--- a/changelog.d/623-takeup-start-date.md
+++ b/changelog.d/623-takeup-start-date.md
@@ -1,0 +1,1 @@
+- Date the Marriage Allowance take-up rate parameter from 2015-04-06 (when the allowance came into force) rather than 2000-01-01, document that 0.5 is the post-2019 steady-state value, and link the HMRC Marriage Allowance statistics page.

--- a/policyengine_uk/parameters/gov/hmrc/income_tax/allowances/marriage_allowance/takeup_rate.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/allowances/marriage_allowance/takeup_rate.yaml
@@ -1,11 +1,13 @@
-description: Share of eligible couples who claim Marriage Allowance. HMRC outturn shows ~2.1m claimants vs ~4.2m eligible couples (~50% take-up). The matching parameter in policyengine-uk-data (`parameters/take_up/marriage_allowance.yaml`) is the load-bearing one for microsimulation, applied stochastically when populating `would_claim_marriage_allowance` per person; this file should be kept in sync.
+description: Share of eligible couples who claim Marriage Allowance. HMRC outturn shows ~2.1m claimants vs ~4.2m eligible couples (~50% take-up) at steady state; take-up was materially lower in the first few years after the allowance was introduced in April 2015 (HMRC outturn costs ran consistently below original forecast for this reason). 0.5 is therefore the post-2019 steady-state rate. The matching parameter in policyengine-uk-data (`parameters/take_up/marriage_allowance.yaml`) is the load-bearing one for microsimulation, applied stochastically when populating `would_claim_marriage_allowance` per person; this file should be kept in sync.
 values:
-  2000-01-01: 0.5
+  2015-04-06: 0.5
 metadata:
   unit: /1
   label: Marriage Allowance take-up rate
   reference:
-    - title: Income Tax Act 2007 s. 55B
+    - title: Income Tax Act 2007 s. 55B (inserted by Finance Act 2014 Sch. 2)
       href: https://www.legislation.gov.uk/ukpga/2007/3/section/55B
     - title: House of Commons Library — Income tax allowances for married couples (SN00870)
       href: https://commonslibrary.parliament.uk/research-briefings/sn00870/
+    - title: HMRC — Marriage Allowance statistics
+      href: https://www.gov.uk/government/statistics/marriage-allowance-statistics


### PR DESCRIPTION
## Summary
- Follow-up to #623 / #1636: the take-up rate parameter still started at 2000-01-01, fifteen years before the allowance existed.
- Marriage Allowance was inserted into ITA 2007 as s.55B by Finance Act 2014 Sch. 2 and came into force on 6 April 2015. Move the parameter's first instant to that date.
- Refine the description to spell out that 0.5 is the post-2019 steady-state value (HoC Library SN00870 notes HMRC outturn costs ran consistently below original forecast because take-up ramped up slowly over the first few years).
- Add the HMRC Marriage Allowance statistics page as a third reference so future updates can pull fresh outturn numbers.

## Test plan
- [x] `policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/income_tax/allowances/marriage_allowance.yaml -c policyengine_uk` (4 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)