### PR TITLE
Add CoL Payments + Energy Bills Rebate docs page (#771)

### DIFF
--- a/changelog.d/771-cost-of-living-docs.md
+++ b/changelog.d/771-cost-of-living-docs.md
@@ -1,0 +1,1 @@
+- Add a documentation page covering the Cost-of-Living Payments (2022-23 and 2023-24) and the 2022 Energy Bills Rebate; ticks off two more entries in the #771 docs-pages todo list.

--- a/docs/book/programs/gov/treasury/cost-of-living-payments.md
+++ b/docs/book/programs/gov/treasury/cost-of-living-payments.md
@@ -1,0 +1,65 @@
+# Cost-of-Living Payments and Energy Bills Rebate
+
+In response to the 2021-23 cost-of-living crisis the UK government
+announced two distinct one-off support packages. Both are modelled in
+PolicyEngine UK under `gov.treasury.*` and feed into household net
+income via [`gov_spending`](https://github.com/PolicyEngine/policyengine-uk/blob/main/policyengine_uk/variables/gov/gov_spending.py)
+and the HBAI benefit aggregates.
+
+## Energy Bills Rebate (winter 2022)
+
+Announced by the Chancellor in February 2022 to help households with the
+spike in domestic energy prices. Two strands:
+
+- **£150 Council Tax Rebate** for households in Council Tax bands A–D in
+  England, paid in April 2022. Equivalent payments were made by the
+  devolved administrations.
+- **£200 Energy Bills Credit** delivered via energy suppliers to all
+  domestic electricity customers from October 2022. Originally announced
+  as a repayable loan, the repayment requirement was scrapped at the May
+  2022 emergency support package.
+
+PolicyEngine models these via:
+
+- `energy_bills_rebate` (Household, YEAR) = `ebr_council_tax_rebate` +
+  `ebr_energy_bills_credit`
+- Parameters at `parameters/gov/treasury/energy_bills_rebate/`:
+  - `energy_bills_credit.yaml` — the £200 flat household amount
+  - `council_tax_rebate/bands.yaml` — qualifying CT bands (A–D)
+  - `council_tax_rebate/amount.yaml` — the £150 rebate amount
+
+## Cost-of-Living Payments (2022-23 and 2023-24)
+
+Two successive packages, both modelled through the variable
+`cost_of_living_support_payment` at `gov/treasury/cost_of_living_support/`.
+The variable returns the **sum** of three independent strands depending
+on which qualifying benefits the household receives:
+
+| Strand | 2022-23 | 2023-24 | Qualifying benefits |
+|--------|---------|---------|---------------------|
+| Means-tested CoL Payment | £650 (two instalments) | £900 (three instalments) | Universal Credit, Pension Credit, Housing Benefit, income-based JSA / ESA, Income Support |
+| Pensioner CoL Payment    | £300 | £300 | Winter Fuel Payment recipients |
+| Disability CoL Payment   | £150 | £150 | DLA, PIP, Attendance Allowance, AFCS, IIDB, SDA, child / war disability pension |
+
+From 2024-01-01 the parameter values are explicitly reset to zero so the
+one-off doesn't extrapolate forward.
+
+### How PolicyEngine computes the payment
+
+For each strand `s ∈ {means_tested_households, pensioners, disabled}`:
+
+```
+on_s = (sum of household's reported amounts in s.qualifying_benefits) > 0
+strand_s = s.amount(period) * on_s
+```
+
+Total `cost_of_living_support_payment = means_test_bonus + pensioner_bonus + disabled_bonus`,
+i.e. the strands stack — a pensioner on Pension Credit who also receives PIP
+will collect all three payments. This matches the actual policy.
+
+## References
+
+- [HMT/DWP, May 2022 cost-of-living support package announcement](https://www.gov.uk/government/news/millions-of-most-vulnerable-households-will-receive-1200-of-help-with-cost-of-living)
+- DWP, [Cost-of-Living Payments 2023-24 guidance](https://www.gov.uk/guidance/cost-of-living-payments-2023-to-2024) (means-tested, pensioner and disability strands).
+- HMT, [Energy Bills Support Scheme](https://www.gov.uk/government/publications/the-energy-bills-support-scheme-explainer) and [Council Tax Energy Rebate](https://www.gov.uk/government/publications/the-council-tax-rebate-2022-23-billing-authority-guidance).
+- House of Commons Library briefing [CBP-9501 — Cost of Living Payments and the energy crisis](https://commonslibrary.parliament.uk/research-briefings/cbp-9501/).


### PR DESCRIPTION
## Summary
- Ticks off two more entries in #771's docs-pages todo list (CoL payments + Energy bills rebate) with a single combined page, since both are short-lived treasury transfers with very similar mechanics.
- New page at `docs/book/programs/gov/treasury/cost-of-living-payments.md` covering:
  - Energy Bills Rebate: the £150 Council Tax Rebate (bands A-D) and the £200 energy bills credit (de-loaned in May 2022), with parameter pointers under `gov.treasury.energy_bills_rebate`.
  - Cost-of-Living Payments: both the 2022-23 and 2023-24 packages — means-tested £650 / £900, pensioner £300, disability £150 — including the stacking behaviour the `cost_of_living_support_payment` formula implements and the 2024-01-01 reset.
- Links HMT/DWP announcements, the cost-of-living-payments-2023-to-2024 guidance, and CBP-9501.

Pure documentation; no parameter or variable changes.

## Test plan
- [x] Markdown lints cleanly; no broken table rows or fenced blocks.
- [ ] Docs build job picks up the new page under `programs/gov/treasury/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)