### PR TITLE
Add UC housing floor changelog

### DIFF
--- a/changelog.d/1755.md
+++ b/changelog.d/1755.md
@@ -1,0 +1,1 @@
+- Floor the Universal Credit housing costs element at zero after non-dependent deductions.


### PR DESCRIPTION
## Summary
- Add a changelog fragment for the Universal Credit housing costs element floor fixed in #1755

## Context
#1755 merged cleanly, but it did not touch changelog.d or pyproject.toml, so the normal versioning workflow did not publish a package containing the fix. This fragment should trigger the regular patch release path after merge.

## Validation
- git diff --check