### PR TITLE
Fix Class 4 NI annual maximum rate factor

### DIFF
--- a/changelog.d/1765.md
+++ b/changelog.d/1765.md
@@ -1,0 +1,1 @@
+- Correct the Class 4 National Insurance annual maximum calculation to use the current main Class 4 rate factor.

--- a/policyengine_uk/tests/test_ni_class_4_maximum.py
+++ b/policyengine_uk/tests/test_ni_class_4_maximum.py
@@ -1,0 +1,26 @@
+import pytest
+
+from policyengine_uk import Simulation
+
+
+def test_class_4_annual_maximum_uses_current_main_rate_factor():
+    year = 2026
+    monthly_primary_class_1 = {f"{year}-{month:02d}": 500 for month in range(1, 13)}
+    sim = Simulation(
+        situation={
+            "people": {
+                "person": {
+                    "age": {year: 40},
+                    "self_employment_income": {year: 100_000},
+                    "ni_class_1_employee_primary": monthly_primary_class_1,
+                }
+            },
+            "benunits": {"benunit": {"members": ["person"]}},
+            "households": {"household": {"members": ["person"]}},
+        }
+    )
+
+    assert sim.calculate("ni_class_4_maximum", year)[0] == pytest.approx(
+        46_484,
+        abs=0.01,
+    )

--- a/policyengine_uk/variables/gov/hmrc/national_insurance/class_4/ni_class_4_maximum.py
+++ b/policyengine_uk/variables/gov/hmrc/national_insurance/class_4/ni_class_4_maximum.py
@@ -30,7 +30,7 @@ class ni_class_4_maximum(Variable):
         case_1 = (step_4 >= 0) & (step_4 > other_aggregate_contributions)
         case_2 = (step_4 >= 0) & (step_4 <= other_aggregate_contributions)
         case_3 = step_4 < 0
-        step_5 = step_4 * 100 / 9
+        step_5 = step_4 / main_rate
         profits = person("self_employment_income", period)
         step_6 = lpl - min_(upl, profits)
         step_7 = max_(0, step_6 - step_5)


### PR DESCRIPTION
Fixes #1765.

## Changes
- Replaces the stale hard-coded `100 / 9` Class 4 annual maximum factor with `1 / main_rate`, so 2026 uses the current 6% main Class 4 rate.
- Adds a regression test for the statutory annual maximum branch with monthly primary Class 1 contributions.
- Adds a changelog entry.

## Tests
- `uv run --extra dev --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/national_insurance/class_4 -c policyengine_uk`
- `uv run --extra dev --python 3.13 pytest policyengine_uk/tests/test_ni_class_4_maximum.py -q`
- `uv run --extra dev --python 3.13 ruff check policyengine_uk/variables/gov/hmrc/national_insurance/class_4/ni_class_4_maximum.py policyengine_uk/tests/test_ni_class_4_maximum.py`
- `uv run --extra dev --python 3.13 ruff format --check policyengine_uk/variables/gov/hmrc/national_insurance/class_4/ni_class_4_maximum.py policyengine_uk/tests/test_ni_class_4_maximum.py`