### PR TITLE
Fix Pension Credit savings credit formula

### DIFF
--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.yaml
@@ -29,6 +29,22 @@
   output:
     is_savings_credit_eligible: true
 
+- name: Has pre-cutoff year SPA member but income below annual threshold, ineligible
+  period: 2026
+  input:
+    people:
+      person:
+        age: 81
+        is_male: false
+        state_pension_age: 60
+    benunits:
+      benunit:
+        members: [person]
+        relation_type: SINGLE
+        savings_credit_income: 10_000
+  output:
+    is_savings_credit_eligible: false
+
 - name: One member reached SPA before cutoff year and income above threshold (couple), eligible
   period: 2023
   input:

--- a/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/savings_credit.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/savings_credit.yaml
@@ -1,0 +1,25 @@
+- name: Maximum savings credit uses the standard minimum guarantee rather than additions
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    is_savings_credit_eligible: true
+    relation_type: SINGLE
+    savings_credit_income: 20_000
+    pension_credit_income: 20_000
+    standard_minimum_guarantee: 12_376
+    minimum_guarantee: 20_000
+  output:
+    savings_credit: 933.816
+
+- name: Amount B reduction uses Pension Credit income rather than qualifying income
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    is_savings_credit_eligible: true
+    relation_type: SINGLE
+    savings_credit_income: 20_000
+    pension_credit_income: 13_000
+    standard_minimum_guarantee: 12_376
+    minimum_guarantee: 12_376
+  output:
+    savings_credit: 684.216

--- a/policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.py
@@ -17,6 +17,6 @@ class is_savings_credit_eligible(Variable):
         income = benunit("savings_credit_income", period)
         sc = parameters(period).gov.dwp.pension_credit.savings_credit
         relation_type = benunit("relation_type", period)
-        threshold = sc.threshold[relation_type]
-        meets_income_threshold = income >= threshold
+        threshold = sc.threshold[relation_type] * WEEKS_IN_YEAR
+        meets_income_threshold = income > threshold
         return has_pre_cutoff_spa_member & meets_income_threshold

--- a/policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/savings_credit.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/savings_credit.py
@@ -15,9 +15,13 @@ class savings_credit(Variable):
         relation_type = benunit("relation_type", period)
         threshold = sc.threshold[relation_type] * WEEKS_IN_YEAR
         minimum_guarantee = benunit("minimum_guarantee", period)
+        standard_minimum_guarantee = benunit("standard_minimum_guarantee", period)
+        claimant_income = benunit("pension_credit_income", period)
         income_over_threshold = max_(income - threshold, 0)
-        income_over_mg = max_(income - minimum_guarantee, 0)
-        maximum_savings_credit = sc.rate.phase_in * (minimum_guarantee - threshold)
+        income_over_mg = max_(claimant_income - minimum_guarantee, 0)
+        maximum_savings_credit = sc.rate.phase_in * max_(
+            standard_minimum_guarantee - threshold, 0
+        )
         phased_in_sc = min_(
             maximum_savings_credit, sc.rate.phase_in * income_over_threshold
         )


### PR DESCRIPTION
Fixes #1753.

## Summary
- annualize the Savings Credit threshold in `is_savings_credit_eligible`
- require qualifying income to exceed, not merely equal, the threshold
- compute the maximum Savings Credit from `standard_minimum_guarantee`, not the full `minimum_guarantee` with additions
- compute the amount-B reduction from `pension_credit_income`, while keeping `savings_credit_income` as qualifying income for amount A
- add focused YAML tests for the annual threshold, standard-minimum cap, and amount-B income source

## Validation
- `uv run ruff format --check policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.py policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/savings_credit.py`
- `uv run ruff check policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.py policyengine_uk/variables/gov/dwp/pension_credit/savings_credit/savings_credit.py`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/is_savings_credit_eligible.yaml policyengine_uk/tests/policy/baseline/gov/dwp/pension_credit/savings_credit/savings_credit.yaml -c policyengine_uk` -> 7 passed

This was identified by the Axiom UK State Pension Credit section 3 oracle comparison: TheAxiomFoundation/axiom-encode#533 and TheAxiomFoundation/rulespec-uk#11.
