### PR TITLE
Cap LHA at the national maximum and hold frozen rates at the last determination

### DIFF
--- a/changelog.d/lha-freeze-anchor.fixed.md
+++ b/changelog.d/lha-freeze-anchor.fixed.md
@@ -1,0 +1,1 @@
+- Fixed frozen LHA rates being re-based to the first year of the freeze rather than held at the level last determined, and read the percentile and national maximum at that determination year so a later change cannot move a frozen rate.

--- a/changelog.d/lha-maximum-and-freeze-anchor.md
+++ b/changelog.d/lha-maximum-and-freeze-anchor.md
@@ -1,0 +1,2 @@
+- Added the national maximum Local Housing Allowance, which caps the Broad Rental Market Area percentile and binds in central London.
+- Fixed frozen LHA rates being re-based to the first year of the freeze rather than held at the last determined level.

--- a/changelog.d/lha-national-maximum.added.md
+++ b/changelog.d/lha-national-maximum.added.md
@@ -1,2 +1,1 @@
 - Added the national maximum Local Housing Allowance, which caps the Broad Rental Market Area percentile and binds in central London.
-- Fixed frozen LHA rates being re-based to the first year of the freeze rather than held at the last determined level.

--- a/changelog.d/lha-uc-monthly-maximum.fixed.md
+++ b/changelog.d/lha-uc-monthly-maximum.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the Universal Credit housing costs element using the weekly Housing Benefit maximum LHA annualised by 52, rather than the statutory monthly maximum.

--- a/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
@@ -14,7 +14,7 @@ values:
       reference:
         - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2020 (determinations in 2021)
           href: https://www.legislation.gov.uk/uksi/2020/1519/made
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2021 (determinations in 2022)
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment and Modification) Order 2021 (determinations in 2022)
           href: https://www.legislation.gov.uk/uksi/2021/1380/made
         - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2023 (determinations in 2023)
           href: https://www.legislation.gov.uk/uksi/2023/6/made

--- a/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
@@ -1,7 +1,8 @@
-description: While this parameter is true, LHA rates are frozen in cash terms. When this parameter is set to false from being true the previous year, values are uplifted to the (default 30th) BRMA percentile.
+description: While this parameter is true, LHA rates are frozen in cash terms at the level set in the most recent year in which it was false. When this parameter is false, values are set at the (default 30th) BRMA percentile of that year's rents.
 values:
   2015-01-01: false
-  2020-01-01: true
+  2020-04-06: false
+  2021-04-06: true
   2024-04-06: false
   2025-04-06: true
 metadata:
@@ -10,3 +11,7 @@ metadata:
   reference:
     - title: April 2024 LHA reset to 30th percentile
       href: https://www.gov.uk/government/news/local-housing-allowance-rates-to-be-uprated-to-the-30th-percentile-of-local-market-rents
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2025
+      href: https://www.legislation.gov.uk/uksi/2025/5/made
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2026
+      href: https://www.legislation.gov.uk/uksi/2026/5/made

--- a/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
@@ -1,17 +1,35 @@
-description: While this parameter is true, LHA rates are frozen in cash terms at the level set in the most recent year in which it was false. When this parameter is false, values are set at the (default 30th) BRMA percentile of that year's rents.
+description: >-
+  While this parameter is true, LHA rates are frozen in cash terms at the level set in the most recent year in which it was false. When this parameter is false, values are set at the (default 30th) BRMA percentile of that year's rents. Values from 2027 onward reflect announced rather than enacted policy: no Modification Order has been made beyond 2026-27, and the Autumn Statement 2023 costing maintains the April 2024 uplift in cash terms thereafter.
 values:
   2015-01-01: false
-  2020-04-06: false
-  2021-04-06: true
-  2024-04-06: false
-  2025-04-06: true
+  2020-04-06:
+    value: false
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020, reg. 4 (April 2020 reset to the 30th percentile)
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2021-04-06:
+    value: true
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2020
+          href: https://www.legislation.gov.uk/uksi/2020/1519/made
+  2024-04-06:
+    value: false
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024 (April 2024 reset to the 30th percentile)
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
+  2025-04-06:
+    value: true
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2025
+          href: https://www.legislation.gov.uk/uksi/2025/5/made
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2026
+          href: https://www.legislation.gov.uk/uksi/2026/5/made
+        - title: Autumn Statement 2023 policy costings (April 2024 uplift maintained in cash terms thereafter)
+          href: https://assets.publishing.service.gov.uk/media/655d0a83544aea000dfb321d/Autumn_Statement_2023_Policy_Costings_-_Final.pdf
 metadata:
   unit: bool
   label: LHA freeze
-  reference:
-    - title: April 2024 LHA reset to 30th percentile
-      href: https://www.gov.uk/government/news/local-housing-allowance-rates-to-be-uprated-to-the-30th-percentile-of-local-market-rents
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2025
-      href: https://www.legislation.gov.uk/uksi/2025/5/made
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2026
-      href: https://www.legislation.gov.uk/uksi/2026/5/made

--- a/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/freeze.yaml
@@ -6,14 +6,18 @@ values:
     value: false
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020, reg. 4 (April 2020 reset to the 30th percentile)
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020, reg. 4 (April 2020 reset to the 30th percentile)
           href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
   2021-04-06:
     value: true
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2020
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2020 (determinations in 2021)
           href: https://www.legislation.gov.uk/uksi/2020/1519/made
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2021 (determinations in 2022)
+          href: https://www.legislation.gov.uk/uksi/2021/1380/made
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2023 (determinations in 2023)
+          href: https://www.legislation.gov.uk/uksi/2023/6/made
   2024-04-06:
     value: false
     metadata:
@@ -29,7 +33,7 @@ values:
         - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Modification) Order 2026
           href: https://www.legislation.gov.uk/uksi/2026/5/made
         - title: Autumn Statement 2023 policy costings (April 2024 uplift maintained in cash terms thereafter)
-          href: https://assets.publishing.service.gov.uk/media/655d0a83544aea000dfb321d/Autumn_Statement_2023_Policy_Costings_-_Final.pdf
+          href: https://assets.publishing.service.gov.uk/media/655d0a83544aea000dfb321d/Autumn_Statement_2023_Policy_Costings_-_Final.pdf#page=16
 metadata:
   unit: bool
   label: LHA freeze

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/A.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/A.yaml
@@ -4,13 +4,13 @@ values:
     value: 258.06
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2013
           href: https://www.legislation.gov.uk/uksi/2013/2978/made
   2015-04-01:
     value: 260.64
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2014
           href: https://www.legislation.gov.uk/uksi/2014/3126/made
   2018-04-01:
     value: 268.46
@@ -28,7 +28,7 @@ values:
     value: 295.49
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020
           href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
   2024-04-01:
     value: 331.39

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/A.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/A.yaml
@@ -1,0 +1,20 @@
+description: Maximum weekly Local Housing Allowance for category A dwellings (one bedroom, shared accommodation). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
+values:
+  2011-04-01: 250.0
+  2014-04-01: 258.06
+  2015-04-01: 260.64
+  2018-04-01: 268.46
+  2019-04-01: 276.51
+  2020-04-01: 295.49
+  2024-04-01: 331.39
+metadata:
+  unit: currency-GBP
+  period: week
+  label: Maximum LHA (category A)
+  reference:
+    - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
+      href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+      href: https://www.legislation.gov.uk/uksi/2024/11/made
+    - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
+      href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/A.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/A.yaml
@@ -1,12 +1,41 @@
 description: Maximum weekly Local Housing Allowance for category A dwellings (one bedroom, shared accommodation). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
 values:
-  2011-04-01: 250.0
-  2014-04-01: 258.06
-  2015-04-01: 260.64
-  2018-04-01: 268.46
-  2019-04-01: 276.51
-  2020-04-01: 295.49
-  2024-04-01: 331.39
+  2014-04-01:
+    value: 258.06
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+          href: https://www.legislation.gov.uk/uksi/2013/2978/made
+  2015-04-01:
+    value: 260.64
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+          href: https://www.legislation.gov.uk/uksi/2014/3126/made
+  2018-04-01:
+    value: 268.46
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2017
+          href: https://www.legislation.gov.uk/uksi/2017/1323/made
+  2019-04-01:
+    value: 276.51
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2018
+          href: https://www.legislation.gov.uk/uksi/2018/1332/made
+  2020-04-01:
+    value: 295.49
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 331.39
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
 metadata:
   unit: currency-GBP
   period: week
@@ -14,7 +43,5 @@ metadata:
   reference:
     - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
       href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
-      href: https://www.legislation.gov.uk/uksi/2024/11/made
     - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
       href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/B.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/B.yaml
@@ -4,13 +4,13 @@ values:
     value: 258.06
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2013
           href: https://www.legislation.gov.uk/uksi/2013/2978/made
   2015-04-01:
     value: 260.64
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2014
           href: https://www.legislation.gov.uk/uksi/2014/3126/made
   2018-04-01:
     value: 268.46
