### PR TITLE
Clarify current_education enrolment vs attainment (#368)

### DIFF
--- a/changelog.d/368.md
+++ b/changelog.d/368.md
@@ -1,0 +1,1 @@
+- Clarify the `current_education` label as "Current education enrolment" and add a docstring distinguishing it from `highest_education` (which captures attainment), so the variable's enrolment-vs-attainment semantics are explicit without an API-breaking rename.

--- a/policyengine_uk/variables/household/demographic/current_education.py
+++ b/policyengine_uk/variables/household/demographic/current_education.py
@@ -10,7 +10,12 @@ class current_education(Variable):
     possible_values = EducationType
     default_value = EducationType.NOT_IN_EDUCATION
     entity = Person
-    label = "Current education"
+    label = "Current education enrolment"
+    documentation = (
+        "Which stage of education the person is currently enrolled in (or "
+        "NOT_IN_EDUCATION if none). This is enrolment status, not attainment "
+        "— see `highest_education` for the highest completed stage."
+    )
     definition_period = YEAR
 
     def formula(person, period, parameters):


### PR DESCRIPTION
## Summary
- #368 suggested renaming `current_education` to `current_education_enrolment` to distinguish enrolment from attainment.
- A full rename would break every dataset row, test YAML, API consumer (`policyengine-app`, `policyengine-household-api`), and external user that currently passes `current_education` as input. That's too disruptive for an issue whose actual ask is **\"make the enrolment-vs-attainment distinction explicit.\"**
- Do the cheaper thing: improve the `label` to `\"Current education enrolment\"` and add a `documentation` string that says it's enrolment status (not attainment) and points at `highest_education` for the latter.
- The variable name stays the same, so no downstream breakage. The new label/documentation is what users see in the API metadata and the docs.

## Test plan
- [x] `Microsimulation()` builds and `system.variables[\"current_education\"].label` returns the new label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)