### PR TITLE
Update TV licence fees through 2026

### DIFF
--- a/changelog.d/tv-licence-fee-2026.md
+++ b/changelog.d/tv-licence-fee-2026.md
@@ -1,0 +1,1 @@
+- Update TV licence fee parameters for 2024-25, 2025-26, and 2026-27.

--- a/policyengine_uk/parameters/gov/dcms/bbc/tv_licence/colour.yaml
+++ b/policyengine_uk/parameters/gov/dcms/bbc/tv_licence/colour.yaml
@@ -5,10 +5,13 @@ values:
   2019-04-01: 154.5
   2020-04-01: 157.5
   2021-04-01: 159
+  2024-04-01: 169.5
+  2025-04-01: 174.5
+  2026-04-01: 180
 metadata:
   unit: currency-GBP
   period: year
   label: TV Licence fee
   reference:
-    - title: The Communications (Television Licensing) Regulations 2004 sch. 1 # F4, F5
+    - title: The Communications (Television Licensing) Regulations 2004 sch. 1
       href: https://www.legislation.gov.uk/uksi/2004/692/schedule/1

--- a/policyengine_uk/tests/policy/baseline/gov/dcms/bbc/tv-licence/tv_licence.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/dcms/bbc/tv-licence/tv_licence.yaml
@@ -1,23 +1,41 @@
-- name: TV Licence full price - ineligible for aged or blind discount.
-  period: 2023
+- name: TV Licence full price in 2024-25.
+  period: 2024
   input:
     household_owns_tv: true
     tv_licence_discount: 0
     would_evade_tv_licence_fee: false
   output:
-    tv_licence: 159.00
+    tv_licence: 169.50
+
+- name: TV Licence full price in 2025-26.
+  period: 2025
+  input:
+    household_owns_tv: true
+    tv_licence_discount: 0
+    would_evade_tv_licence_fee: false
+  output:
+    tv_licence: 174.50
+
+- name: TV Licence full price - ineligible for aged or blind discount.
+  period: 2026
+  input:
+    household_owns_tv: true
+    tv_licence_discount: 0
+    would_evade_tv_licence_fee: false
+  output:
+    tv_licence: 180.00
 
 - name: TV Licence half price - eligible for blind discount but not aged.
-  period: 2023
+  period: 2026
   input:
     household_owns_tv: true
     tv_licence_discount: 0.5
     would_evade_tv_licence_fee: false
   output:
-    tv_licence: 79.50
+    tv_licence: 90.00
 
 - name: Free TV Licence - eligible for aged discount.
-  period: 2023
+  period: 2026
   input:
     household_owns_tv: true
     tv_licence_discount: 1

--- a/policyengine_uk/tests/policy/integration/entitledto_scenarios.yaml
+++ b/policyengine_uk/tests/policy/integration/entitledto_scenarios.yaml
@@ -33,7 +33,7 @@
     universal_credit: 3_662.72
     housing_benefit: 0
     child_benefit: 0
-    household_net_income: 14_303.68
+    household_net_income: 14_288.18
 
 - name: "EntitledTo #2 - couple with 2 children, one earner at £22k, social housing in North West"
   period: 2025
@@ -63,11 +63,11 @@
   output:
     # Household-level aggregates only — per-person income_tax / NI can't be
     # asserted with a single scalar when multiple people are in the benunit.
-    household_tax: 4_047.45
+    household_tax: 4_062.95
     universal_credit: 12_490.86
     housing_benefit: 0
     child_benefit: 2_251.60
-    household_net_income: 36_130.40
+    household_net_income: 36_114.90
 
 - name: "EntitledTo #3 - pensioner couple, low state pension, qualifies for Pension Credit"
   period: 2025
@@ -96,4 +96,4 @@
     winter_fuel_allowance: 200
     income_tax: 0
     national_insurance: 0
-    household_net_income: 15_848.68
+    household_net_income: 15_833.18


### PR DESCRIPTION
## Summary
- Add TV licence colour fee parameters for 2024-25, 2025-26, and 2026-27 from the Communications (Television Licensing) Regulations 2004 Schedule 1.
- Update TV licence policy tests for the current 2026 fee and add 2024/2025 regression cases.

## Test
- uv run --python 3.13 policyengine-core test policyengine_uk/tests/policy/baseline/gov/dcms/bbc/tv-licence/tv_licence.yaml -c policyengine_uk

Source: https://www.legislation.gov.uk/uksi/2004/692/schedule/1