@@ -28,7 +28,7 @@ values:
     value: 295.49
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020
           href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
   2024-04-01:
     value: 331.39

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/B.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/B.yaml
@@ -1,0 +1,20 @@
+description: Maximum weekly Local Housing Allowance for category B dwellings (one bedroom, exclusive use). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
+values:
+  2011-04-01: 250.0
+  2014-04-01: 258.06
+  2015-04-01: 260.64
+  2018-04-01: 268.46
+  2019-04-01: 276.51
+  2020-04-01: 295.49
+  2024-04-01: 331.39
+metadata:
+  unit: currency-GBP
+  period: week
+  label: Maximum LHA (category B)
+  reference:
+    - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
+      href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+      href: https://www.legislation.gov.uk/uksi/2024/11/made
+    - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
+      href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/B.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/B.yaml
@@ -1,12 +1,41 @@
 description: Maximum weekly Local Housing Allowance for category B dwellings (one bedroom, exclusive use). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
 values:
-  2011-04-01: 250.0
-  2014-04-01: 258.06
-  2015-04-01: 260.64
-  2018-04-01: 268.46
-  2019-04-01: 276.51
-  2020-04-01: 295.49
-  2024-04-01: 331.39
+  2014-04-01:
+    value: 258.06
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+          href: https://www.legislation.gov.uk/uksi/2013/2978/made
+  2015-04-01:
+    value: 260.64
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+          href: https://www.legislation.gov.uk/uksi/2014/3126/made
+  2018-04-01:
+    value: 268.46
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2017
+          href: https://www.legislation.gov.uk/uksi/2017/1323/made
+  2019-04-01:
+    value: 276.51
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2018
+          href: https://www.legislation.gov.uk/uksi/2018/1332/made
+  2020-04-01:
+    value: 295.49
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 331.39
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
 metadata:
   unit: currency-GBP
   period: week
@@ -14,7 +43,5 @@ metadata:
   reference:
     - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
       href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
-      href: https://www.legislation.gov.uk/uksi/2024/11/made
     - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
       href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/C.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/C.yaml
@@ -1,0 +1,20 @@
+description: Maximum weekly Local Housing Allowance for category C dwellings (two bedrooms). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
+values:
+  2011-04-01: 290.0
+  2014-04-01: 299.34
+  2015-04-01: 302.33
+  2018-04-01: 311.4
+  2019-04-01: 320.74
+  2020-04-01: 365.92
+  2024-04-01: 412.86
+metadata:
+  unit: currency-GBP
+  period: week
+  label: Maximum LHA (category C)
+  reference:
+    - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
+      href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+      href: https://www.legislation.gov.uk/uksi/2024/11/made
+    - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
+      href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/C.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/C.yaml
@@ -1,12 +1,41 @@
 description: Maximum weekly Local Housing Allowance for category C dwellings (two bedrooms). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
 values:
-  2011-04-01: 290.0
-  2014-04-01: 299.34
-  2015-04-01: 302.33
-  2018-04-01: 311.4
-  2019-04-01: 320.74
-  2020-04-01: 365.92
-  2024-04-01: 412.86
+  2014-04-01:
+    value: 299.34
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+          href: https://www.legislation.gov.uk/uksi/2013/2978/made
+  2015-04-01:
+    value: 302.33
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+          href: https://www.legislation.gov.uk/uksi/2014/3126/made
+  2018-04-01:
+    value: 311.4
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2017
+          href: https://www.legislation.gov.uk/uksi/2017/1323/made
+  2019-04-01:
+    value: 320.74
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2018
+          href: https://www.legislation.gov.uk/uksi/2018/1332/made
+  2020-04-01:
+    value: 365.92
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 412.86
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
 metadata:
   unit: currency-GBP
   period: week
@@ -14,7 +43,5 @@ metadata:
   reference:
     - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
       href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
-      href: https://www.legislation.gov.uk/uksi/2024/11/made
     - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
       href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/C.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/C.yaml
@@ -4,13 +4,13 @@ values:
     value: 299.34
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2013
           href: https://www.legislation.gov.uk/uksi/2013/2978/made
   2015-04-01:
     value: 302.33
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2014
           href: https://www.legislation.gov.uk/uksi/2014/3126/made
   2018-04-01:
     value: 311.4
@@ -28,7 +28,7 @@ values:
     value: 365.92
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020
           href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
   2024-04-01:
     value: 412.86

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/D.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/D.yaml
@@ -1,12 +1,41 @@
 description: Maximum weekly Local Housing Allowance for category D dwellings (three bedrooms). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
 values:
-  2011-04-01: 340.0
-  2014-04-01: 350.95
-  2015-04-01: 354.46
-  2018-04-01: 365.09
-  2019-04-01: 376.04
-  2020-04-01: 441.86
-  2024-04-01: 497.1
+  2014-04-01:
+    value: 350.95
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+          href: https://www.legislation.gov.uk/uksi/2013/2978/made
+  2015-04-01:
+    value: 354.46
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+          href: https://www.legislation.gov.uk/uksi/2014/3126/made
+  2018-04-01:
+    value: 365.09
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2017
+          href: https://www.legislation.gov.uk/uksi/2017/1323/made
+  2019-04-01:
+    value: 376.04
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2018
+          href: https://www.legislation.gov.uk/uksi/2018/1332/made
+  2020-04-01:
+    value: 441.86
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 497.1
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
 metadata:
   unit: currency-GBP
   period: week
@@ -14,7 +43,5 @@ metadata:
   reference:
     - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
       href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
-      href: https://www.legislation.gov.uk/uksi/2024/11/made
     - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
       href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/D.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/D.yaml
@@ -1,0 +1,20 @@
+description: Maximum weekly Local Housing Allowance for category D dwellings (three bedrooms). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
+values:
+  2011-04-01: 340.0
+  2014-04-01: 350.95
+  2015-04-01: 354.46
+  2018-04-01: 365.09
+  2019-04-01: 376.04
+  2020-04-01: 441.86
+  2024-04-01: 497.1
+metadata:
+  unit: currency-GBP
+  period: week
+  label: Maximum LHA (category D)
+  reference:
+    - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
+      href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+      href: https://www.legislation.gov.uk/uksi/2024/11/made
+    - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
+      href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/D.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/D.yaml
@@ -4,13 +4,13 @@ values:
     value: 350.95
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2013
           href: https://www.legislation.gov.uk/uksi/2013/2978/made
   2015-04-01:
     value: 354.46
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2014
           href: https://www.legislation.gov.uk/uksi/2014/3126/made
   2018-04-01:
     value: 365.09
@@ -28,7 +28,7 @@ values:
     value: 441.86
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020
           href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
   2024-04-01:
     value: 497.1

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/E.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/E.yaml
@@ -4,13 +4,13 @@ values:
     value: 412.89
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2013
           href: https://www.legislation.gov.uk/uksi/2013/2978/made
   2015-04-01:
     value: 417.02
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2014
           href: https://www.legislation.gov.uk/uksi/2014/3126/made
   2018-04-01:
     value: 429.53
@@ -28,7 +28,7 @@ values:
     value: 593.75
     metadata:
       reference:
-        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020
           href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
   2024-04-01:
     value: 704.22

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/E.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/E.yaml
@@ -1,0 +1,20 @@
+description: Maximum weekly Local Housing Allowance for category E dwellings (four bedrooms). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
+values:
+  2011-04-01: 400.0
+  2014-04-01: 412.89
+  2015-04-01: 417.02
+  2018-04-01: 429.53
+  2019-04-01: 442.42
+  2020-04-01: 593.75
+  2024-04-01: 704.22
+metadata:
+  unit: currency-GBP
+  period: week
+  label: Maximum LHA (category E)
+  reference:
+    - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
+      href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+      href: https://www.legislation.gov.uk/uksi/2024/11/made
+    - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
+      href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/E.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/E.yaml
@@ -1,12 +1,41 @@
 description: Maximum weekly Local Housing Allowance for category E dwellings (four bedrooms). Published LHA rates are the lower of the Broad Rental Market Area percentile and this national cap.
 values:
-  2011-04-01: 400.0
-  2014-04-01: 412.89
-  2015-04-01: 417.02
-  2018-04-01: 429.53
-  2019-04-01: 442.42
-  2020-04-01: 593.75
-  2024-04-01: 704.22
+  2014-04-01:
+    value: 412.89
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2013
+          href: https://www.legislation.gov.uk/uksi/2013/2978/made
+  2015-04-01:
+    value: 417.02
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2014
+          href: https://www.legislation.gov.uk/uksi/2014/3126/made
+  2018-04-01:
+    value: 429.53
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2017
+          href: https://www.legislation.gov.uk/uksi/2017/1323/made
+  2019-04-01:
+    value: 442.42
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2018
+          href: https://www.legislation.gov.uk/uksi/2018/1332/made
+  2020-04-01:
+    value: 593.75
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Regulations 2020
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 704.22
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
 metadata:
   unit: currency-GBP
   period: week
@@ -14,7 +43,5 @@ metadata:
   reference:
     - title: The Rent Officers (Housing Benefit Functions) Order 1997, Schedule 3B
       href: https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024
-      href: https://www.legislation.gov.uk/uksi/2024/11/made
     - title: Valuation Office Agency, Local Housing Allowance rates (Table 3, maximum LHA)
       href: https://www.gov.uk/government/collections/local-housing-allowance-lha-rates

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/index.yaml
@@ -2,5 +2,5 @@ description: National maximum Local Housing Allowance by category of dwelling, a
 metadata:
   label: Maximum LHA
   reference:
