### PR TITLE
Add legislative references to PAWHP parameters (#1458)

### DIFF
--- a/changelog.d/1458-pawhp-refs.md
+++ b/changelog.d/1458-pawhp-refs.md
@@ -1,0 +1,1 @@
+- Add legislative references and tidy labels for the Pension Age Winter Heating Payment (Scotland) parameter suite (amounts and eligibility), citing The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250) and the June 2025 Scottish Government announcement reinstating a universal element.

--- a/policyengine_uk/parameters/gov/social_security_scotland/pawhp/amount/base.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/pawhp/amount/base.yaml
@@ -1,8 +1,15 @@
-description: Amount paid to non-benefit-claiming pensioners for the PAWHP.
+description: Pension Age Winter Heating Payment universal base award paid to Scottish State-Pension-age households that do not qualify for a means-tested PAWHP. £0 in winter 2024-25 (PAWHP was means-tested only); £100 from winter 2025-26 following the Scottish Government's reinstatement of a universal element.
 values:
   2024-01-01: 0
   2025-01-01: 100
 metadata:
   unit: currency-GBP
-  label: Pawhp base payment
+  label: PAWHP universal base amount
   uprating: gov.economic_assumptions.indices.obr.consumer_price_index
+  reference:
+    - title: The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250)
+      href: https://www.legislation.gov.uk/ssi/2024/250/contents/made
+    - title: Scottish Government — Pension Age Winter Heating Payment to be paid to all pensioners (June 2025)
+      href: https://www.gov.scot/news/winter-fuel-payment-to-be-paid-to-all-pensioners/
+    - title: Social Security Scotland — Pension Age Winter Heating Payment
+      href: https://www.mygov.scot/pension-age-winter-heating-payment

--- a/policyengine_uk/parameters/gov/social_security_scotland/pawhp/amount/higher.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/pawhp/amount/higher.yaml
@@ -1,6 +1,12 @@
+description: Pension Age Winter Heating Payment higher (80-and-over) award paid to Scottish households containing someone aged 80 or over who receives a qualifying benefit.
 values:
   2024-01-01: 300
 metadata:
   unit: currency-GBP
-  label: Pawhp lower amount
+  label: PAWHP higher (80+) amount
   uprating: gov.economic_assumptions.indices.obr.consumer_price_index
+  reference:
+    - title: The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250)
+      href: https://www.legislation.gov.uk/ssi/2024/250/contents/made
+    - title: Social Security Scotland — Pension Age Winter Heating Payment
+      href: https://www.mygov.scot/pension-age-winter-heating-payment

--- a/policyengine_uk/parameters/gov/social_security_scotland/pawhp/amount/lower.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/pawhp/amount/lower.yaml
@@ -1,6 +1,12 @@
+description: Pension Age Winter Heating Payment lower (under-80) award paid to Scottish households containing someone of State Pension age who receives a qualifying benefit.
 values:
   2024-01-01: 200
 metadata:
   unit: currency-GBP
-  label: Pawhp lower amount
+  label: PAWHP lower (under-80) amount
   uprating: gov.economic_assumptions.indices.obr.consumer_price_index
+  reference:
+    - title: The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250)
+      href: https://www.legislation.gov.uk/ssi/2024/250/contents/made
+    - title: Social Security Scotland — Pension Age Winter Heating Payment
+      href: https://www.mygov.scot/pension-age-winter-heating-payment

--- a/policyengine_uk/parameters/gov/social_security_scotland/pawhp/eligibility/higher_age_requirement.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/pawhp/eligibility/higher_age_requirement.yaml
@@ -1,6 +1,9 @@
-description: Age requirement to qualify for the higher PAWHP.
+description: Age at which a qualifying household becomes entitled to the higher PAWHP award.
 values:
   2000-01-01: 80
 metadata:
   unit: year
-  label: Winter Fuel Payment higher amount age requirement
+  label: PAWHP higher amount age requirement
+  reference:
+    - title: The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250), reg. 5
+      href: https://www.legislation.gov.uk/ssi/2024/250/regulation/5/made

--- a/policyengine_uk/parameters/gov/social_security_scotland/pawhp/eligibility/require_benefits.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/pawhp/eligibility/require_benefits.yaml
@@ -1,8 +1,16 @@
-description: Whether receipt of means-tested benefits is required to qualify for the Winter Fuel Payment.
+description: Whether receipt of a qualifying means-tested benefit is required for PAWHP entitlement.
 values:
   2000-01-01: false
-  2024-01-01: 
+  2024-01-01:
     value: true
+    reference:
+      - title: The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250), reg. 4
+        href: https://www.legislation.gov.uk/ssi/2024/250/regulation/4/made
 metadata:
   unit: bool
-  label: Pawhp means-tested benefits requirement
+  label: PAWHP means-tested benefits requirement
+  reference:
+    - title: The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250)
+      href: https://www.legislation.gov.uk/ssi/2024/250/contents/made
+    - title: Scottish Government — Pension Age Winter Heating Payment to be paid to all pensioners (June 2025)
+      href: https://www.gov.scot/news/winter-fuel-payment-to-be-paid-to-all-pensioners/

--- a/policyengine_uk/parameters/gov/social_security_scotland/pawhp/eligibility/state_pension_age_requirement.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/pawhp/eligibility/state_pension_age_requirement.yaml
@@ -1,6 +1,9 @@
-description: Whether individuals must be State Pension Age to qualify for the PAWHP.
+description: Whether individuals must be of State Pension Age to qualify for the PAWHP.
 values:
   2000-01-01: true
 metadata:
   unit: bool
-  label: Pawhp State Pension age requirement
+  label: PAWHP State Pension age requirement
+  reference:
+    - title: The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250), reg. 3
+      href: https://www.legislation.gov.uk/ssi/2024/250/regulation/3/made


### PR DESCRIPTION
## Summary
- Down-payment on #1458 (\"Add legislative references to every policy parameter\"), focused on the Pension Age Winter Heating Payment (Scotland) suite — none of the six YAML files carried a statutory reference and two of the labels (\"Pawhp lower amount\") were copy-paste leftovers from Winter Fuel Payment.
- Cites **The Pension Age Winter Heating Payment (Scotland) Regulations 2024 (SSI 2024/250)** and, where relevant, the June 2025 Scottish Government announcement reinstating a universal £100 base element for winter 2025-26.
- All six files updated:
  - `pawhp/amount/{lower,higher,base}.yaml` — proper descriptions, distinct labels, statutory reference plus a `mygov.scot` user-facing reference.
  - `pawhp/eligibility/{state_pension_age_requirement,higher_age_requirement,require_benefits}.yaml` — pinpoint references to the relevant regulation within SSI 2024/250.

No numeric values change; this is metadata only.

## Test plan
- [x] `yaml.safe_load` succeeds on all six files and `metadata.reference` is present.
- [x] `Microsimulation()` still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)