### PR TITLE
Split childcare_entitlements umbrella into per-programme registry rows (#1644)

### DIFF
--- a/changelog.d/1644-childcare-registry.md
+++ b/changelog.d/1644-childcare-registry.md
@@ -1,0 +1,1 @@
+- Split the `childcare_entitlements` umbrella entry in `programs.yaml` into three rows (universal/extended/targeted) each bound to its variable and parameter prefix, removing an orphan registry row flagged in the childcare-coverage audit.

--- a/policyengine_uk/programs.yaml
+++ b/policyengine_uk/programs.yaml
@@ -336,17 +336,44 @@ programs:
     verified_start_year: 2022
 
   # --- DfE programs ---
-  - id: childcare_entitlements
-    name: Childcare entitlements
-    full_name: Free Childcare Entitlements
+  - id: universal_childcare_entitlement
+    name: Universal childcare entitlement (15h)
+    full_name: Universal Free Childcare Entitlement (3- and 4-year-olds, England)
     category: Education
     agency: DfE
     status: complete
     coverage: England
-    parameter_prefix: gov.dfe
+    variable: universal_childcare_entitlement
+    parameter_prefix: gov.dfe.universal_childcare_entitlement
     verified_start_year: 2023
     verified_end_year: 2025
-    notes: Universal (15h), extended (30h), and targeted entitlements; parameters need expansion for later years
+    notes: 570 hours/year (15h/week over 38 weeks term-time) for all 3- and 4-year-olds; parameters may need expansion for later years.
+
+  - id: extended_childcare_entitlement
+    name: Extended childcare entitlement (30h)
+    full_name: Extended Free Childcare Entitlement (working parents, England)
+    category: Education
+    agency: DfE
+    status: complete
+    coverage: England
+    variable: extended_childcare_entitlement
+    parameter_prefix: gov.dfe.extended_childcare_entitlement
+    verified_start_year: 2023
+    verified_end_year: 2025
+    notes: Additional 570 hours/year on top of the universal entitlement for working parents meeting the earnings test.
+
+  - id: targeted_childcare_entitlement
+    name: Targeted childcare entitlement
+    full_name: Targeted Free Childcare Entitlement (disadvantaged 2-year-olds and working families, England)
+    category: Education
+    agency: DfE
+    status: complete
+    coverage: England
+    variable: targeted_childcare_entitlement
+    parameter_prefix: gov.dfe.targeted_childcare_entitlement
+    verified_start_year: 2023
+    verified_end_year: 2025
+    notes: Free hours for disadvantaged 2-year-olds and, since April 2024, working families with younger children.
 
   - id: childcare_grant
     name: Childcare Grant


### PR DESCRIPTION
## Summary
- Addresses structural finding #1 from the childcare-coverage audit (#1644): the `childcare_entitlements` entry in `programs.yaml` lacked both `variable` and `parameter_prefix`, leaving it orphan on the model-coverage page.
- The repo actually exposes three separate entitlement variables and parameter trees: `universal_childcare_entitlement` (15h), `extended_childcare_entitlement` (30h working parents), and `targeted_childcare_entitlement` (disadvantaged 2yo + working families).
- Split the umbrella row into those three, each properly bound to its variable and `gov.dfe.<name>` prefix. Notes preserved/refined from the original entry.

The remaining items in #1644 (UK-wide coverage gaps, Scotland/Wales/NI programmes, regionalising `weeks_per_year` and `childcare_funding_rate`) stay open and will be handled in separate PRs.

## Test plan
- [x] `yaml.safe_load(programs.yaml)` succeeds; `childcare_entitlements` is gone and the three new ids are present.
- [x] Each new row has both `variable` and `parameter_prefix` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)