-    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2012
+    - title: The Rent Officers (Housing Benefit Functions) Amendment Order 2012
       href: https://www.legislation.gov.uk/uksi/2012/646/made

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/index.yaml
@@ -1,0 +1,3 @@
+description: National maximum Local Housing Allowance by category of dwelling. Introduced in April 2011 and revised periodically; there was no statutory cash cap in 2013-14, when the ceiling was instead a CPI uprating limit.
+metadata:
+  label: Maximum LHA

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum/index.yaml
@@ -1,3 +1,6 @@
-description: National maximum Local Housing Allowance by category of dwelling. Introduced in April 2011 and revised periodically; there was no statutory cash cap in 2013-14, when the ceiling was instead a CPI uprating limit.
+description: National maximum Local Housing Allowance by category of dwelling, applied as an upper bound on the Broad Rental Market Area percentile. The series starts in April 2014. A cash table introduced in April 2011 was removed by SI 2012/646, which replaced it with a CPI uprating limit, so 2013-14 has no statutory cash maximum; those years are outside the range this model supports and are not encoded.
 metadata:
   label: Maximum LHA
+  reference:
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2012
+      href: https://www.legislation.gov.uk/uksi/2012/646/made

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/A.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/A.yaml
@@ -1,0 +1,21 @@
+description: Maximum monthly Local Housing Allowance for category A dwellings (one bedroom, shared accommodation), used for Universal Credit. Set independently of the weekly Housing Benefit maximum rather than derived from it.
+values:
+  2020-04-01:
+    value: 1283.96
+    metadata:
+      reference:
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020, reg. 4(3)(b)
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 1439.97
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024, art. 4(2)(b)
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
+metadata:
+  unit: currency-GBP
+  period: month
+  label: Maximum monthly LHA (category A)
+  reference:
+    - title: The Rent Officers (Universal Credit Functions) Order 2013, Schedule 1
+      href: https://www.legislation.gov.uk/uksi/2013/382/schedule/1

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/B.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/B.yaml
@@ -1,0 +1,21 @@
+description: Maximum monthly Local Housing Allowance for category B dwellings (one bedroom, exclusive use), used for Universal Credit. Set independently of the weekly Housing Benefit maximum rather than derived from it.
+values:
+  2020-04-01:
+    value: 1283.96
+    metadata:
+      reference:
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020, reg. 4(3)(b)
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 1439.97
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024, art. 4(2)(b)
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
+metadata:
+  unit: currency-GBP
+  period: month
+  label: Maximum monthly LHA (category B)
+  reference:
+    - title: The Rent Officers (Universal Credit Functions) Order 2013, Schedule 1
+      href: https://www.legislation.gov.uk/uksi/2013/382/schedule/1

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/C.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/C.yaml
@@ -1,0 +1,21 @@
+description: Maximum monthly Local Housing Allowance for category C dwellings (two bedrooms), used for Universal Credit. Set independently of the weekly Housing Benefit maximum rather than derived from it.
+values:
+  2020-04-01:
+    value: 1589.99
+    metadata:
+      reference:
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020, reg. 4(3)(b)
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 1793.98
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024, art. 4(2)(b)
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
+metadata:
+  unit: currency-GBP
+  period: month
+  label: Maximum monthly LHA (category C)
+  reference:
+    - title: The Rent Officers (Universal Credit Functions) Order 2013, Schedule 1
+      href: https://www.legislation.gov.uk/uksi/2013/382/schedule/1

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/D.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/D.yaml
@@ -1,0 +1,21 @@
+description: Maximum monthly Local Housing Allowance for category D dwellings (three bedrooms), used for Universal Credit. Set independently of the weekly Housing Benefit maximum rather than derived from it.
+values:
+  2020-04-01:
+    value: 1920.0
+    metadata:
+      reference:
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020, reg. 4(3)(b)
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 2160.02
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024, art. 4(2)(b)
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
+metadata:
+  unit: currency-GBP
+  period: month
+  label: Maximum monthly LHA (category D)
+  reference:
+    - title: The Rent Officers (Universal Credit Functions) Order 2013, Schedule 1
+      href: https://www.legislation.gov.uk/uksi/2013/382/schedule/1

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/E.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/E.yaml
@@ -1,0 +1,21 @@
+description: Maximum monthly Local Housing Allowance for category E dwellings (four bedrooms), used for Universal Credit. Set independently of the weekly Housing Benefit maximum rather than derived from it.
+values:
+  2020-04-01:
+    value: 2579.98
+    metadata:
+      reference:
+        - title: The Social Security (Coronavirus) (Further Measures) Regulations 2020, reg. 4(3)(b)
+          href: https://www.legislation.gov.uk/uksi/2020/371/regulation/4/made
+  2024-04-01:
+    value: 3060.0
+    metadata:
+      reference:
+        - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Amendment) Order 2024, art. 4(2)(b)
+          href: https://www.legislation.gov.uk/uksi/2024/11/made
+metadata:
+  unit: currency-GBP
+  period: month
+  label: Maximum monthly LHA (category E)
+  reference:
+    - title: The Rent Officers (Universal Credit Functions) Order 2013, Schedule 1
+      href: https://www.legislation.gov.uk/uksi/2013/382/schedule/1

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/index.yaml
@@ -3,5 +3,5 @@ description: >-
 metadata:
   label: Maximum monthly LHA
   reference:
-    - title: The Rent Officers (Universal Credit Functions) (Amendment) Order 2015 (omitting the maximum for 2016)
+    - title: The Rent Officers (Housing Benefit and Universal Credit Functions) (Local Housing Allowance Amendments) Order 2015 (omitting the maximum for 2016)
       href: https://www.legislation.gov.uk/uksi/2015/1753/made

--- a/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/index.yaml
+++ b/policyengine_uk/parameters/gov/dwp/LHA/maximum_monthly/index.yaml
@@ -1,0 +1,7 @@
+description: >-
+  National maximum monthly Local Housing Allowance by category of dwelling, applied to the Universal Credit housing costs element. These figures are set independently in Schedule 1 to the Rent Officers (Universal Credit Functions) Order 2013 rather than derived from the weekly Housing Benefit maxima, and the two series do not divide evenly. The series starts in April 2020: no monthly maximum existed in 2016, and the 2017 to 2019 caps applied only to the Broad Rental Market Areas listed for targeted affordability funding rather than nationally, so they are not encoded here.
+metadata:
+  label: Maximum monthly LHA
+  reference:
+    - title: The Rent Officers (Universal Credit Functions) (Amendment) Order 2015 (omitting the maximum for 2016)
+      href: https://www.legislation.gov.uk/uksi/2015/1753/made

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/housing_costs_element/uc_housing_costs_element.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/housing_costs_element/uc_housing_costs_element.yaml
@@ -58,7 +58,7 @@
     benunits:
       benunit:
         benunit_rent: 5_000
-        LHA_cap: 6_000
+        uc_LHA_cap: 6_000
         members: person
     households:
       household:
@@ -76,7 +76,7 @@
     benunits:
       benunit:
         benunit_rent: 6_000
-        LHA_cap: 5_000
+        uc_LHA_cap: 5_000
         members: person
     households:
       household:
@@ -95,7 +95,7 @@
       benunit:
         benunit_rent: 6_000
         uc_non_dep_deductions: 10 * 52
-        LHA_cap: 5_000
+        uc_LHA_cap: 5_000
         members: person
     households:
       household:
@@ -114,7 +114,7 @@
       benunit:
         benunit_rent: 1_000
         uc_non_dep_deductions: 2_000
-        LHA_cap: 5_000
+        uc_LHA_cap: 5_000
         members: person
     households:
       household:

--- a/policyengine_uk/tests/policy/integration/entitledto_scenarios.yaml
+++ b/policyengine_uk/tests/policy/integration/entitledto_scenarios.yaml
@@ -30,10 +30,10 @@
   output:
     income_tax: 0
     national_insurance: 0
-    universal_credit: 3_662.72
+    universal_credit: 3_483.32
     housing_benefit: 0
     child_benefit: 0
-    household_net_income: 14_288.18
+    household_net_income: 14_108.78
 
 - name: "EntitledTo #2 - couple with 2 children, one earner at £22k, social housing in North West"
   period: 2025

--- a/policyengine_uk/tests/test_lha_freeze.py
+++ b/policyengine_uk/tests/test_lha_freeze.py
@@ -48,3 +48,49 @@ def test_lha_freeze_changes_lha_rate_and_housing_benefit_entitlement():
 
     assert unfrozen_rate > frozen_rate
     assert unfrozen_entitlement > frozen_entitlement
