### PR TITLE
Add bus_fare_spending input variable

### DIFF
--- a/changelog.d/1780.md
+++ b/changelog.d/1780.md
@@ -1,0 +1,1 @@
+- Add `bus_fare_spending` Household input variable (COICOP 7.3.2 bus & coach fares), the companion to the LCFS bus fare imputation in policyengine-uk-data, providing the passenger fare households pay (distinct from the ETB-based `bus_subsidy_spending`) as a building block for modelling bus fare reforms. Resolves #1779.

--- a/policyengine_uk/data/uprating_indices.yaml
+++ b/policyengine_uk/data/uprating_indices.yaml
@@ -8,6 +8,7 @@ gov.economic_assumptions.yoy_growth.obr.average_earnings:
 gov.economic_assumptions.yoy_growth.obr.consumer_price_index:
 - afcs_reported
 - alcohol_and_tobacco_consumption
+- bus_fare_spending
 - bsp_reported
 - carers_allowance_reported
 - child_benefit_reported

--- a/policyengine_uk/tests/test_road_fuel_volume_uprating.py
+++ b/policyengine_uk/tests/test_road_fuel_volume_uprating.py
@@ -107,3 +107,42 @@ def test_petrol_and_diesel_spending_preserve_road_fuel_litres_not_cpi():
         weighted_litres(household_2034, "diesel_spending", diesel_price, 2034)
         * (1 + road_fuel_volume(2035))
     )
+
+
+def test_bus_fare_spending_uses_cpi_uprating():
+    parameters = system.parameters
+    cpi = parameters.gov.economic_assumptions.yoy_growth.obr.consumer_price_index
+
+    dataset = UKSingleYearDataset(
+        person=pd.DataFrame(
+            {
+                "person_id": [1],
+                "person_benunit_id": [1],
+                "person_household_id": [1],
+                "age": [40],
+            }
+        ),
+        benunit=pd.DataFrame({"benunit_id": [1]}),
+        household=pd.DataFrame(
+            {
+                "household_id": [1],
+                "region": ["LONDON"],
+                "tenure_type": ["OWNED_OUTRIGHT"],
+                "council_tax": [1_500.0],
+                "rent": [0.0],
+                "household_weight": [1.0],
+                "bus_fare_spending": [100.0],
+            }
+        ),
+        fiscal_year=2025,
+    )
+
+    extended = extend_single_year_dataset(
+        dataset,
+        tax_benefit_system_parameters=parameters,
+        end_year=2026,
+    )
+
+    assert extended[2026].household["bus_fare_spending"].iloc[0] == pytest.approx(
+        100 * (1 + cpi(2026))
+    )

--- a/policyengine_uk/variables/input/consumption/bus_fare_spending.py
+++ b/policyengine_uk/variables/input/consumption/bus_fare_spending.py
@@ -1,0 +1,17 @@
+from policyengine_uk.model_api import *
+
+# COICOP 7.3.2 (passenger transport by road: bus & coach fares). A
+# sub-component of transport_consumption, imputed separately from LCFS by
+# policyengine-uk-data so bus fare reforms can be modelled. Not added into the
+# `consumption` total, which already counts it via transport_consumption.
+
+
+class bus_fare_spending(Variable):
+    label = "bus and coach fare spending"
+    documentation = "Household spending on bus and coach fares (COICOP 7.3.2)."
+    entity = Household
+    definition_period = YEAR
+    value_type = float
+    unit = GBP
+    quantity_type = FLOW
+    uprating = "gov.economic_assumptions.indices.obr.consumer_price_index"


### PR DESCRIPTION
## What

Adds a Household input variable `bus_fare_spending` (COICOP 7.3.2 — bus & coach fares), the companion to the LCFS bus fare imputation in PolicyEngine/policyengine-uk-data#428.

## Why

The data PR writes a `bus_fare_spending` column, but without a registered variable the model silently skips it on load (`simulation.py` ignores unknown columns). This variable lets the model consume it. `bus_fare_spending` is the **passenger fare households pay**, distinct from `bus_subsidy_spending` (the ETB government-subsidy benefit-in-kind) — the building block for modelling bus fare reforms (£2 cap, free travel for young people), as the bus analogue of the existing rail fare modelling.

## Details

- Mirrors `petrol_spending` / `diesel_spending`, which are likewise COICOP sub-components of `transport_consumption`.
- CPI-uprated (`gov.economic_assumptions.indices.obr.consumer_price_index`), matching `transport_consumption` and the data-side uprating.
- **Not** added into the `consumption` total — `transport_consumption` already includes bus fares, so adding it would double-count.

Verified: registers in the tax-benefit system and the uprating parameter resolves.

Resolves #1779. Companion to PolicyEngine/policyengine-uk-data#428 (tracked in PolicyEngine/policyengine-uk-data#427).

🤖 Generated with [Claude Code](https://claude.com/claude-code)