### PR TITLE
Fix ruff formatting in validation notebook

### DIFF
--- a/changelog.d/587-format.md
+++ b/changelog.d/587-format.md
@@ -1,0 +1,1 @@
+- Apply ruff formatting to the validation notebook (blank line after the warnings import) so the repo-wide `ruff format --check` lint passes on main.

--- a/docs/book/validation/validation.ipynb
+++ b/docs/book/validation/validation.ipynb
@@ -1790,6 +1790,7 @@
    ],
    "source": [
     "import warnings\n",
+    "\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "from policyengine_uk import Microsimulation\n",


### PR DESCRIPTION
## Summary
- #1696 inserted `import warnings` / `warnings.filterwarnings("ignore")` at the top of the validation notebook's code cell, but the lines weren't ruff-formatted (ruff wants a blank line after the import).
- #1696 was docs-only, so its merge skipped the path-filtered "Code changes" (Lint+Test) workflow — the violation only surfaced when #1698 (a parameter change) triggered a repo-wide `ruff format --check`, turning the Lint job red on main.
- This applies `ruff format` to the notebook to restore a green main.

## Test plan
- [x] `ruff format --check docs/book/validation/validation.ipynb` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)