### PR TITLE
Populate 2023-24 Cost-of-Living Payment amounts (#609)

### DIFF
--- a/changelog.d/609.md
+++ b/changelog.d/609.md
@@ -1,0 +1,1 @@
+- Add the 2023-24 Cost-of-Living Payments to the `cost_of_living_support_payment` parameters — £900 means-tested (paid in three instalments), £300 pensioner, £150 disability — announced at Autumn Statement 2022 and previously left at zero; values reset to 0 from 2024-01-01.

--- a/policyengine_uk/parameters/gov/treasury/cost_of_living_support/disabled/amount.yaml
+++ b/policyengine_uk/parameters/gov/treasury/cost_of_living_support/disabled/amount.yaml
@@ -1,11 +1,14 @@
-description: Payment to households receiving disability benefits.
+description: One-off Disability Cost-of-Living Payment to households containing someone on a qualifying disability benefit. £150 in both 2022-23 and 2023-24, withdrawn from 2024-25.
 values:
   2022-01-01: 150
-  2023-01-01: 0
+  2023-01-01: 150
+  2024-01-01: 0
 metadata:
   unit: currency-GBP
   period: year
-  label: Payment to households on disability benefits
+  label: Disability Cost-of-Living Payment
   reference:
-    - title: Cost-of-living support announcement | GOV.UK
+    - title: 2022-23 Cost-of-Living Support package announcement (HMT/DWP, May 2022)
       href: https://www.gov.uk/government/news/millions-of-most-vulnerable-households-will-receive-1200-of-help-with-cost-of-living
+    - title: Disability Cost-of-Living Payment 2023-24 (DWP guidance)
+      href: https://www.gov.uk/guidance/cost-of-living-payment-disability

--- a/policyengine_uk/parameters/gov/treasury/cost_of_living_support/means_tested_households/amount.yaml
+++ b/policyengine_uk/parameters/gov/treasury/cost_of_living_support/means_tested_households/amount.yaml
@@ -1,11 +1,14 @@
-description: Payment to households on means-tested benefits.
+description: One-off Cost-of-Living Payment to households on qualifying means-tested benefits. £650 across 2022-23 (Spring £326 + Autumn £324) and £900 across 2023-24 (Spring £301 + Autumn £300 + Spring 2024 £299).
 values:
   2022-01-01: 650
-  2023-01-01: 0
+  2023-01-01: 900
+  2024-01-01: 0
 metadata:
   unit: currency-GBP
   period: year
-  label: Payment to households on means-tested benefits
+  label: Cost-of-Living Payment (means-tested)
   reference:
-    - title: Cost-of-living support announcement | GOV.UK
+    - title: 2022-23 Cost-of-Living Support package announcement (HMT/DWP, May 2022)
       href: https://www.gov.uk/government/news/millions-of-most-vulnerable-households-will-receive-1200-of-help-with-cost-of-living
+    - title: 2023-24 Cost-of-Living Payments (Autumn Statement 2022, DWP guidance)
+      href: https://www.gov.uk/guidance/cost-of-living-payments-2023-to-2024

--- a/policyengine_uk/parameters/gov/treasury/cost_of_living_support/pensioners/amount.yaml
+++ b/policyengine_uk/parameters/gov/treasury/cost_of_living_support/pensioners/amount.yaml
@@ -1,11 +1,14 @@
-description: Payment to pensioner households receiving benefits.
+description: One-off Pensioner Cost-of-Living Payment paid as a top-up to the Winter Fuel Payment to households containing someone of State Pension age. £300 in both winter 2022-23 and winter 2023-24, withdrawn from winter 2024-25.
 values:
   2022-01-01: 300
-  2023-01-01: 0
+  2023-01-01: 300
+  2024-01-01: 0
 metadata:
   unit: currency-GBP
   period: year
-  label: Payment to pensioner households
+  label: Pensioner Cost-of-Living Payment
   reference:
-    - title: Cost-of-living support announcement | GOV.UK
+    - title: 2022-23 Cost-of-Living Support package announcement (HMT/DWP, May 2022)
       href: https://www.gov.uk/government/news/millions-of-most-vulnerable-households-will-receive-1200-of-help-with-cost-of-living
+    - title: Pensioner Cost-of-Living Payment 2023-24 (DWP guidance)
+      href: https://www.gov.uk/guidance/cost-of-living-payment-pensioner

--- a/policyengine_uk/tests/policy/baseline/gov/treasury/cost_of_living_support/cost_of_living_support_payment.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/treasury/cost_of_living_support/cost_of_living_support_payment.yaml
@@ -1,0 +1,63 @@
+- name: 2022 Cost-of-Living Payments — means-tested only
+  period: 2022
+  input:
+    people:
+      person:
+        universal_credit_reported: 100
+    benunits:
+      benunit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+  output:
+    cost_of_living_support_payment: 650
+
+- name: 2023 Cost-of-Living Payments — means-tested £900 (Autumn Statement 2022)
+  period: 2023
+  input:
+    people:
+      person:
+        universal_credit_reported: 100
+    benunits:
+      benunit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+  output:
+    cost_of_living_support_payment: 900
+
+- name: 2023 Cost-of-Living Payments — pensioner £300 stacks with means-tested
+  period: 2023
+  input:
+    people:
+      person:
+        age: 70
+        universal_credit_reported: 100
+    benunits:
+      benunit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        country: ENGLAND
+  output:
+    # £900 means-tested + £300 pensioner (triggered via Winter Fuel Allowance
+    # which paid universally in 2023 before the 2024 means test).
+    cost_of_living_support_payment: 1200
+
+- name: 2024 Cost-of-Living Payments withdrawn
+  period: 2024
+  input:
+    people:
+      person:
+        universal_credit_reported: 100
+    benunits:
+      benunit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+  output:
+    cost_of_living_support_payment: 0


### PR DESCRIPTION
## Summary
- Closes #609.
- The `gov.treasury.cost_of_living_support` parameters were populated for the 2022-23 CoL package only and reset to £0 at 2023-01-01. Autumn Statement 2022 actually announced a second package across 2023-24:
  - **Means-tested CoL Payment**: £900 (paid in three instalments — Spring 2023 £301, Autumn 2023 £300, Spring 2024 £299).
  - **Pensioner CoL Payment**: £300 (top-up to Winter Fuel Payment, paid winter 2023-24).
  - **Disability CoL Payment**: £150 (paid Summer 2023).
- Set the 2023-01-01 values to those announced amounts and add an explicit 2024-01-01 reset to 0 so the one-off doesn't extrapolate forward.
- Add YAML test coverage for 2022, 2023 (means-only and stacked with the pensioner top-up), and the 2024 withdrawal.

## Test plan
- [x] `policyengine-core test policyengine_uk/tests/policy/baseline/gov/treasury/cost_of_living_support/cost_of_living_support_payment.yaml -c policyengine_uk` (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)