### PR TITLE
Round tapered personal allowance up to nearest pound

### DIFF
--- a/changelog.d/1738.md
+++ b/changelog.d/1738.md
@@ -1,0 +1,1 @@
+- Rounded tapered Personal Allowance amounts up to the nearest pound.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/income_tax/allowances/personal_allowance.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/income_tax/allowances/personal_allowance.yaml
@@ -159,3 +159,11 @@
     # ANI for taper = £110k - £12.5k = £97.5k (below £100k)
     # Full PA restored
     personal_allowance: 12570
+
+- name: PA taper rounds fractional allowance up to nearest pound
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    employment_income: 100001
+  output:
+    personal_allowance: 12570

--- a/policyengine_uk/variables/gov/hmrc/income_tax/allowances/personal_allowance.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/allowances/personal_allowance.py
@@ -1,4 +1,5 @@
 from policyengine_uk.model_api import *
+from numpy import ceil
 
 
 class personal_allowance(Variable):
@@ -23,4 +24,4 @@ class personal_allowance(Variable):
         ANI_for_taper = ANI - gift_aid_grossed_up
         excess = max_(0, ANI_for_taper - PA.maximum_ANI)
         reduction = excess * PA.reduction_rate
-        return max_(0, personal_allowance - reduction)
+        return ceil(max_(0, personal_allowance - reduction))


### PR DESCRIPTION
## Summary
- round tapered Personal Allowance amounts up to the nearest pound
- add a zero-margin 2026 regression case for a fractional taper amount
- add the changelog entry for #1738

## Notes
The formula stays vectorized: it applies `numpy.ceil` to the array returned by `max_(0, personal_allowance - reduction)` rather than using scalar control flow.

Fixes #1738.

## Tests
- `uv run ruff check policyengine_uk/variables/gov/hmrc/income_tax/allowances/personal_allowance.py`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/income_tax/allowances/personal_allowance.yaml -c policyengine_uk`
- `git diff --check`
