### PR TITLE
Add cash ISA and stocks and shares ISA holdings variables

### DIFF
--- a/changelog.d/add-isa-balance-variables.added.md
+++ b/changelog.d/add-isa-balance-variables.added.md
@@ -1,0 +1,1 @@
+- Add `cash_isa` and `stocks_and_shares_isa` Household wealth input variables for ISA balances.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Cash ISA and stocks and shares ISA holdings as household wealth input variables.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,0 @@
-- bump: minor
-  changes:
-    added:
-      - Cash ISA and stocks and shares ISA holdings as household wealth input variables.

--- a/policyengine_uk/variables/household/wealth/cash_isa.py
+++ b/policyengine_uk/variables/household/wealth/cash_isa.py
@@ -1,0 +1,12 @@
+from policyengine_uk.model_api import *
+
+
+class cash_isa(Variable):
+    label = "cash ISA holdings"
+    documentation = "Amount held in cash Individual Savings Accounts"
+    entity = Household
+    definition_period = YEAR
+    value_type = float
+    unit = GBP
+    uprating = "gov.economic_assumptions.indices.obr.per_capita.gdp"
+    quantity_type = STOCK

--- a/policyengine_uk/variables/household/wealth/stocks_and_shares_isa.py
+++ b/policyengine_uk/variables/household/wealth/stocks_and_shares_isa.py
@@ -1,0 +1,15 @@
+from policyengine_uk.model_api import *
+
+
+class stocks_and_shares_isa(Variable):
+    label = "stocks and shares ISA holdings"
+    documentation = (
+        "Amount held in stocks and shares (investment) Individual Savings "
+        "Accounts"
+    )
+    entity = Household
+    definition_period = YEAR
+    value_type = float
+    unit = GBP
+    uprating = "gov.economic_assumptions.indices.obr.per_capita.gdp"
+    quantity_type = STOCK

--- a/policyengine_uk/variables/household/wealth/stocks_and_shares_isa.py
+++ b/policyengine_uk/variables/household/wealth/stocks_and_shares_isa.py
@@ -4,8 +4,7 @@ from policyengine_uk.model_api import *
 class stocks_and_shares_isa(Variable):
     label = "stocks and shares ISA holdings"
     documentation = (
-        "Amount held in stocks and shares (investment) Individual Savings "
-        "Accounts"
+        "Amount held in stocks and shares (investment) Individual Savings Accounts"
     )
     entity = Household
     definition_period = YEAR


### PR DESCRIPTION
## What

Adds two household-level wealth input variables:

- `cash_isa` — amount held in cash ISAs
- `stocks_and_shares_isa` — amount held in stocks & shares (investment) ISAs

Both are `Household`, `STOCK`, `GBP`, GDP-per-capita uprated, mirroring `corporate_wealth` / `savings`.

## Why

The only ISA variable today is the income flow `individual_savings_account_interest_income`. ISA **balances** had nowhere to land:

- investment ISAs were folded into `corporate_wealth` in the (now archived) `policyengine-uk-data` wealth imputation, so they were not separable; and
- cash ISAs were not represented at all.

These variables provide the model-side home for ISA balances imputed by the data pipeline, enabling ISA-balance modelling (ISA reforms, wealth-tax scenarios).

## Data side

The matching data work — surfacing `cash_isa` and `stocks_and_shares_isa` from the Wealth and Assets Survey in the populace UK build — is tracked in PolicyEngine/populace#180.