### PR TITLE
Fix UC housing costs element floor

### DIFF
--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/housing_costs_element/uc_housing_costs_element.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/housing_costs_element/uc_housing_costs_element.yaml
@@ -103,3 +103,22 @@
         members: person
   output:
     uc_housing_costs_element: 5_000 - 10 * 52
+
+- name: Rented privately, non-dependent deductions exceed housing costs
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    people:
+      person: {}
+    benunits:
+      benunit:
+        benunit_rent: 1_000
+        uc_non_dep_deductions: 2_000
+        LHA_cap: 5_000
+        members: person
+    households:
+      household:
+        tenure_type: RENT_PRIVATELY
+        members: person
+  output:
+    uc_housing_costs_element: 0

--- a/policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/uc_housing_costs_element.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/uc_housing_costs_element.py
@@ -26,4 +26,4 @@ class uc_housing_costs_element(Variable):
             default=0,
         )
         non_dependent_deductions = benunit("uc_non_dep_deductions", period)
-        return max_housing_costs - non_dependent_deductions
+        return max_(max_housing_costs - non_dependent_deductions, 0)


### PR DESCRIPTION
## Summary
- Floor the Universal Credit housing costs element at zero after non-dependent deductions
- Add a YAML regression where non-dependent deductions exceed eligible housing costs

## Validation
- uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/housing_costs_element/uc_housing_costs_element.yaml -c policyengine_uk
- uv run --python 3.13 ruff format --check policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/uc_housing_costs_element.py
- uv run --python 3.13 ruff check policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/uc_housing_costs_element.py
- Axiom local EFRS comparison, 1,000 rows, with this PE worktree plus Axiom award-expression fix: 37,154 compared values, 0 mismatches, 0 oracle divergences

## Context
Axiom RuleSpec validation found PE-UK can emit negative uc_housing_costs_element values when non-dependent deductions exceed eligible housing costs. This caused 164 / 37,152 sampled EFRS comparison values to mismatch before this fix.