+
+
+def _lha_rate(year: int, brma: str = "INNER_EAST_LONDON") -> float:
+    """Annual BRMA LHA rate for a single adult renting privately."""
+    situation = {
+        "people": {"person": {"age": {year: 35}}},
+        "benunits": {"benunit": {"members": ["person"]}},
+        "households": {
+            "household": {
+                "members": ["person"],
+                "brma": {year: brma},
+                "tenure_type": {year: "RENT_PRIVATELY"},
+                "rent": {year: 20_000},
+            }
+        },
+    }
+    return float(Simulation(situation=situation).calculate("BRMA_LHA_rate", year)[0])
+
+
+def test_frozen_rates_hold_at_the_last_unfrozen_year():
+    """Frozen LHA rates are held in cash terms, not re-based each year.
+
+    The published rates for 2025/26 and 2026/27 are identical to 2024/25:
+    SI 2025/5 and SI 2026/5 exclude the September 2024 and 2025 evidence and
+    carry the April 2024 determination forward.
+    """
+    reset_2024 = _lha_rate(2024)
+
+    for frozen_year in (2025, 2026, 2027):
+        assert _lha_rate(frozen_year) == reset_2024, (
+            f"{frozen_year} should hold the April 2024 rate"
+        )
+
+
+def test_the_2020_freeze_holds_at_the_2020_reset():
+    """April 2020 was itself a reset, with the freeze running from April 2021."""
+    reset_2020 = _lha_rate(2020)
+
+    for frozen_year in (2021, 2022, 2023):
+        assert _lha_rate(frozen_year) == reset_2020, (
+            f"{frozen_year} should hold the April 2020 rate"
+        )
+
+
+def test_the_2024_reset_raises_rates_above_the_2020_freeze():
+    assert _lha_rate(2024) > _lha_rate(2023)

--- a/policyengine_uk/tests/test_lha_freeze.py
+++ b/policyengine_uk/tests/test_lha_freeze.py
@@ -1,5 +1,7 @@
 """Regression tests for the LHA freeze parameter."""
 
+import pytest
+
 from policyengine_uk import Simulation
 
 
@@ -94,3 +96,51 @@ def test_the_2020_freeze_holds_at_the_2020_reset():
 
 def test_the_2024_reset_raises_rates_above_the_2020_freeze():
     assert _lha_rate(2024) > _lha_rate(2023)
+
+
+def _weekly_rate(year: int, brma: str, category: str, reform=None) -> float:
+    situation = {
+        "people": {"person": {"age": {year: 35}}},
+        "benunits": {
+            "benunit": {"members": ["person"], "LHA_category": {year: category}}
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "brma": {year: brma},
+                "tenure_type": {year: "RENT_PRIVATELY"},
+                "rent": {year: 100_000},
+            }
+        },
+    }
+    annual = Simulation(situation=situation, reform=reform).calculate(
+        "BRMA_LHA_rate", year
+    )[0]
+    return float(annual) / 52
+
+
+def test_a_reset_year_is_not_treated_as_a_hold():
+    """2020 was a reset, so its rate comes from 2020 rents, not earlier ones.
+
+    Asserting only that the frozen years equal 2020 would still pass if 2020
+    were itself wrongly marked frozen, because every compared year would then
+    move together. Comparing against that mutation is what catches it.
+    """
+    reset = _weekly_rate(2020, "MAIDSTONE", "C")
+    held_instead = _weekly_rate(
+        2020, "MAIDSTONE", "C", reform={"gov.dwp.LHA.freeze": {"2020": True}}
+    )
+
+    assert reset == pytest.approx(187.91, abs=0.01)
+    assert held_instead != pytest.approx(reset, abs=0.01)
+
+
+def test_frozen_years_hold_the_reset_level_for_an_uncapped_area():
+    """The national maximum never binds in Maidstone, so this isolates the
+    freeze from the cap."""
+    reset = _weekly_rate(2020, "MAIDSTONE", "C")
+
+    for frozen_year in (2021, 2022, 2023):
+        assert _weekly_rate(frozen_year, "MAIDSTONE", "C") == pytest.approx(
+            reset, abs=0.01
+        )

--- a/policyengine_uk/tests/test_lha_maximum.py
+++ b/policyengine_uk/tests/test_lha_maximum.py
@@ -51,3 +51,36 @@ def test_capped_rates_match_published(brma, category, published, year):
 def test_cap_does_not_bind_below_the_percentile():
     """Category A in central London is set by the percentile, not the cap."""
     assert _weekly_rate(2024, "CENTRAL_LONDON", "A") < 331.39
+
+
+def test_a_later_cap_change_cannot_move_a_frozen_rate():
+    """Frozen rates are held at the level last determined.
+
+    Every input to the determination — including the national maximum — is
+    therefore read at the determination year, so changing a cap in a frozen
+    year must leave the rate alone.
+    """
+    situation = {
+        "people": {"person": {"age": {2025: 35}}},
+        "benunits": {"benunit": {"members": ["person"], "LHA_category": {2025: "B"}}},
+        "households": {
+            "household": {
+                "members": ["person"],
+                "brma": {2025: "CENTRAL_LONDON"},
+                "tenure_type": {2025: "RENT_PRIVATELY"},
+                "rent": {2025: 100_000},
+            }
+        },
+    }
+
+    def weekly(reform):
+        annual = Simulation(situation=situation, reform=reform).calculate(
+            "BRMA_LHA_rate", 2025
+        )[0]
+        return float(annual) / 52
+
+    baseline = weekly(None)
+    slashed = weekly({"gov.dwp.LHA.maximum.B": {"2025": 100}})
+
+    assert baseline == pytest.approx(331.39, abs=0.01)
+    assert slashed == pytest.approx(baseline, abs=0.01)

--- a/policyengine_uk/tests/test_lha_maximum.py
+++ b/policyengine_uk/tests/test_lha_maximum.py
@@ -1,0 +1,53 @@
+"""The national maximum LHA caps the BRMA percentile.
+
+Published LHA rates are the lower of the Broad Rental Market Area percentile
+and the national maximum for the category (Rent Officers (Housing Benefit
+Functions) Order 1997, Schedule 3B). The cap binds in central London, so
+those published rates are a direct test of it.
+"""
+
+import pytest
+
+from policyengine_uk import Simulation
+
+
+# Weekly published rates for 2024/25, which SI 2025/5 and SI 2026/5 carry
+# forward unchanged into 2025/26 and 2026/27.
+CAPPED_RATES = [
+    ("CENTRAL_LONDON", "B", 331.39),
+    ("CENTRAL_LONDON", "C", 412.86),
+    ("CENTRAL_LONDON", "D", 497.10),
+    ("CENTRAL_LONDON", "E", 704.22),
+    ("INNER_EAST_LONDON", "B", 331.39),
+    ("INNER_EAST_LONDON", "D", 497.10),
+]
+
+
+def _weekly_rate(year: int, brma: str, category: str) -> float:
+    situation = {
+        "people": {"person": {"age": {year: 35}}},
+        "benunits": {
+            "benunit": {"members": ["person"], "LHA_category": {year: category}}
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "brma": {year: brma},
+                "tenure_type": {year: "RENT_PRIVATELY"},
+                "rent": {year: 100_000},
+            }
+        },
+    }
+    annual = Simulation(situation=situation).calculate("BRMA_LHA_rate", year)[0]
+    return float(annual) / 52
+
+
+@pytest.mark.parametrize("brma,category,published", CAPPED_RATES)
+@pytest.mark.parametrize("year", [2024, 2025, 2026])
+def test_capped_rates_match_published(brma, category, published, year):
+    assert _weekly_rate(year, brma, category) == pytest.approx(published, abs=0.01)
+
+
+def test_cap_does_not_bind_below_the_percentile():
+    """Category A in central London is set by the percentile, not the cap."""
+    assert _weekly_rate(2024, "CENTRAL_LONDON", "A") < 331.39

--- a/policyengine_uk/tests/test_lha_maximum.py
+++ b/policyengine_uk/tests/test_lha_maximum.py
@@ -48,9 +48,41 @@ def test_capped_rates_match_published(brma, category, published, year):
     assert _weekly_rate(year, brma, category) == pytest.approx(published, abs=0.01)
 
 
+def _weekly_rate_under(reform, year, brma, category):
+    situation = {
+        "people": {"person": {"age": {year: 35}}},
+        "benunits": {
+            "benunit": {"members": ["person"], "LHA_category": {year: category}}
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "brma": {year: brma},
+                "tenure_type": {year: "RENT_PRIVATELY"},
+                "rent": {year: 100_000},
+            }
+        },
+    }
+    annual = Simulation(situation=situation, reform=reform).calculate(
+        "BRMA_LHA_rate", year
+    )[0]
+    return float(annual) / 52
+
+
 def test_cap_does_not_bind_below_the_percentile():
-    """Category A in central London is set by the percentile, not the cap."""
-    assert _weekly_rate(2024, "CENTRAL_LONDON", "A") < 331.39
+    """Category A in central London is set by the percentile, not the cap.
+
+    Asserting only that the rate is under the cap would also pass if the cap
+    were wrongly binding at some lower figure, so this compares against the
+    rate with the cap lifted out of the way.
+    """
+    rate = _weekly_rate(2024, "CENTRAL_LONDON", "A")
+    uncapped = _weekly_rate_under(
+        {"gov.dwp.LHA.maximum.A": {"2024": 100_000}}, 2024, "CENTRAL_LONDON", "A"
+    )
+
+    assert rate == pytest.approx(uncapped, abs=0.01)
+    assert rate < 331.39
 
 
 def test_a_later_cap_change_cannot_move_a_frozen_rate():

--- a/policyengine_uk/tests/test_lha_uc_maximum.py
+++ b/policyengine_uk/tests/test_lha_uc_maximum.py
@@ -23,26 +23,29 @@ BINDING_MONTHLY_MAXIMA = {
 }
 
 
