### PR TITLE
Add employment sector (public/private) and SIC industry input variables

### DIFF
--- a/changelog.d/1785.md
+++ b/changelog.d/1785.md
@@ -1,0 +1,1 @@
+- Add `employment_sector` (public/private) and `sic_industry_division` as Person-level input variables, enabling identification of public-sector workers and industry-level analysis once populated from the FRS.

--- a/policyengine_uk/variables/household/income/employment_sector.py
+++ b/policyengine_uk/variables/household/income/employment_sector.py
@@ -1,0 +1,21 @@
+from policyengine_uk.model_api import *
+
+
+class EmploymentSector(Enum):
+    NOT_EMPLOYED = "Not in paid employment"
+    PRIVATE = "Private sector"
+    PUBLIC = "Public sector"
+
+
+class employment_sector(Variable):
+    value_type = Enum
+    entity = Person
+    possible_values = EmploymentSector
+    default_value = EmploymentSector.NOT_EMPLOYED
+    label = "Employer sector (public or private) of the person's main job"
+    documentation = (
+        "Whether the person's main job is in the public or private sector. "
+        "Sourced from the FRS `mjobsect` field; NOT_EMPLOYED where the person "
+        "has no main job."
+    )
+    definition_period = YEAR

--- a/policyengine_uk/variables/household/income/sic_industry_division.py
+++ b/policyengine_uk/variables/household/income/sic_industry_division.py
@@ -1,0 +1,14 @@
+from policyengine_uk.model_api import *
+
+
+class sic_industry_division(Variable):
+    value_type = int
+    entity = Person
+    label = "Standard Industrial Classification (2007) division of the main job"
+    documentation = (
+        "Two-digit SIC 2007 division of the person's main job (0 if unknown). "
+        "Sourced from the FRS `sic` field. Division 84 = 'Public administration "
+        "and defence; compulsory social security'."
+    )
+    default_value = 0
+    definition_period = YEAR


### PR DESCRIPTION
## What this does

Adds two Person-level input variables so PolicyEngine UK can represent **employer sector** and **industry** — which it currently cannot (the only employment classification is `employment_status`, which captures employed/self-employed × FT/PT but not who employs the person).

- **`employment_sector`** — `Enum(EmploymentSector)`: `NOT_EMPLOYED`, `PRIVATE`, `PUBLIC`. Direct public/private flag for the main job.
- **`sic_industry_division`** — `int`: SIC 2007 division of the main job (0 if unknown). Division **84 = public administration & defence**.

Both are unpopulated defaults here; the companion `policyengine-uk-data` PR fills them from the FRS `mjobsect` and `sic` fields, following the same passthrough pattern used for `employment_status`, `region`, and `tenure_type`.

## Why

Enables identifying public-sector workers (e.g. public-sector pay reforms) and cutting analysis by sector/industry. The backing FRS fields are well-populated: `mjobsect` covers ≈100% of workers; `sic` covers ~92% of adults.

## Ordering

Must merge before the companion data PR, since the dataset build needs these variables to exist.

Closes #1784. Companion: PolicyEngine/policyengine-uk-data#432.

## Tests

Verified both variables register in the model and the `EmploymentSector` enum loads (`NOT_EMPLOYED`/`PRIVATE`/`PUBLIC`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
