### PR TITLE
Fix Carer Support Payment parameter dates

### DIFF
--- a/changelog.d/csp-parameter-dates.fixed.md
+++ b/changelog.d/csp-parameter-dates.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Carer Support Payment and Scottish Carer Supplement 2026 parameter dates.

--- a/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/rate.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/rate.yaml
@@ -1,8 +1,8 @@
 description: Weekly rate of Carer Support Payment.
 values:
   2024-11-01: 81.9
-  2025-04-01: 83.29
-  2026-04-01: 86.45
+  2025-04-01: 83.3
+  2026-04-05: 86.45
 metadata:
   period: week
   unit: currency-GBP
@@ -11,3 +11,5 @@ metadata:
   reference:
     - title: Carer Support Payment - mygov.scot
       href: https://www.mygov.scot/carer-support-payment
+    - title: The Social Security (Up-rating) (Miscellaneous Amendments) (Scotland) Regulations 2026 reg. 12(3)(a)
+      href: https://www.legislation.gov.uk/ssi/2026/170/regulation/12/made

--- a/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/supplement.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/supplement.yaml
@@ -1,7 +1,8 @@
 description: Weekly rate of the Scottish Carer Supplement, paid on top of the Carer Support Payment.
 values:
   2024-11-01: 0
-  2026-03-01: 11.70
+  2026-03-15: 11.29
+  2026-04-05: 11.7
 metadata:
   period: week
   unit: currency-GBP
@@ -9,3 +10,7 @@ metadata:
   reference:
     - title: New rates for carer and disability payments in 2026
       href: https://www.socialsecurity.gov.scot/news-events/news/new-payment-rates-from-april-2026
+    - title: The Carer's Assistance (Miscellaneous and Consequential Amendments, Revocation, Transitional and Saving Provisions) (Scotland) Regulations 2025 reg. 3
+      href: https://www.legislation.gov.uk/ssi/2025/340/made
+    - title: The Social Security (Up-rating) (Miscellaneous Amendments) (Scotland) Regulations 2026 reg. 12(3)(b)
+      href: https://www.legislation.gov.uk/ssi/2026/170/regulation/12/made

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/personal/carer_support_payment.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/personal/carer_support_payment.yaml
@@ -6,7 +6,7 @@
     care_hours: 40
     country: SCOTLAND
   output:
-    carer_support_payment: 4331.08
+    carer_support_payment: 4331.6
     carers_allowance: 0
 
 - name: Carer in England receives CA not CSP


### PR DESCRIPTION
## Summary
- correct the 2025 Carer Support Payment weekly rate to £83.30
- move the 2026 Carer Support Payment and Scottish Carer Supplement uprating dates to 2026-04-05
- add the missing £11.29 Scottish Carer Supplement period from 2026-03-15

Closes #1762.

## Tests
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/personal/carer_support_payment.yaml -c policyengine_uk`
- `uv run pytest policyengine_uk/tests/test_carer_support_payment.py -q`
- `uvx ruff format --check .`
