### PR TITLE
Trigger release for NI land intensity fix

### DIFF
--- a/changelog.d/1809.fixed.md
+++ b/changelog.d/1809.fixed.md
@@ -1,0 +1,1 @@
+Lower Northern Ireland's regional land intensity from 0.673 to 0.44, interpolating from price-similar regions consistently with Scotland and Wales.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,8 +1,0 @@
-- bump: patch
-  changes:
-    fixed:
-    - Northern Ireland regional land intensity lowered from 0.673 (population-weighted
-      English mean) to 0.44, interpolated from the price-similar North East and North
-      West regions, consistent with the Scotland and Wales treatment. The previous
-      value placed NI above every English region except London despite NI having
-      roughly the lowest house prices in the UK.


### PR DESCRIPTION
## Summary

Replace the obsolete root-level `changelog_entry.yaml` from #1809 with a recognized Towncrier fragment, `changelog.d/1809.fixed.md`. This makes the versioning workflow publish the merged Northern Ireland land-intensity correction.

## Root cause

The versioning workflow only triggers for changes under `changelog.d/**` or `pyproject.toml`, so #1809 did not produce a package release.

## Validation

- Towncrier draft renders the NI correction under **Fixed** for `2.89.4`
- `.github/bump_version.py` selects patch release `2.89.4`
- `git diff --check` passes