### PR TITLE
Default property_purchased to False to stop phantom stamp duty

### DIFF
--- a/changelog.d/fix-property-purchased-default-false.fixed.md
+++ b/changelog.d/fix-property-purchased-default-false.fixed.md
@@ -1,0 +1,1 @@
+Fix property_purchased default from True to False so households are not charged stamp duty on their entire property wealth unless they explicitly purchased this year. The True default charged every household in population datasets full SDLT/LBTT/LTT on its home value, inflating the first income decile's effective tax rate to 251% and breaking the data pipeline.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/stamp_duty/property_purchased_default.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/stamp_duty/property_purchased_default.yaml
@@ -1,0 +1,8 @@
+- name: Household with a home but no purchase pays no stamp duty (property_purchased defaults False)
+  period: 2026
+  input:
+    main_residence_value: 400_000
+  output:
+    property_purchased: false
+    main_residential_property_purchased: 0
+    stamp_duty_land_tax: 0

--- a/policyengine_uk/variables/input/consumption/property/property_purchased.py
+++ b/policyengine_uk/variables/input/consumption/property/property_purchased.py
@@ -7,4 +7,12 @@ class property_purchased(Variable):
     entity = Household
     definition_period = YEAR
     value_type = bool
-    default_value = True
+    # Fail-safe default: a household has NOT bought all its property this year.
+    # main_residential_property_purchased is computed as
+    # main_residence_value * property_purchased, so a True default charges
+    # every household stamp duty on its full property wealth (~£370bn of
+    # phantom SDLT). Population datasets set this explicitly for the small
+    # share of genuine purchasers; the household calculator and tests set
+    # main_residential_property_purchased directly. False is the correct
+    # neutral default for any household where it is not set.
+    default_value = False


### PR DESCRIPTION
## Problem

`property_purchased` had `default_value = True` (introduced incidentally in the 2025 one-variable-per-file refactor, #1139). Because `main_residential_property_purchased = main_residence_value * property_purchased`, a `True` default charges **every household in a population dataset** full SDLT/LBTT/LTT on its entire home value — ~£370bn of phantom stamp duty, ~26× real receipts.

This inflated the **first income decile's effective tax rate to 251%** and has broken the `policyengine-uk-data` build (`test_first_decile_tax_rate_reasonable`) for ~2 weeks, blocking all new UK data releases.

## Fix

Flip the default to `False` (fail-safe: a household has not bought all its property this year).

- The household calculator and YAML tests set `main_residential_property_purchased` **directly**, so they are unaffected — all 16 SDLT/LTT YAML tests still pass.
- Population datasets explicitly set `property_purchased` for the ~3.85% of genuine purchasers (see the paired `policyengine-uk-data` determinism PR).

## Test plan

- [x] All SDLT + LTT baseline YAML tests pass (16 cases).
- [x] New regression test: a household with `main_residence_value` but no purchase now computes `stamp_duty_land_tax: 0` (was full SDLT).
- [x] Verified end-to-end: £400k home, no explicit purchase → `property_purchased=False`, `main_residential_property_purchased=£0`, `stamp_duty_land_tax=£0`.
