### PR TITLE
Fix UC childcare work condition for couples

### DIFF
--- a/changelog.d/uc-childcare-work-condition.md
+++ b/changelog.d/uc-childcare-work-condition.md
@@ -1,0 +1,1 @@
+- Fixed Universal Credit childcare work-condition eligibility so couples require all adults to be in work.

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/childcare_element/uc_childcare_work_condition.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/childcare_element/uc_childcare_work_condition.yaml
@@ -26,7 +26,7 @@
       person1:
         in_work: false
         is_adult: true
-      person2:  
+      person2:
         in_work: true
         is_adult: false
   output:
@@ -40,10 +40,27 @@
       person1:
         in_work: false
         is_adult: true
-      person2:  
+      person2:
         in_work: true
         is_adult: true
-    benunits: 
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    uc_childcare_work_condition: false
+
+- name: Couple, both adults in work
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        in_work: true
+        is_adult: true
+      person2:
+        in_work: true
+        is_adult: true
+    benunits:
       benunit:
         members: [person1, person2]
   output:

--- a/policyengine_uk/variables/gov/dwp/universal_credit/childcare_element/uc_childcare_work_condition.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/childcare_element/uc_childcare_work_condition.py
@@ -14,4 +14,5 @@ class uc_childcare_work_condition(Variable):
         in_work = person("in_work", period)
         adults_in_work = adult & in_work
         # Benefit unit must not have any adults not in work.
-        return benunit.any(adults_in_work)
+        all_adults_in_work = benunit.all(in_work | ~adult)
+        return benunit.any(adults_in_work) & all_adults_in_work


### PR DESCRIPTION
## Summary
- require all adults in a benefit unit to be in work for the UC childcare work condition
- update the couple regression test so one working adult is ineligible and both working adults remain eligible
- add a changelog fragment

## EFRS oracle evidence
Using the new Axiom RuleSpec Regulation 32 surface over the local enhanced FRS:
- published `policyengine-uk==2.88.42`: 5,996 mismatches out of 61,858 benefit units
- this branch installed locally: 0 mismatches out of 61,858 benefit units

The mismatches are all cases where current PE returns true for the childcare work condition while RuleSpec returns false, consistent with the existing formula using `any(adults_in_work)` instead of requiring all adults in the benefit unit to be in work.

## Tests
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/childcare_element/uc_childcare_work_condition.yaml -c policyengine_uk`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/childcare_element -c policyengine_uk`
- `uv run ruff check policyengine_uk/variables/gov/dwp/universal_credit/childcare_element/uc_childcare_work_condition.py`
- `uv run ruff format --check policyengine_uk/variables/gov/dwp/universal_credit/childcare_element/uc_childcare_work_condition.py`
- `git diff --check`
