### PR TITLE
Warn instead of silently mislabelling a dataset's fiscal year

### DIFF
--- a/changelog.d/dataset-fiscal-year-default.md
+++ b/changelog.d/dataset-fiscal-year-default.md
@@ -1,0 +1,1 @@
+- Warned when `UKSingleYearDataset` is given a `fiscal_year` alongside a file path, where it cannot take effect, and when it is built from DataFrames without one.

--- a/policyengine_uk/data/dataset_schema.py
+++ b/policyengine_uk/data/dataset_schema.py
@@ -1,3 +1,4 @@
+import warnings
 import pandas as pd
 import numpy as np
 from typing import TYPE_CHECKING
@@ -40,16 +41,28 @@ class UKSingleYearDataset:
 
         return True
 
+    # Used when a dataset is built from DataFrames without a fiscal year.
+    # Deprecated: pass fiscal_year explicitly, as this will become required.
+    DEFAULT_FISCAL_YEAR = 2025
+
     def __init__(
         self,
         file_path: str = None,
         person: pd.DataFrame = None,
         benunit: pd.DataFrame = None,
         household: pd.DataFrame = None,
-        fiscal_year: int = 2025,
+        fiscal_year: int = None,
     ):
         file_path = str(file_path) if file_path else None
         if file_path is not None:
+            if fiscal_year is not None:
+                warnings.warn(
+                    "fiscal_year is ignored when loading from a file: the "
+                    "time period is read from the file itself. Drop the "
+                    "argument, or use uprate_dataset to change the period.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             self.validate_file_path(file_path)
             with pd.HDFStore(file_path) as f:
                 self._person = f["person"]
@@ -61,6 +74,17 @@ class UKSingleYearDataset:
                 raise ValueError(
                     "Must provide either a file path or all three DataFrames (person, benunit, household)."
                 )
+            if fiscal_year is None:
+                warnings.warn(
+                    "fiscal_year was not given, so this dataset is labelled "
+                    f"{self.DEFAULT_FISCAL_YEAR}. The label is the year the "
+                    "financial year starts, so FRS 2024/25 data is 2024. "
+                    "Pass fiscal_year explicitly; the default will be "
+                    "removed.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                fiscal_year = self.DEFAULT_FISCAL_YEAR
             self._person = person
             self._benunit = benunit
             self._household = household

--- a/policyengine_uk/tests/test_dataset_fiscal_year.py
+++ b/policyengine_uk/tests/test_dataset_fiscal_year.py
@@ -1,0 +1,66 @@
+"""`fiscal_year` labelling on UKSingleYearDataset.
+
+The year label is the year the financial year starts, so FRS 2024/25 data
+is labelled 2024. A dataset loaded from a file takes its period from the
+file; one built from DataFrames takes it from the argument.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from policyengine_uk.data.dataset_schema import UKSingleYearDataset
+
+
+@pytest.fixture
+def frames():
+    person = pd.DataFrame(
+        {"person_id": [1], "person_benunit_id": [1], "person_household_id": [1]}
+    )
+    benunit = pd.DataFrame({"benunit_id": [1]})
+    household = pd.DataFrame({"household_id": [1]})
+    return person, benunit, household
+
+
+def test_fiscal_year_sets_the_time_period(frames):
+    person, benunit, household = frames
+    dataset = UKSingleYearDataset(
+        person=person, benunit=benunit, household=household, fiscal_year=2024
+    )
+    assert dataset.time_period == "2024"
+
+
+def test_omitting_fiscal_year_warns(frames):
+    person, benunit, household = frames
+    with pytest.warns(DeprecationWarning, match="fiscal_year was not given"):
+        dataset = UKSingleYearDataset(
+            person=person, benunit=benunit, household=household
+        )
+    assert dataset.time_period == str(UKSingleYearDataset.DEFAULT_FISCAL_YEAR)
+
+
+def test_fiscal_year_alongside_a_file_path_warns(tmp_path, frames):
+    person, benunit, household = frames
+    file_path = tmp_path / "dataset.h5"
+    UKSingleYearDataset(
+        person=person, benunit=benunit, household=household, fiscal_year=2024
+    ).save(file_path)
+
+    with pytest.warns(UserWarning, match="ignored when loading from a file"):
+        dataset = UKSingleYearDataset(file_path=file_path, fiscal_year=2030)
+
+    # The file's own period wins, so the ignored argument cannot mislabel it.
+    assert dataset.time_period == "2024"
+
+
+def test_loading_without_fiscal_year_does_not_warn(tmp_path, frames):
+    person, benunit, household = frames
+    file_path = tmp_path / "dataset.h5"
+    UKSingleYearDataset(
+        person=person, benunit=benunit, household=household, fiscal_year=2024
+    ).save(file_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert UKSingleYearDataset(file_path=file_path).time_period == "2024"


### PR DESCRIPTION
Closes #1845.

`UKSingleYearDataset.__init__` declared `fiscal_year: int = 2025` but used it on only one of its two branches, so both halves failed quietly.

**Ignored alongside a file path.** With `file_path`, the period comes from the file and the argument was discarded without comment:

```
frs_2024_25.h5                     -> time_period = 2024
  same file with fiscal_year=2030  -> time_period = 2024   (silently ignored)
```

**A hardcoded default that drifts.** Building from DataFrames without it labelled the data 2025 — already a year ahead of the newest release, since FRS 2024/25 is label 2024 on our convention, and wrong differently every year:

```
UKSingleYearDataset(person=..., benunit=..., household=...)  -> 2025
```

This came up with an external collaborator who was labelling 2024/25 data as 2025 and reasonably assumed the argument did something.

### This PR

`fiscal_year` now defaults to `None`, and both silent paths warn:

- passing it with `file_path` raises a `UserWarning` saying it cannot take effect, and points at `uprate_dataset` for changing the period;
- omitting it on the DataFrame branch raises a `DeprecationWarning` naming the label it fell back to and restating the convention.

Behaviour is otherwise unchanged: the fallback still yields 2025, kept as `DEFAULT_FISCAL_YEAR`. Nothing we ship is affected — `create_frs` passes `fiscal_year` at all three construction sites.

### Why deprecate rather than require

Making `fiscal_year` mandatory is the better end state, but it breaks any caller relying on the default, so I have not done it here. If you would rather take the break now, say and I will switch the `DeprecationWarning` to a `ValueError` — it is a two-line change and the tests already cover both paths.

### Tests

`test_dataset_fiscal_year.py`: the argument sets the period; omitting it warns and falls back; passing it with a file path warns and the file's period still wins; loading normally warns about nothing.

Full suite: 1,140 yaml policy tests and 181 pytest (44 skipped), ruff clean.
