### PR TITLE
Add Newham council tax reduction

### DIFF
--- a/changelog.d/council-tax-reduction-newham.md
+++ b/changelog.d/council-tax-reduction-newham.md
@@ -1,0 +1,1 @@
+- Add working-age Council Tax Reduction for Newham.

--- a/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/maximum_support_rate.yaml
+++ b/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/maximum_support_rate.yaml
@@ -1,0 +1,10 @@
+description: Maximum share of eligible Council Tax liability covered for working-age households under the Newham Council Tax Reduction scheme.
+values:
+  2026-04-01: 0.70
+metadata:
+  unit: /1
+  period: year
+  label: Newham Council Tax Reduction maximum support rate
+  reference:
+    - title: Council Tax Reduction Scheme 2026
+      href: https://www.newham.gov.uk/downloads/file/10753/council-tax-reduction-scheme-2026

--- a/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/means_test/capital_limit.yaml
+++ b/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/means_test/capital_limit.yaml
@@ -1,0 +1,10 @@
+description: Capital limit for working-age households under the Newham Council Tax Reduction scheme.
+values:
+  2026-04-01: 6_000
+metadata:
+  unit: currency-GBP
+  period: year
+  label: Newham Council Tax Reduction capital limit
+  reference:
+    - title: Council Tax Reduction Scheme 2026
+      href: https://www.newham.gov.uk/downloads/file/10753/council-tax-reduction-scheme-2026

--- a/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/means_test/withdrawal_rate.yaml
+++ b/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/means_test/withdrawal_rate.yaml
@@ -1,0 +1,10 @@
+description: Withdrawal rate for working-age households under the Newham Council Tax Reduction scheme.
+values:
+  2026-04-01: 0.25
+metadata:
+  unit: /1
+  period: year
+  label: Newham Council Tax Reduction withdrawal rate
+  reference:
+    - title: Council Tax Reduction Scheme 2026
+      href: https://www.newham.gov.uk/downloads/file/10753/council-tax-reduction-scheme-2026

--- a/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/non_dep_deduction/amount.yaml
+++ b/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/non_dep_deduction/amount.yaml
@@ -1,0 +1,27 @@
+description: Weekly working-age non-dependant deduction schedule under the Newham Council Tax Reduction scheme.
+brackets:
+  - threshold:
+      2026-04-01: 0
+    amount:
+      2026-04-01: 7.54
+  - threshold:
+      2026-04-01: 183
+    amount:
+      2026-04-01: 14.96
+  - threshold:
+      2026-04-01: 316
+    amount:
+      2026-04-01: 18.84
+  - threshold:
+      2026-04-01: 394
+    amount:
+      2026-04-01: 22.61
+metadata:
+  amount_unit: currency-GBP
+  period: week
+  threshold_unit: currency-GBP
+  type: single_amount
+  label: Newham Council Tax Reduction non-dependant deduction schedule
+  reference:
+    - title: Council Tax Reduction Scheme 2026
+      href: https://www.newham.gov.uk/downloads/file/10753/council-tax-reduction-scheme-2026

--- a/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/non_dep_deduction/remunerative_work_hours.yaml
+++ b/policyengine_uk/parameters/gov/local_authorities/newham/council_tax_reduction/non_dep_deduction/remunerative_work_hours.yaml
@@ -1,0 +1,10 @@
+description: Weekly hours threshold for remunerative work in the Newham Council Tax Reduction non-dependant deduction schedule.
+values:
+  2026-04-01: 16
+metadata:
+  unit: hour
+  period: week
+  label: Newham Council Tax Reduction remunerative work hours
+  reference:
+    - title: Council Tax Reduction Scheme 2026
+      href: https://www.newham.gov.uk/downloads/file/10753/council-tax-reduction-scheme-2026

--- a/policyengine_uk/tests/policy/baseline/gov/local_authorities/council_tax_reduction/council_tax_reduction.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/local_authorities/council_tax_reduction/council_tax_reduction.yaml
@@ -407,3 +407,161 @@
   output:
     uc_assessable_capital: 0
     council_tax_reduction: 1_800