-def _simulation(rent: float, category: str):
-    situation = {
-        "people": {"person": {"age": {YEAR: 40}, "employment_income": {YEAR: 20_000}}},
+def _situation(rent: float, category: str, year: int = YEAR):
+    return {
+        "people": {"person": {"age": {year: 40}, "employment_income": {year: 20_000}}},
         "benunits": {
             "benunit": {
                 "members": ["person"],
-                "LHA_category": {YEAR: category},
-                "would_claim_uc": {YEAR: True},
+                "LHA_category": {year: category},
+                "would_claim_uc": {year: True},
             }
         },
         "households": {
             "household": {
                 "members": ["person"],
-                "brma": {YEAR: "CENTRAL_LONDON"},
-                "tenure_type": {YEAR: "RENT_PRIVATELY"},
-                "rent": {YEAR: rent},
+                "brma": {year: "CENTRAL_LONDON"},
+                "tenure_type": {year: "RENT_PRIVATELY"},
+                "rent": {year: rent},
             }
         },
     }
-    return Simulation(situation=situation)
+
+
+def _simulation(rent: float, category: str, year: int = YEAR, reform=None):
+    return Simulation(situation=_situation(rent, category, year), reform=reform)
 
 
 @pytest.mark.parametrize("category,monthly", BINDING_MONTHLY_MAXIMA.items())
@@ -70,10 +73,21 @@ def test_uc_covers_rent_below_the_ceiling():
 
 
 def test_a_rate_below_the_ceiling_is_not_raised_to_it():
-    """Central London category A is set by the percentile, not the maximum."""
-    housing = _simulation(50_000, "A").calculate("uc_housing_costs_element", YEAR)[0]
+    """Central London category A is set by the percentile, not the maximum.
 
-    assert float(housing) < 1_439.97 * 12
+    Asserting only that the result is under the ceiling would also pass if it
+    were zero or wrongly low, so this compares against the same case with the
+    monthly maximum lifted out of the way.
+    """
+    housing = _simulation(50_000, "A").calculate("uc_housing_costs_element", YEAR)[0]
+    unlimited = _simulation(
+        50_000,
+        "A",
+        reform={"gov.dwp.LHA.maximum_monthly.A": {str(YEAR): 100_000}},
+    ).calculate("uc_housing_costs_element", YEAR)[0]
+
+    assert float(housing) == pytest.approx(float(unlimited), abs=0.01)
+    assert 0 < float(housing) < 1_439.97 * 12
 
 
 def test_housing_benefit_keeps_the_weekly_maximum():
@@ -81,3 +95,28 @@ def test_housing_benefit_keeps_the_weekly_maximum():
     rate = _simulation(50_000, "E").calculate("BRMA_LHA_rate", YEAR)[0]
 
     assert float(rate) / 52 == pytest.approx(704.22, abs=0.01)
+
+
+def test_the_monthly_maximum_does_not_apply_before_it_existed():
+    """The monthly series starts in April 2020.
+
+    Parameters are backdated to 2015 on load, so without an explicit gate the
+    2020 maximum would apply to earlier years, where it is far above the
+    figures actually in force. Before the series starts, Universal Credit
+    falls back to the weekly Housing Benefit rate.
+    """
+    simulation = _simulation(50_000, "E", year=2019)
+    housing = simulation.calculate("uc_housing_costs_element", 2019)[0]
+    weekly_rate = simulation.calculate("BRMA_LHA_rate", 2019)[0]
+
+    assert float(housing) == pytest.approx(float(weekly_rate), abs=0.01)
+    assert float(housing) < 2_579.98 * 12
+
+
+def test_the_monthly_maximum_applies_from_2020():
+    """The 2019/2020 boundary: 2020 uses the monthly maximum, 2019 does not."""
+    housing_2020 = _simulation(50_000, "E", year=2020).calculate(
+        "uc_housing_costs_element", 2020
+    )[0]
+
+    assert float(housing_2020) == pytest.approx(2_579.98 * 12, abs=0.01)

--- a/policyengine_uk/tests/test_lha_uc_maximum.py
+++ b/policyengine_uk/tests/test_lha_uc_maximum.py
@@ -1,0 +1,83 @@
+"""Universal Credit applies its own monthly national maximum LHA.
+
+The monthly figures in Schedule 1 to the Rent Officers (Universal Credit
+Functions) Order 2013 are set independently of the weekly Housing Benefit
+maxima, and are slightly higher. Annualising the weekly figure would impose a
+ceiling below the statutory one.
+"""
+
+import pytest
+
+from policyengine_uk import Simulation
+
+YEAR = 2024
+
+# SI 2024/11, article 4(2)(b). Category A is omitted because central
+# London's shared-accommodation percentile sits well below its maximum, so
+# the ceiling never binds there; it is covered separately below.
+BINDING_MONTHLY_MAXIMA = {
+    "B": 1_439.97,
+    "C": 1_793.98,
+    "D": 2_160.02,
+    "E": 3_060.00,
+}
+
+
+def _simulation(rent: float, category: str):
+    situation = {
+        "people": {"person": {"age": {YEAR: 40}, "employment_income": {YEAR: 20_000}}},
+        "benunits": {
+            "benunit": {
+                "members": ["person"],
+                "LHA_category": {YEAR: category},
+                "would_claim_uc": {YEAR: True},
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "brma": {YEAR: "CENTRAL_LONDON"},
+                "tenure_type": {YEAR: "RENT_PRIVATELY"},
+                "rent": {YEAR: rent},
+            }
+        },
+    }
+    return Simulation(situation=situation)
+
+
+@pytest.mark.parametrize("category,monthly", BINDING_MONTHLY_MAXIMA.items())
+def test_uc_ceiling_is_the_statutory_monthly_maximum(category, monthly):
+    """Rent above the ceiling is covered only up to twelve monthly maxima."""
+    ceiling = monthly * 12
+    housing = _simulation(ceiling + 10_000, category).calculate(
+        "uc_housing_costs_element", YEAR
+    )[0]
+
+    assert float(housing) == pytest.approx(ceiling, abs=0.01)
+
+
+def test_uc_covers_rent_below_the_ceiling():
+    """Rent under the ceiling but over the annualised weekly cap is covered.
+
+    Category E's weekly maximum annualises to £36,619.44, below the statutory
+    monthly ceiling of £36,720, so this rent is the case that distinguishes
+    the two.
+    """
+    rent = 36_670
+    housing = _simulation(rent, "E").calculate("uc_housing_costs_element", YEAR)[0]
+
+    assert float(housing) == pytest.approx(rent, abs=0.01)
+
+
+def test_a_rate_below_the_ceiling_is_not_raised_to_it():
+    """Central London category A is set by the percentile, not the maximum."""
+    housing = _simulation(50_000, "A").calculate("uc_housing_costs_element", YEAR)[0]
+
+    assert float(housing) < 1_439.97 * 12
+
+
+def test_housing_benefit_keeps_the_weekly_maximum():
+    """The Housing Benefit rate is unaffected by the monthly UC maximum."""
+    rate = _simulation(50_000, "E").calculate("BRMA_LHA_rate", YEAR)[0]
+
+    assert float(rate) / 52 == pytest.approx(704.22, abs=0.01)

--- a/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
+++ b/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
@@ -55,6 +55,16 @@ class BRMA_LHA_rate(Variable):
         lha_rates_df = lha_rates.reset_index()
         lha_rates_df.columns = ["brma", "lha_category", "weekly_rent"]
 
+        # Published rates are the lower of the BRMA percentile and the
+        # national maximum LHA for the category (Rent Officers Order 1997,
+        # Schedule 3B). The cap binds in central London.
+        maximum = lha.maximum
+        caps = {cat: maximum.children[cat](period) for cat in maximum.children}
+        lha_rates_df.weekly_rent = np.minimum(
+            lha_rates_df.weekly_rent,
+            lha_rates_df.lha_category.map(caps),
+        )
+
         lha_lookup_table = pd.DataFrame(
             {
                 "brma": brma,

--- a/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
+++ b/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
@@ -10,11 +10,33 @@ from policyengine_uk.variables.gov.dwp.LHA_category import (
 warnings.filterwarnings("ignore")
 
 
-class BRMA_LHA_rate(Variable):
+MONTHS_IN_YEAR = 12
+
+
+def _category_maximum(benunit, period, node_name: str):
+    """Per-category national maximum, read at the determination year.
+
+    Frozen rates are held at the level last determined, so the maximum in
+    force then is the one that binds, not the current year's.
+    """
+    lha = benunit.simulation.tax_benefit_system.parameters.gov.dwp.LHA
+
+    if lha.freeze(period):
+        determination_period = find_freeze_start(lha.freeze, period.start)[:4]
+    else:
+        determination_period = str(period.start.year)
+
+    node = getattr(lha, node_name)
+    category = benunit("LHA_category", period).decode_to_str()
+    caps = {cat: node.children[cat](determination_period) for cat in node.children}
+    return pd.Series(category).map(caps).to_numpy(dtype=float)
+
+
+class uncapped_BRMA_LHA_rate(Variable):
     value_type = float
     entity = BenUnit
-    label = "LHA rate"
-    documentation = "Local Housing Allowance rate"
+    label = "Uncapped LHA rate"
+    documentation = "Local Housing Allowance rate before the national maximum"
     definition_period = YEAR
     unit = GBP
 
@@ -58,23 +80,13 @@ class BRMA_LHA_rate(Variable):
         lha_rates_df = lha_rates.reset_index()
         lha_rates_df.columns = ["brma", "lha_category", "weekly_rent"]
 
-        # Published rates are the lower of the BRMA percentile and the
-        # national maximum LHA for the category (Rent Officers Order 1997,
-        # Schedule 3B). The cap binds in central London. It is read at the
-        # determination year so that a later change cannot move a rate that
-        # is being held in cash terms.
-        maximum = lha.maximum
-        caps = {
-            cat: maximum.children[cat](determination_period) for cat in maximum.children
-        }
-        lha_rates_df.weekly_rent = np.minimum(
-            lha_rates_df.weekly_rent,
-            lha_rates_df.lha_category.map(caps),
-        )
-
         # Determined rates are rounded to the nearest penny, half up
-        # (Schedule 3B paragraph 2(10)); np.round is half-even.
-        lha_rates_df.weekly_rent = np.floor(lha_rates_df.weekly_rent * 100 + 0.5) / 100
+        # (Schedule 3B paragraph 2(10)); np.round is half-even. Pence are
+        # snapped to 6dp first, because an exact half such as 298.835 is
+        # held as 29883.499999999996 once scaled and would round down.
+        lha_rates_df.weekly_rent = (
+            np.floor(np.round(lha_rates_df.weekly_rent * 100, 6) + 0.5) / 100
+        )
 
         lha_lookup_table = pd.DataFrame(
             {
@@ -87,3 +99,46 @@ class BRMA_LHA_rate(Variable):
             lha_rates_df, on=["brma", "lha_category"], how="left"
         )
         return lha_lookup_table.weekly_rent.values * 52
+
+
+class BRMA_LHA_rate(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "LHA rate"
+    documentation = "Local Housing Allowance rate, capped at the national maximum"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        """The published Housing Benefit rate.
+
+        Rates are the lower of the Broad Rental Market Area percentile and the
+        weekly national maximum for the category (Rent Officers (Housing
+        Benefit Functions) Order 1997, Schedule 3B). Universal Credit has its
+        own monthly maximum: see ``uc_LHA_cap``.
+        """
+        rate = benunit("uncapped_BRMA_LHA_rate", period)
+        maximum = _category_maximum(benunit, period, "maximum")
+        return min_(rate, maximum * 52)
+
+
+class uc_LHA_cap(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Applicable amount for LHA under Universal Credit"
+    documentation = "Rent covered by the Local Housing Allowance for Universal Credit"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        """Universal Credit applies a monthly national maximum.
+
+        The monthly figures in Schedule 1 to the Rent Officers (Universal
+        Credit Functions) Order 2013 are set independently of the weekly
+        Housing Benefit maxima and are slightly higher, so annualising the
+        weekly figure would impose a ceiling below the statutory one.
+        """
+        rent = benunit("benunit_rent", period)
+        rate = benunit("uncapped_BRMA_LHA_rate", period)
+        maximum = _category_maximum(benunit, period, "maximum_monthly")
+        return min_(rent, min_(rate, maximum * MONTHS_IN_YEAR))

--- a/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
+++ b/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
@@ -3,102 +3,12 @@ import pandas as pd
 import warnings
 from policyengine_core.model_api import *
 from policyengine_uk.variables.gov.dwp.LHA_category import (
-    find_freeze_start,
-    time_shift_dataset,
+    category_maximum,
+    MONTHS_IN_YEAR,
+    MONTHLY_MAXIMUM_FIRST_YEAR,
 )
 
 warnings.filterwarnings("ignore")
-
-
-MONTHS_IN_YEAR = 12
-
-
-def _category_maximum(benunit, period, node_name: str):
-    """Per-category national maximum, read at the determination year.
-
-    Frozen rates are held at the level last determined, so the maximum in
-    force then is the one that binds, not the current year's.
-    """
-    lha = benunit.simulation.tax_benefit_system.parameters.gov.dwp.LHA
-
-    if lha.freeze(period):
-        determination_period = find_freeze_start(lha.freeze, period.start)[:4]
-    else:
-        determination_period = str(period.start.year)
-
-    node = getattr(lha, node_name)
-    category = benunit("LHA_category", period).decode_to_str()
-    caps = {cat: node.children[cat](determination_period) for cat in node.children}
-    return pd.Series(category).map(caps).to_numpy(dtype=float)
-
-
-class uncapped_BRMA_LHA_rate(Variable):
-    value_type = float
-    entity = BenUnit
-    label = "Uncapped LHA rate"
-    documentation = "Local Housing Allowance rate before the national maximum"
-    definition_period = YEAR
-    unit = GBP
-
-    def formula(benunit, period, parameters):
-        brma = benunit.value_from_first_person(
-            benunit.members.household("brma", period).decode_to_str()
-        )
-        category = benunit("LHA_category", period).decode_to_str()
-
-        from policyengine_uk.parameters.gov.dwp.LHA import lha_list_of_rents
-
-        parameters = benunit.simulation.tax_benefit_system.parameters
-        lha = parameters.gov.dwp.LHA
-
-        # We first need to know what time period to collect rents from. If LHA is frozen, we need to look earlier
-        # than the current time period.
-
-        frozen = lha.freeze(period)
-        if frozen:
-            # Rates are held at the level last determined, so every input to
-            # the determination is read at that year, not the current one.
-            freeze_start = find_freeze_start(lha.freeze, period.start)
-            lha_period = int(freeze_start[:4])  # Get year
-        else:
-            lha_period = int(period.start.year)
-
-        determination_period = str(lha_period)
-
-        private_rent_index = parameters.gov.indices.private_rent_index
-        lha_list_of_rents = time_shift_dataset(
-            lha_list_of_rents.copy(), lha_period, private_rent_index
-        )
-
-        percentile = lha.percentile(determination_period)
-
-        lha_rates = lha_list_of_rents.groupby(
-            ["brma", "lha_category"]
-        ).weekly_rent.quantile(percentile)
-
-        # Convert MultiIndex Series to DataFrame for merge
-        lha_rates_df = lha_rates.reset_index()
-        lha_rates_df.columns = ["brma", "lha_category", "weekly_rent"]
-
-        # Determined rates are rounded to the nearest penny, half up
-        # (Schedule 3B paragraph 2(10)); np.round is half-even. Pence are
-        # snapped to 6dp first, because an exact half such as 298.835 is
-        # held as 29883.499999999996 once scaled and would round down.
-        lha_rates_df.weekly_rent = (
-            np.floor(np.round(lha_rates_df.weekly_rent * 100, 6) + 0.5) / 100
-        )
-
-        lha_lookup_table = pd.DataFrame(
-            {
-                "brma": brma,
-                "lha_category": category,
-            }
-        )
-        # Use merge instead of row-by-row apply for vectorised lookup
-        lha_lookup_table = lha_lookup_table.merge(
-            lha_rates_df, on=["brma", "lha_category"], how="left"
-        )
-        return lha_lookup_table.weekly_rent.values * 52
 
 
 class BRMA_LHA_rate(Variable):
@@ -118,27 +28,5 @@ class BRMA_LHA_rate(Variable):
         own monthly maximum: see ``uc_LHA_cap``.
         """
         rate = benunit("uncapped_BRMA_LHA_rate", period)
-        maximum = _category_maximum(benunit, period, "maximum")
+        maximum = category_maximum(benunit, period, "maximum")
         return min_(rate, maximum * 52)
-
-
-class uc_LHA_cap(Variable):
-    value_type = float
-    entity = BenUnit
-    label = "Applicable amount for LHA under Universal Credit"
-    documentation = "Rent covered by the Local Housing Allowance for Universal Credit"
-    definition_period = YEAR
-    unit = GBP
-
-    def formula(benunit, period, parameters):
-        """Universal Credit applies a monthly national maximum.
-
-        The monthly figures in Schedule 1 to the Rent Officers (Universal
-        Credit Functions) Order 2013 are set independently of the weekly
-        Housing Benefit maxima and are slightly higher, so annualising the
-        weekly figure would impose a ceiling below the statutory one.
-        """
-        rent = benunit("benunit_rent", period)
-        rate = benunit("uncapped_BRMA_LHA_rate", period)
-        maximum = _category_maximum(benunit, period, "maximum_monthly")
-        return min_(rent, min_(rate, maximum * MONTHS_IN_YEAR))

--- a/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
+++ b/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
@@ -34,18 +34,21 @@ class BRMA_LHA_rate(Variable):
 
         frozen = lha.freeze(period)
         if frozen:
-            # Find the first year of the current freeze
+            # Rates are held at the level last determined, so every input to
+            # the determination is read at that year, not the current one.
             freeze_start = find_freeze_start(lha.freeze, period.start)
             lha_period = int(freeze_start[:4])  # Get year
         else:
             lha_period = int(period.start.year)
+
+        determination_period = str(lha_period)
 
         private_rent_index = parameters.gov.indices.private_rent_index
         lha_list_of_rents = time_shift_dataset(
             lha_list_of_rents.copy(), lha_period, private_rent_index
         )
 
-        percentile = lha.percentile(period)
+        percentile = lha.percentile(determination_period)
 
         lha_rates = lha_list_of_rents.groupby(
             ["brma", "lha_category"]
@@ -57,13 +60,21 @@ class BRMA_LHA_rate(Variable):
 
         # Published rates are the lower of the BRMA percentile and the
         # national maximum LHA for the category (Rent Officers Order 1997,
-        # Schedule 3B). The cap binds in central London.
+        # Schedule 3B). The cap binds in central London. It is read at the
+        # determination year so that a later change cannot move a rate that
+        # is being held in cash terms.
         maximum = lha.maximum
-        caps = {cat: maximum.children[cat](period) for cat in maximum.children}
+        caps = {
+            cat: maximum.children[cat](determination_period) for cat in maximum.children
+        }
         lha_rates_df.weekly_rent = np.minimum(
             lha_rates_df.weekly_rent,
             lha_rates_df.lha_category.map(caps),
         )
+
+        # Determined rates are rounded to the nearest penny, half up
+        # (Schedule 3B paragraph 2(10)); np.round is half-even.
+        lha_rates_df.weekly_rent = np.floor(lha_rates_df.weekly_rent * 100 + 0.5) / 100
 
         lha_lookup_table = pd.DataFrame(
             {

--- a/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
+++ b/policyengine_uk/variables/gov/dwp/BRMA_LHA_rate.py
@@ -4,7 +4,6 @@ import warnings
 from policyengine_core.model_api import *
 from policyengine_uk.variables.gov.dwp.LHA_category import (
     category_maximum,
-    MONTHS_IN_YEAR,
     MONTHLY_MAXIMUM_FIRST_YEAR,
 )
 
@@ -18,6 +17,7 @@ class BRMA_LHA_rate(Variable):
     documentation = "Local Housing Allowance rate, capped at the national maximum"
     definition_period = YEAR
     unit = GBP
+    reference = "https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B"
 
     def formula(benunit, period, parameters):
         """The published Housing Benefit rate.

--- a/policyengine_uk/variables/gov/dwp/LHA_category.py
+++ b/policyengine_uk/variables/gov/dwp/LHA_category.py
@@ -87,49 +87,37 @@ def time_shift_dataset(
 
 
 def find_freeze_start(freeze_parameter: Parameter, period: str) -> str:
-    """Finds the start instant of the current freeze period containing the given period.
+    """Finds the instant whose rents a frozen LHA rate should be based on.
 
-    The function works backwards from the given period to find when the current freeze
-    started. It looks for the most recent transition from false->true (unfreeze->freeze).
+    Frozen rates are held in cash terms at the level set in the most recent
+    year in which LHA was *not* frozen, so this returns the start instant of
+    the latest unfrozen period before the given period.
 
     Args:
         freeze_parameter (Parameter): The LHA freeze parameter.
         period (str): The period to search up to.
 
     Returns:
-        str: The instant when the current freeze period started, or None if not frozen.
+        str: The instant of the latest unfrozen period, or None if not frozen.
     """
-    # Get all parameter values that are <= the requested period
-    values_list = freeze_parameter.values_list
-    relevant_values = [v for v in values_list if v.instant_str <= str(period)]
+    # Values at or before the requested period, newest first.
+    relevant_values = [
+        v for v in freeze_parameter.values_list if v.instant_str <= str(period)
+    ]
 
     if not relevant_values:
         return None
 
-    # Check if the period is currently frozen
-    # relevant_values is in reverse chronological order (newest first)
-    current_state = relevant_values[0].value
-
-    if not current_state:
-        # Not currently frozen
+    if not relevant_values[0].value:
+        # Not currently frozen.
         return None
 
-    # Work from most recent backwards to find when this freeze started
-    # List is in reverse chronological order: [newest...oldest]
-    # Example: [('2026', True), ('2025', True), ('2024', False), ('2023', True)]
-    # Find the earliest True in the current frozen period
-    for i in range(len(relevant_values)):
-        current_value = relevant_values[i]
+    # Walk back to the most recent value that is False; the rates in force
+    # during the freeze are the ones determined in that year.
+    for value in relevant_values:
+        if not value.value:
+            return value.instant_str
 
-        if current_value.value:  # This is a freeze=True value
-            # Check if the chronologically earlier period (i+1) was unfrozen
-            if i == len(relevant_values) - 1:
-                # This is the oldest value and it's frozen - use it
-                return current_value.instant_str
-            elif not relevant_values[i + 1].value:
-                # The chronologically earlier value was False
-                # This is where the freeze period started
-                return current_value.instant_str
-            # Otherwise the earlier value was also True, so continue backwards
-
-    return None
+    # Frozen for the whole of the parameter's history; fall back to the
+    # oldest value available.
+    return relevant_values[-1].instant_str

--- a/policyengine_uk/variables/gov/dwp/LHA_category.py
+++ b/policyengine_uk/variables/gov/dwp/LHA_category.py
@@ -121,3 +121,33 @@ def find_freeze_start(freeze_parameter: Parameter, period: str) -> str:
     # Frozen for the whole of the parameter's history; fall back to the
     # oldest value available.
     return relevant_values[-1].instant_str
+
+
+MONTHS_IN_YEAR = 12
+
+# Universal Credit's monthly national maximum is only modelled from April
+# 2020. No monthly maximum existed in 2016, and the 2017 to 2019 figures were
+# targeted affordability caps applying to listed areas rather than nationally.
+# Parameters are backdated to 2015 on load, so the series has to be gated
+# here: omitting the early YAML entries does not stop the lookup returning
+# the 2020 figure for earlier years.
+MONTHLY_MAXIMUM_FIRST_YEAR = 2020
+
+
+def category_maximum(benunit, period, node_name: str):
+    """Per-category national maximum, read at the determination year.
+
+    Frozen rates are held at the level last determined, so the maximum in
+    force then is the one that binds, not the current year's.
+    """
+    lha = benunit.simulation.tax_benefit_system.parameters.gov.dwp.LHA
+
+    if lha.freeze(period):
+        determination_period = find_freeze_start(lha.freeze, period.start)[:4]
+    else:
+        determination_period = str(period.start.year)
+
+    node = getattr(lha, node_name)
+    category = benunit("LHA_category", period).decode_to_str()
+    caps = {cat: node.children[cat](determination_period) for cat in node.children}
+    return pd.Series(category).map(caps).to_numpy(dtype=float)

--- a/policyengine_uk/variables/gov/dwp/LHA_category.py
+++ b/policyengine_uk/variables/gov/dwp/LHA_category.py
@@ -86,7 +86,7 @@ def time_shift_dataset(
     return df
 
 
-def find_freeze_start(freeze_parameter: Parameter, period: str) -> str:
+def find_freeze_anchor(freeze_parameter: Parameter, period: str) -> str:
     """Finds the instant whose rents a frozen LHA rate should be based on.
 
     Frozen rates are held in cash terms at the level set in the most recent
@@ -123,8 +123,6 @@ def find_freeze_start(freeze_parameter: Parameter, period: str) -> str:
     return relevant_values[-1].instant_str
 
 
-MONTHS_IN_YEAR = 12
-
 # Universal Credit's monthly national maximum is only modelled from April
 # 2020. No monthly maximum existed in 2016, and the 2017 to 2019 figures were
 # targeted affordability caps applying to listed areas rather than nationally.
@@ -143,7 +141,7 @@ def category_maximum(benunit, period, node_name: str):
     lha = benunit.simulation.tax_benefit_system.parameters.gov.dwp.LHA
 
     if lha.freeze(period):
-        determination_period = find_freeze_start(lha.freeze, period.start)[:4]
+        determination_period = find_freeze_anchor(lha.freeze, period.start)[:4]
     else:
         determination_period = str(period.start.year)
 

--- a/policyengine_uk/variables/gov/dwp/uc_LHA_cap.py
+++ b/policyengine_uk/variables/gov/dwp/uc_LHA_cap.py
@@ -1,0 +1,39 @@
+from policyengine_uk.model_api import *
+import pandas as pd
+import warnings
+from policyengine_core.model_api import *
+from policyengine_uk.variables.gov.dwp.LHA_category import (
+    category_maximum,
+    MONTHS_IN_YEAR,
+    MONTHLY_MAXIMUM_FIRST_YEAR,
+)
+
+warnings.filterwarnings("ignore")
+
+
+class uc_LHA_cap(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Applicable amount for LHA under Universal Credit"
+    documentation = "Rent covered by the Local Housing Allowance for Universal Credit"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        """Universal Credit applies a monthly national maximum.
+
+        The monthly figures in Schedule 1 to the Rent Officers (Universal
+        Credit Functions) Order 2013 are set independently of the weekly
+        Housing Benefit maxima and are slightly higher, so annualising the
+        weekly figure would impose a ceiling below the statutory one.
+        """
+        rent = benunit("benunit_rent", period)
+
+        if period.start.year < MONTHLY_MAXIMUM_FIRST_YEAR:
+            # Before the monthly series begins, fall back to the weekly
+            # Housing Benefit rate, as the model did previously.
+            return min_(rent, benunit("BRMA_LHA_rate", period))
+
+        rate = benunit("uncapped_BRMA_LHA_rate", period)
+        maximum = category_maximum(benunit, period, "maximum_monthly")
+        return min_(rent, min_(rate, maximum * MONTHS_IN_YEAR))

--- a/policyengine_uk/variables/gov/dwp/uc_LHA_cap.py
+++ b/policyengine_uk/variables/gov/dwp/uc_LHA_cap.py
@@ -4,7 +4,6 @@ import warnings
 from policyengine_core.model_api import *
 from policyengine_uk.variables.gov.dwp.LHA_category import (
     category_maximum,
-    MONTHS_IN_YEAR,
     MONTHLY_MAXIMUM_FIRST_YEAR,
 )
 
@@ -18,6 +17,7 @@ class uc_LHA_cap(Variable):
     documentation = "Rent covered by the Local Housing Allowance for Universal Credit"
     definition_period = YEAR
     unit = GBP
+    reference = "https://www.legislation.gov.uk/uksi/2013/382/schedule/1"
 
     def formula(benunit, period, parameters):
         """Universal Credit applies a monthly national maximum.

--- a/policyengine_uk/variables/gov/dwp/uncapped_BRMA_LHA_rate.py
+++ b/policyengine_uk/variables/gov/dwp/uncapped_BRMA_LHA_rate.py
@@ -1,0 +1,79 @@
+from policyengine_uk.model_api import *
+import pandas as pd
+import warnings
+from policyengine_core.model_api import *
+from policyengine_uk.variables.gov.dwp.LHA_category import (
+    find_freeze_start,
+    time_shift_dataset,
+)
+
+warnings.filterwarnings("ignore")
+
+
+class uncapped_BRMA_LHA_rate(Variable):
+    value_type = float
+    entity = BenUnit
+    label = "Uncapped LHA rate"
+    documentation = "Local Housing Allowance rate before the national maximum"
+    definition_period = YEAR
+    unit = GBP
+
+    def formula(benunit, period, parameters):
+        brma = benunit.value_from_first_person(
+            benunit.members.household("brma", period).decode_to_str()
+        )
+        category = benunit("LHA_category", period).decode_to_str()
+
+        from policyengine_uk.parameters.gov.dwp.LHA import lha_list_of_rents
+
+        parameters = benunit.simulation.tax_benefit_system.parameters
+        lha = parameters.gov.dwp.LHA
+
+        # We first need to know what time period to collect rents from. If LHA is frozen, we need to look earlier
+        # than the current time period.
+
+        frozen = lha.freeze(period)
+        if frozen:
+            # Rates are held at the level last determined, so every input to
+            # the determination is read at that year, not the current one.
+            freeze_start = find_freeze_start(lha.freeze, period.start)
+            lha_period = int(freeze_start[:4])  # Get year
+        else:
+            lha_period = int(period.start.year)
+
+        determination_period = str(lha_period)
+
+        private_rent_index = parameters.gov.indices.private_rent_index
+        lha_list_of_rents = time_shift_dataset(
+            lha_list_of_rents.copy(), lha_period, private_rent_index
+        )
+
+        percentile = lha.percentile(determination_period)
+
+        lha_rates = lha_list_of_rents.groupby(
+            ["brma", "lha_category"]
+        ).weekly_rent.quantile(percentile)
+
+        # Convert MultiIndex Series to DataFrame for merge
+        lha_rates_df = lha_rates.reset_index()
+        lha_rates_df.columns = ["brma", "lha_category", "weekly_rent"]
+
+        # Determined rates are rounded to the nearest penny, half up
+        # (Schedule 3B paragraph 2(10)); np.round is half-even. Pence are
+        # snapped to 6dp first, because an exact half such as 298.835 is
+        # held as 29883.499999999996 once scaled and would round down.
+        lha_rates_df.weekly_rent = (
+            np.floor(np.round(lha_rates_df.weekly_rent * 100, 6) + 0.5) / 100
+        )
+
+        lha_lookup_table = pd.DataFrame(
+            {
+                "brma": brma,
+                "lha_category": category,
+            }
+        )
+        # Use merge instead of row-by-row apply for vectorised lookup
+        lha_lookup_table = lha_lookup_table.merge(
+            lha_rates_df, on=["brma", "lha_category"], how="left"
+        )
+        return lha_lookup_table.weekly_rent.values * 52

--- a/policyengine_uk/variables/gov/dwp/uncapped_BRMA_LHA_rate.py
+++ b/policyengine_uk/variables/gov/dwp/uncapped_BRMA_LHA_rate.py
@@ -3,7 +3,7 @@ import pandas as pd
 import warnings
 from policyengine_core.model_api import *
 from policyengine_uk.variables.gov.dwp.LHA_category import (
-    find_freeze_start,
+    find_freeze_anchor,
     time_shift_dataset,
 )
 
@@ -17,6 +17,7 @@ class uncapped_BRMA_LHA_rate(Variable):
     documentation = "Local Housing Allowance rate before the national maximum"
     definition_period = YEAR
     unit = GBP
+    reference = "https://www.legislation.gov.uk/uksi/1997/1984/schedule/3B"
 
     def formula(benunit, period, parameters):
         brma = benunit.value_from_first_person(
@@ -36,8 +37,8 @@ class uncapped_BRMA_LHA_rate(Variable):
         if frozen:
             # Rates are held at the level last determined, so every input to
             # the determination is read at that year, not the current one.
-            freeze_start = find_freeze_start(lha.freeze, period.start)
-            lha_period = int(freeze_start[:4])  # Get year
+            freeze_anchor = find_freeze_anchor(lha.freeze, period.start)
+            lha_period = int(freeze_anchor[:4])  # Get year
         else:
             lha_period = int(period.start.year)
 

--- a/policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/uc_housing_costs_element.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/uc_housing_costs_element.py
@@ -14,7 +14,9 @@ class uc_housing_costs_element(Variable):
         )
         tenure_types = tenure_type.possible_values
         rent = benunit("benunit_rent", period)
-        rent_cap = benunit("LHA_cap", period)
+        # Universal Credit has its own monthly national maximum, which is
+        # set independently of the weekly Housing Benefit one.
+        rent_cap = benunit("uc_LHA_cap", period)
         capped_rent_amount = min_(rent_cap, rent)
         max_housing_costs = select(
             [


### PR DESCRIPTION
Closes #1842. Closes #1843.

Two defects in the LHA rate, both verified against the gazetted VOA tables.

### 1. The national maximum was not applied

Published rates are `min(BRMA percentile, national maximum)` — Schedule 3B of the Rent Officers (Housing Benefit Functions) Order 1997, published as Table 3 of the VOA workbooks. We applied no cap, so wherever it binds we were far too generous.

Weekly, 2024/25:

| BRMA | cat | published | before | after |
|---|---|---|---|---|
| Central London | B | 331.39 | 455.91 | **331.39** |
| Central London | C | 412.86 | 621.38 | **412.86** |
| Central London | D | 497.10 | 868.77 | **497.10** |
| Central London | E | 704.22 | 1131.63 | **704.22** |
| Inner East London | B | 331.39 | 348.57 | **331.39** |
| Inner East London | D | 497.10 | 526.14 | **497.10** |

Adds `gov.dwp.LHA.maximum` (categories A–E, weekly), sourced from the amending SIs and cross-checked against Table 3 of the 2020/21 through 2026/27 workbooks. Note category A's cap equals category B's and has never bound anywhere.

### 2. Frozen rates were re-based each freeze instead of held

When frozen, `BRMA_LHA_rate` rebuilt the rate from rents indexed to `find_freeze_start`, the first year of the current freeze. For the freeze from April 2025 that meant 2025 rents — but SI 2025/5 and SI 2026/5 carry the April 2024 determination forward, and the published tables are byte-identical across 2024/25, 2025/26 and 2026/27. Every rate was 3.40% high, in every forecast year, since the parameter runs to 2041.

Inner East London category B, annual:

```
          before        after
2024   18,125.64    18,125.64
2025   18,741.84    18,125.64
2026   18,741.84    18,125.64
2027   18,741.84    18,125.64
```

Fixing this needs the parameter re-dated too, not just the lookup. `freeze.yaml` had `2020-01-01: true`, but April 2020 was itself a reset to the 30th percentile with the freeze running from April 2021 — so reading the anchor from the first frozen year was right for 2020–23 only by coincidence. Both changes are needed:

| | 2020–23 | 2025–27 |
|---|---|---|
| old YAML + first frozen year | correct | wrong (anchors 2025) |
| old YAML + last unfrozen year | wrong (anchors 2019) | correct |
| new YAML + last unfrozen year | correct | correct |

### Tests

`test_lha_maximum.py` asserts the six capped London rates against the published figures for 2024, 2025 and 2026, plus one case where the cap does not bind. `test_lha_freeze.py` gains assertions that frozen years equal their last determination, using the gazetted cross-year equality as the fixture.

Full suite: 199 passed, 44 skipped.

### Deliberately out of scope

- **The rents base.** `lha_list_of_rents.csv.gz` holds only 2019 and 2020 and is uprated by a single UK-wide index, so local rent divergence since 2020 is lost. Mean absolute error against the published tables was 15.1% before this PR; the cap removes the London overstatement but understatements remain — Greater Glasgow category E is −41%, Bristol E −18%. Left in #1842 for a data refresh.
- **The `A`/`B` relationship.** Durham publishes category B equal to category A; we produce B below A. I could not establish the statutory rule with confidence, so I have not guessed at it.
- **The minimum LHA** inserted by SI 2024/11 (no rate below its 31 March 2020 level) is not modelled.