+
+- name: Newham working-age claimant receives 70 percent maximum support
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      claimant:
+        age: 35
+    benunits:
+      benunit:
+        members: [claimant]
+        would_claim_uc: false
+        claims_all_entitled_benefits: true
+    households:
+      household:
+        members: [claimant]
+        country: ENGLAND
+        local_authority: NEWHAM
+        council_tax: 1_800
+        savings: 0
+  output:
+    council_tax_reduction_scheme_supported: true
+    simulated_council_tax_reduction_benunit: 1_260
+    council_tax_reduction: 1_260
+    council_tax_less_benefit: 540
+
+- name: Newham working-age claimant above capital limit gets no local support
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      claimant:
+        age: 35
+        council_tax_benefit_reported: 500
+    benunits:
+      benunit:
+        members: [claimant]
+        claims_all_entitled_benefits: true
+    households:
+      household:
+        members: [claimant]
+        country: ENGLAND
+        local_authority: NEWHAM
+        council_tax: 1_800
+        savings: 6_001
+  output:
+    council_tax_reduction_scheme_supported: true
+    simulated_council_tax_reduction_benunit: 0
+    council_tax_benefit: 0
+    council_tax_reduction: 0
+
+- name: Newham applies a 25 percent excess-income taper
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      claimant:
+        age: 35
+    benunits:
+      benunit:
+        members: [claimant]
+        would_claim_uc: false
+        claims_all_entitled_benefits: true
+        council_tax_reduction_applicable_amount: 10_000
+        council_tax_reduction_applicable_income: 11_000
+        council_tax_reduction_relevant_income_based_benefit: false
+    households:
+      household:
+        members: [claimant]
+        country: ENGLAND
+        local_authority: NEWHAM
+        council_tax: 1_800
+        savings: 0
+  output:
+    council_tax_reduction: 1_010
+    council_tax_less_benefit: 790
+
+- name: Newham applies its 2026 local non-dependant deduction schedule
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      claimant:
+        age: 35
+      non_dep:
+        age: 25
+        employment_income: 5_200
+        private_pension_income: 11_232
+        weekly_hours: 16
+    benunits:
+      claimant_benunit:
+        members: [claimant]
+        would_claim_uc: false
+        claims_all_entitled_benefits: true
+      non_dep_benunit:
+        members: [non_dep]
+    households:
+      household:
+        members: [claimant, non_dep]
+        country: ENGLAND
+        local_authority: NEWHAM
+        council_tax: 1_800
+        savings: 0
+  output:
+    council_tax_reduction_scheme_supported: true
+    council_tax_reduction: 280.32
+
+- name: Newham uses the not-in-remunerative-work non-dependant deduction below 16 weekly hours
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      claimant:
+        age: 35
+      non_dep:
+        age: 25
+        employment_income: 31_460
+        weekly_hours: 15
+    benunits:
+      claimant_benunit:
+        members: [claimant]
+        would_claim_uc: false
+        claims_all_entitled_benefits: true
+      non_dep_benunit:
+        members: [non_dep]
+    households:
+      household:
+        members: [claimant, non_dep]
+        country: ENGLAND
+        local_authority: NEWHAM
+        council_tax: 1_800
+        savings: 0
+  output:
+    council_tax_reduction: 867.92
+
+- name: Newham UC claimant uses UC-reported capital against the local limit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      claimant:
+        age: 35
+    benunits:
+      claimant_benunit:
+        members: [claimant]
+        would_claim_uc: true
+        claims_all_entitled_benefits: true
+        uc_reported_capital: 0
+    households:
+      household:
+        members: [claimant]
+        country: ENGLAND
+        local_authority: NEWHAM
+        council_tax: 1_800
+        savings: 20_000
+  output:
+    uc_assessable_capital: 0
+    council_tax_reduction: 1_260

--- a/policyengine_uk/variables/gov/local_authorities/council_tax_reduction/config.py
+++ b/policyengine_uk/variables/gov/local_authorities/council_tax_reduction/config.py
@@ -35,6 +35,14 @@ def is_kingston_upon_thames_working_age(local_authority, country, has_pensioner)
     )
 
 
+def is_newham(local_authority):
+    return local_authority == LocalAuthority.NEWHAM
+
+
+def is_newham_working_age(local_authority, country, has_pensioner):
+    return (country == Country.ENGLAND) & ~has_pensioner & is_newham(local_authority)
+
+
 def is_supported_scheme(country, has_pensioner, local_authority):
     return (
         is_england_pensioner_scheme(country, has_pensioner)
@@ -42,4 +50,5 @@ def is_supported_scheme(country, has_pensioner, local_authority):
         | is_wales_scheme(country)
         | is_merton_working_age(local_authority, country, has_pensioner)
         | is_kingston_upon_thames_working_age(local_authority, country, has_pensioner)
+        | is_newham_working_age(local_authority, country, has_pensioner)
     )

--- a/policyengine_uk/variables/gov/local_authorities/council_tax_reduction/simulated_council_tax_reduction_benunit.py
+++ b/policyengine_uk/variables/gov/local_authorities/council_tax_reduction/simulated_council_tax_reduction_benunit.py
@@ -8,6 +8,7 @@ from policyengine_uk.variables.gov.local_authorities.council_tax_reduction.confi
 LOCAL_COUNCIL_TAX_REDUCTION_VARIABLES = [
     "merton_council_tax_reduction",
     "kingston_upon_thames_council_tax_reduction",
+    "newham_council_tax_reduction",
 ]
 
 

--- a/policyengine_uk/variables/gov/local_authorities/newham/council_tax_reduction/newham_council_tax_reduction.py
+++ b/policyengine_uk/variables/gov/local_authorities/newham/council_tax_reduction/newham_council_tax_reduction.py
@@ -1,0 +1,31 @@
+from policyengine_uk.model_api import *
+from policyengine_uk.variables.gov.local_authorities.council_tax_reduction._legacy import (
+    legacy_council_tax_reduction,
+)
+from policyengine_uk.variables.gov.local_authorities.council_tax_reduction.config import (
+    is_newham_working_age,
+)
+
+
+class newham_council_tax_reduction(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Newham Council Tax Reduction"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        ctr = parameters(period).gov.local_authorities.newham.council_tax_reduction
+        household = benunit.household
+        working_age = is_newham_working_age(
+            household("local_authority", period),
+            household("country", period),
+            household("council_tax_reduction_household_has_pensioner", period),
+        )
+        return legacy_council_tax_reduction(
+            benunit,
+            period,
+            ctr,
+            working_age,
+            "newham_council_tax_reduction_non_dep_deductions",
+        )

--- a/policyengine_uk/variables/gov/local_authorities/newham/council_tax_reduction/newham_council_tax_reduction_individual_non_dep_deduction.py
+++ b/policyengine_uk/variables/gov/local_authorities/newham/council_tax_reduction/newham_council_tax_reduction_individual_non_dep_deduction.py
@@ -1,0 +1,32 @@
+from policyengine_uk.model_api import *
+from policyengine_uk.variables.gov.local_authorities.council_tax_reduction._legacy import (
+    normal_gross_income_non_dep_deduction,
+)
+from policyengine_uk.variables.gov.local_authorities.council_tax_reduction.config import (
+    is_newham_working_age,
+)
+
+
+class newham_council_tax_reduction_individual_non_dep_deduction(Variable):
+    value_type = float
+    entity = Person
+    label = "Newham CTR individual non-dependent deduction"
+    definition_period = YEAR
+    unit = GBP
+    defined_for = "council_tax_reduction_individual_non_dep_deduction_eligible"
+
+    def formula(person, period, parameters):
+        ctr = parameters(period).gov.local_authorities.newham.council_tax_reduction
+        household = person.household
+        working_age = is_newham_working_age(
+            household("local_authority", period),
+            household("country", period),
+            household("council_tax_reduction_household_has_pensioner", period),
+        )
+        return normal_gross_income_non_dep_deduction(
+            person,
+            period,
+            ctr,
+            working_age,
+            exempt_uc_no_earned_income=True,
+        )

--- a/policyengine_uk/variables/gov/local_authorities/newham/council_tax_reduction/newham_council_tax_reduction_non_dep_deductions.py
+++ b/policyengine_uk/variables/gov/local_authorities/newham/council_tax_reduction/newham_council_tax_reduction_non_dep_deductions.py
@@ -1,0 +1,19 @@
+from policyengine_uk.model_api import *
+from policyengine_uk.variables.gov.local_authorities.council_tax_reduction._legacy import (
+    local_non_dep_deductions,
+)
+
+
+class newham_council_tax_reduction_non_dep_deductions(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Newham CTR non-dependent deductions"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        return local_non_dep_deductions(
+            benunit,
+            period,
+            "newham_council_tax_reduction_individual_non_dep_deduction",
+        )


### PR DESCRIPTION
## Summary
- Add working-age Council Tax Reduction for Newham from the council's 2026 scheme PDF.
- Register Newham as a supported local CTR scheme and include it in the local CTR aggregator alongside Merton and Kingston upon Thames.
- Reuse the shared legacy CTR helper for Newham's 70% maximum support, £6,000 capital limit, 25% withdrawal rate, and working-age non-dependant deductions.

## Source
- London Borough of Newham, Council Tax Reduction Scheme 2026: https://www.newham.gov.uk/downloads/file/10753/council-tax-reduction-scheme-2026
- Modeled source facts: 70% working-age maximum support, £6,000 working-age capital exclusion limit, 25% excess-income taper, 16-hour remunerative-work gate, 2026 working-age non-dependant deduction schedule, UC maximum amount/income/capital treatment, and UC no-earned-income non-dependant exemption.

## Tests
- `uvx ruff format --check .`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/local_authorities/council_tax_reduction/council_tax_reduction.yaml -c policyengine_uk`
- `uv run ruff check policyengine_uk/variables/gov/local_authorities/council_tax_reduction policyengine_uk/variables/gov/local_authorities/newham`
- `uv run policyengine-core test policyengine_uk/tests/policy -c policyengine_uk`
- `uv run --with pytest --with pytest-cov python -m pytest policyengine_uk/tests/ --cov=policyengine_uk --cov-report=xml --maxfail=1 -v`
- `git diff --check origin/main...HEAD`
