### PR TITLE
Fix Universal Credit claimant and qualifying-child roles

### DIFF
--- a/changelog.d/uc-claimant-relationships.added.md
+++ b/changelog.d/uc-claimant-relationships.added.md
@@ -1,0 +1,1 @@
+- Added the is_uc_claimant input to identify Universal Credit claimants and partners from recorded benefit-unit relationships.

--- a/changelog.d/uc-claimant-relationships.fixed.md
+++ b/changelog.d/uc-claimant-relationships.fixed.md
@@ -1,1 +1,1 @@
-- Fixed Universal Credit claimant classification and work allowances for families with qualifying young people, and excluded claimants from their own child element and two-child-limit counts.
+- Fixed Universal Credit claimant classification and work allowances for families with qualifying young people, and excluded claimants from their own ordinary and disability child elements and two-child-limit counts.

--- a/changelog.d/uc-claimant-relationships.fixed.md
+++ b/changelog.d/uc-claimant-relationships.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Universal Credit claimant classification and work allowances for families with qualifying young people, and excluded claimants from their own child element and two-child-limit counts.

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/child_qualifying_young_person.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/child_qualifying_young_person.yaml
@@ -175,6 +175,7 @@
     people:
       parent:
         age: 40
+        is_parent: true
       looked_after_child:
         age: 12
         is_looked_after_by_local_authority: true

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/child_element/disability/uc_individual_disabled_child_element.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/child_element/disability/uc_individual_disabled_child_element.yaml
@@ -3,6 +3,19 @@
   absolute_error_margin: 100
   input:
     age: 6
+    is_uc_claimant: false
     is_disabled_for_benefits: true
   output:
     uc_individual_disabled_child_element: 1_902
+
+- name: Case 2, an explicit young claimant receives no disabled child addition for themselves.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    age: 18
+    is_in_non_advanced_education: true
+    is_uc_claimant: true
+    is_disabled_for_benefits: true
+  output:
+    is_child_or_qualifying_young_person_for_universal_credit: true
+    uc_individual_disabled_child_element: 0

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/child_element/disability/uc_individual_severely_disabled_child_element.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/child_element/disability/uc_individual_severely_disabled_child_element.yaml
@@ -3,6 +3,18 @@
   absolute_error_margin: 100
   input:
     age: 6
+    is_uc_claimant: false
     is_severely_disabled_for_benefits: true
   output:
     uc_individual_severely_disabled_child_element: 5_942
+
+- name: Case 2, a fallback young claimant receives no severe child addition for themselves.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    age: 18
+    is_in_non_advanced_education: true
+    is_severely_disabled_for_benefits: true
+  output:
+    is_uc_claimant: true
+    uc_individual_severely_disabled_child_element: 0

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_child_element.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_child_element.yaml
@@ -1,0 +1,99 @@
+# The UC child element is for a claimant's dependent child, not the claimant.
+# In 2025 the under-25 single allowance is 316.98 * 12 = 3,803.76;
+# the amount per child born after April 2017 is 292.81 * 12 = 3,513.72.
+
+- name: Case 1, an explicitly identified young claimant is not their own child.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 18
+        is_in_non_advanced_education: true
+        is_uc_claimant: true
+    benunits:
+      benunit:
+        members: [person1]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1]
+  output:
+    # The age/education predicate remains unchanged; claim roles exclude it
+    # from UC child amounts without redefining qualification for other uses.
+    is_child_or_qualifying_young_person_for_universal_credit: true
+    uc_child_index: -1
+    uc_individual_child_element: 0
+    uc_is_child_limit_affected: false
+    uc_work_allowance: 0
+    universal_credit: 3_803.76
+
+# No is_uc_claimant input: evaluating final UC and child ordering exercises
+# the fallback through the QYP predicate and detects any dependency cycle.
+- name: Case 2, a young parent inferred from source roles receives one child element.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 18
+        is_benunit_head: true
+        is_parent: true
+        is_in_non_advanced_education: true
+      person2:
+        age: 1
+        is_benunit_head: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    is_uc_claimant: [true, false]
+    uc_child_index: [-1, 1]
+    uc_individual_child_element: [0, 3_513.72]
+    uc_is_child_limit_affected: [false, false]
+    uc_work_allowance: 8_208
+    universal_credit: 7_317.48
+
+- name: Case 3, a young claimant does not use a place under the two-child limit.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 18
+        is_benunit_head: true
+        is_parent: true
+        is_in_non_advanced_education: true
+      person2:
+        age: 3
+        is_benunit_head: false
+      person3:
+        age: 2
+        is_benunit_head: false
+      person4:
+        age: 1
+        is_benunit_head: false
+    benunits:
+      benunit:
+        members: [person1, person2, person3, person4]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+  output:
+    is_uc_claimant: [true, false, false, false]
+    uc_child_index: [-1, 1, 2, 3]
+    uc_individual_child_element: [0, 3_513.72, 3_513.72, 0]
+    uc_is_child_limit_affected: [false, false, false, true]
+    uc_child_element: 7_027.44
+    universal_credit: 10_831.20

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_child_element.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_child_element.yaml
@@ -97,3 +97,36 @@
     uc_is_child_limit_affected: [false, false, false, true]
     uc_child_element: 7_027.44
     universal_credit: 10_831.20
+
+- name: Case 4, disabled dependent additions remain payable beyond the ordinary child limit.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_parent: true
+      person2:
+        age: 7
+      person3:
+        age: 6
+      person4:
+        age: 4
+        is_disabled_for_benefits: true
+      person5:
+        age: 2
+        is_severely_disabled_for_benefits: true
+    benunits:
+      benunit:
+        members: [person1, person2, person3, person4, person5]
+        uc_LCWRA_element: 0
+  output:
+    # Reg. 24(2) disabled-child additions are separate from the ordinary limit.
+    # 2025 monthly additions: 158.76 * 12 = 1,905.12; 495.87 * 12 = 5,950.44.
+    is_uc_claimant: [true, false, false, false, false]
+    uc_child_index: [-1, 1, 2, 3, 4]
+    uc_individual_child_element: [0, 3_513.72, 3_513.72, 0, 0]
+    uc_is_child_limit_affected: [false, false, false, true, true]
+    uc_individual_disabled_child_element: [0, 0, 0, 1_905.12, 0]
+    uc_individual_severely_disabled_child_element: [0, 0, 0, 0, 5_950.44]
+    uc_disability_elements: 7_855.56

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_relationships.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_relationships.yaml
@@ -181,3 +181,35 @@
     uc_work_allowance: 0
     uc_child_element: 0
     universal_credit: 4_801.68
+
+- name: Case 7, a cohabiting 19-year-old in education is not the partner's child.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 24
+      person2:
+        age: 19
+        is_in_non_advanced_education: true
+        age_started_or_accepted_current_education_or_training: 18
+        is_before_universal_credit_qualifying_young_person_terminal_date: true
+    benunits:
+      benunit:
+        members: [person1, person2]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    # No role or marriage inputs: two claimants under 25, no dependent children.
+    # The 2025 monthly couple allowance is 497.55; 497.55 * 12 = 5,970.60.
+    is_uc_claimant: [true, true]
+    uc_standard_allowance_claimant_type: COUPLE_YOUNG
+    uc_standard_allowance: 5_970.60
+    uc_child_index: [-1, -1]
+    uc_child_element: 0
+    uc_work_allowance: 0
+    universal_credit: 5_970.60

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_relationships.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/claimant_relationships.yaml
@@ -1,0 +1,183 @@
+# Regulations 22 and 36 of SI 2013/376 distinguish claimants from the
+# children or qualifying young people for whom they are responsible.
+# 2025 annual amounts: single 25+ = 400.14 * 12; couple under 25 =
+# 497.55 * 12; first child born before April 2017 = 339 * 12.
+# With no housing, the work allowance is 684 * 12. On 12,000 earnings
+# below the tax/NI thresholds, the UC reduction is (12,000 - 8,208) * 0.55.
+
+- name: Case 1, lone parent with an 18-year-old qualifying young person.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 12_000
+        is_benunit_head: true
+        is_parent: true
+      person2:
+        age: 18
+        is_benunit_head: false
+        is_in_non_advanced_education: true
+    benunits:
+      benunit:
+        members: [person1, person2]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    uc_standard_allowance_claimant_type: SINGLE_OLD
+    uc_standard_allowance: 4_801.68
+    uc_work_allowance: 8_208
+    uc_child_element: 4_068
+    universal_credit: 6_784.08
+
+- name: Case 2, lone parent with a 19-year-old before the qualifying terminal date.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 12_000
+        is_benunit_head: true
+        is_parent: true
+      person2:
+        age: 19
+        is_benunit_head: false
+        is_in_non_advanced_education: true
+        age_started_or_accepted_current_education_or_training: 18
+        is_before_universal_credit_qualifying_young_person_terminal_date: true
+    benunits:
+      benunit:
+        members: [person1, person2]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    uc_standard_allowance_claimant_type: SINGLE_OLD
+    uc_standard_allowance: 4_801.68
+    uc_work_allowance: 8_208
+    uc_child_element: 4_068
+    universal_credit: 6_784.08
+
+- name: Case 3, genuine couple with an older qualifying child remains a couple.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 12_000
+        is_benunit_head: true
+        is_parent: true
+      person2:
+        age: 39
+        is_benunit_head: false
+        is_parent: true
+      person3:
+        age: 18
+        is_benunit_head: false
+        is_in_non_advanced_education: true
+    benunits:
+      benunit:
+        members: [person1, person2, person3]
+        is_married: false
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2, person3]
+  output:
+    uc_standard_allowance_claimant_type: COUPLE_OLD
+    uc_standard_allowance: 7_537.20
+    uc_work_allowance: 8_208
+    universal_credit: 9_519.60
+
+- name: Case 4, cohabiting young claimants do not need a marriage input.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 24
+      person2:
+        age: 23
+    benunits:
+      benunit:
+        members: [person1, person2]
+        is_married: false
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    uc_standard_allowance_claimant_type: COUPLE_YOUNG
+    uc_standard_allowance: 5_970.60
+    uc_work_allowance: 0
+    universal_credit: 5_970.60
+
+# The existing eligibility formula excludes all under-18 claimants. This case
+# fixes claimant classification only; it does not implement the legal exceptions.
+- name: Case 5, an under-18 parent is not a couple because adult count is zero.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 17
+        is_benunit_head: true
+        is_parent: true
+      person2:
+        age: 1
+        is_benunit_head: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    uc_standard_allowance_claimant_type: SINGLE_YOUNG
+    uc_standard_allowance: 3_803.76
+    universal_credit: 0
+
+- name: Case 6, retained nonqualifying child roles do not imply a partner.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_uc_claimant: true
+      person2:
+        age: 19
+        is_uc_claimant: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+        uc_reported_capital: 0
+        uc_latent_deduction_rate: 0
+        benefit_cap_reduction: 0
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    # The generic family variable deliberately retains its existing semantics.
+    family_type: COUPLE_NO_CHILDREN
+    uc_standard_allowance_claimant_type: SINGLE_OLD
+    uc_standard_allowance: 4_801.68
+    uc_work_allowance: 0
+    uc_child_element: 0
+    universal_credit: 4_801.68

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_uc_claimant.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_uc_claimant.yaml
@@ -76,3 +76,20 @@
     is_in_non_advanced_education: true
   output:
     is_uc_claimant: true
+
+- name: Case 6, an older member without qualifying education remains an adult fallback.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_parent: true
+      person2:
+        age: 18
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    # The default education input does not establish an older dependent QYP.
+    is_child_or_qualifying_young_person_for_universal_credit: [false, false]
+    is_uc_claimant: [true, true]

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_uc_claimant.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/is_uc_claimant.yaml
@@ -1,0 +1,78 @@
+- name: Case 1, fallback distinguishes two parents and an older qualifying child.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_parent: true
+      person2:
+        age: 39
+        is_parent: true
+      person3:
+        age: 18
+        is_in_non_advanced_education: true
+    benunits:
+      benunit:
+        members: [person1, person2, person3]
+  output:
+    is_uc_claimant: [true, true, false]
+
+- name: Case 2, one supplied parent flag does not erase a genuine adult partner.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_parent: true
+      person2:
+        age: 39
+      person3:
+        age: 5
+    benunits:
+      benunit:
+        members: [person1, person2, person3]
+  output:
+    is_uc_claimant: [true, true, false]
+
+- name: Case 3, an identified young parent remains a claimant while in education.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 18
+        is_parent: true
+        is_in_non_advanced_education: true
+      person2:
+        age: 25
+        is_parent: true
+      person3:
+        age: 1
+    benunits:
+      benunit:
+        members: [person1, person2, person3]
+  output:
+    is_uc_claimant: [true, true, false]
+
+- name: Case 4, explicit source roles override an age-only fallback.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_uc_claimant: true
+      person2:
+        age: 19
+        is_uc_claimant: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    is_uc_claimant: [true, false]
+
+- name: Case 5, the head of a young person's own benefit unit is a claimant.
+  period: 2025
+  input:
+    age: 17
+    is_in_non_advanced_education: true
+  output:
+    is_uc_claimant: true

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/standard_allowance/uc_standard_allowance_claimant_type.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/standard_allowance/uc_standard_allowance_claimant_type.yaml
@@ -1,32 +1,48 @@
 - name: Single under 25
   period: 2025
   input:
-    eldest_adult_age: 24
-    is_single: true
+    age: 24
+    is_uc_claimant: true
   output:
     uc_standard_allowance_claimant_type: SINGLE_YOUNG
 
 - name: Single over 25
   period: 2025
   input:
-    eldest_adult_age: 25
-    is_single: true
+    age: 25
+    is_uc_claimant: true
   output:
     uc_standard_allowance_claimant_type: SINGLE_OLD
 
 - name: Couple under 25
   period: 2025
   input:
-    eldest_adult_age: 24
-    is_single: false
+    people:
+      person1:
+        age: 24
+        is_uc_claimant: true
+      person2:
+        age: 24
+        is_uc_claimant: true
+    benunits:
+      benunit:
+        members: [person1, person2]
   output:
     uc_standard_allowance_claimant_type: COUPLE_YOUNG
 
 - name: Couple over 25
   period: 2025
   input:
-    eldest_adult_age: 25
-    is_single: false
+    people:
+      person1:
+        age: 24
+        is_uc_claimant: true
+      person2:
+        age: 25
+        is_uc_claimant: true
+    benunits:
+      benunit:
+        members: [person1, person2]
   output:
     uc_standard_allowance_claimant_type: COUPLE_OLD
 
@@ -36,14 +52,13 @@
     people:   
       person1:
         age: 24
-        is_adult: true
+        is_uc_claimant: true
       person2:
         age: 25
-        is_adult: true
+        is_uc_claimant: true
     benunits:
       benunit:
         members: [person1, person2]
-        is_single: false
   output:
     uc_standard_allowance_claimant_type: COUPLE_OLD
 
@@ -53,13 +68,12 @@
     people:   
       person1:
         age: 24
-        is_adult: true
+        is_uc_claimant: true
       person2:
         age: 24
-        is_adult: true
+        is_uc_claimant: true
     benunits:
       benunit:
         members: [person1, person2]
-        is_single: false
   output:
     uc_standard_allowance_claimant_type: COUPLE_YOUNG

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/work_allowance/is_uc_work_allowance_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/work_allowance/is_uc_work_allowance_eligible.yaml
@@ -78,3 +78,41 @@
         members: [person1, person2]
   output:
     is_uc_work_allowance_eligible: false
+
+- name: Case 6, a nonqualifying 16-year-old does not create a work allowance.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_parent: true
+        uc_limited_capability_for_WRA: false
+      person2:
+        age: 16
+        is_in_non_advanced_education: false
+        is_in_approved_training: false
+        uc_limited_capability_for_WRA: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    is_uc_work_allowance_eligible: false
+
+- name: Case 7, a looked-after child does not create a work allowance.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_parent: true
+        uc_limited_capability_for_WRA: false
+      person2:
+        age: 5
+        is_looked_after_by_local_authority: true
+        uc_limited_capability_for_WRA: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    is_child_or_qualifying_young_person_for_universal_credit: [false, false]
+    is_uc_work_allowance_eligible: false

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/work_allowance/is_uc_work_allowance_eligible.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit/work_allowance/is_uc_work_allowance_eligible.yaml
@@ -3,11 +3,11 @@
   input:
     people:   
       person1:
+        age: 40
         uc_limited_capability_for_WRA: false
-        is_child: false
       person2:
+        age: 5
         uc_limited_capability_for_WRA: false
-        is_child: true
     benunits:
       benunit:
         members: [person1, person2]
@@ -19,11 +19,60 @@
   input:
     people:   
       person1:
+        age: 40
         uc_limited_capability_for_WRA: false
-        is_child: false
       person2:
+        age: 39
         uc_limited_capability_for_WRA: false
-        is_child: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    is_uc_work_allowance_eligible: false
+
+- name: Case 3, a young claimant is not their own dependent child.
+  period: 2025
+  input:
+    age: 17
+    is_benunit_head: true
+    is_in_non_advanced_education: true
+    uc_limited_capability_for_WRA: false
+  output:
+    is_uc_work_allowance_eligible: false
+
+- name: Case 4, a nonqualifying 17-year-old does not create a work allowance.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_uc_claimant: true
+        uc_limited_capability_for_WRA: false
+      person2:
+        age: 17
+        is_uc_claimant: false
+        is_in_non_advanced_education: false
+        is_in_approved_training: false
+        uc_limited_capability_for_WRA: false
+    benunits:
+      benunit:
+        members: [person1, person2]
+  output:
+    is_uc_work_allowance_eligible: false
+
+- name: Case 5, an explicitly identified young partner is not a dependent child.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 22
+        is_uc_claimant: true
+        uc_limited_capability_for_WRA: false
+      person2:
+        age: 18
+        is_uc_claimant: true
+        is_in_non_advanced_education: true
+        uc_limited_capability_for_WRA: false
     benunits:
       benunit:
         members: [person1, person2]

--- a/policyengine_uk/variables/gov/dwp/universal_credit/child_element/disability/severe_disability/uc_individual_severely_disabled_child_element.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/child_element/disability/severe_disability/uc_individual_severely_disabled_child_element.py
@@ -8,10 +8,11 @@ class uc_individual_severely_disabled_child_element(Variable):
     definition_period = YEAR
     unit = GBP
     defined_for = "is_severely_disabled_for_benefits"
+    reference = "https://www.legislation.gov.uk/uksi/2013/376/regulation/24/2"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.dwp.universal_credit.elements.child.severely_disabled
         child = person(
             "is_child_or_qualifying_young_person_for_universal_credit", period
-        )
+        ) & ~person("is_uc_claimant", period)
         return (child * p.amount) * MONTHS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/universal_credit/child_element/disability/uc_individual_disabled_child_element.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/child_element/disability/uc_individual_disabled_child_element.py
@@ -8,10 +8,11 @@ class uc_individual_disabled_child_element(Variable):
     definition_period = YEAR
     unit = GBP
     defined_for = "is_disabled_for_benefits"
+    reference = "https://www.legislation.gov.uk/uksi/2013/376/regulation/24/2"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.dwp.universal_credit.elements.child.disabled
         child = person(
             "is_child_or_qualifying_young_person_for_universal_credit", period
-        )
+        ) & ~person("is_uc_claimant", period)
         return (child * p.amount) * MONTHS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/universal_credit/child_element/uc_child_index.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/child_element/uc_child_index.py
@@ -6,12 +6,16 @@ class uc_child_index(Variable):
     entity = Person
     label = "Universal Credit child reference number"
     definition_period = YEAR
-    reference = "https://www.legislation.gov.uk/uksi/2013/376/regulation/24A"
+    reference = (
+        "https://www.legislation.gov.uk/uksi/2013/376/regulation/24",
+        "https://www.legislation.gov.uk/uksi/2013/376/regulation/24A",
+        "https://www.gov.uk/universal-credit/what-youll-get",
+    )
 
     def formula(person, period, parameters):
         is_uc_child = person(
             "is_child_or_qualifying_young_person_for_universal_credit", period
-        )
+        ) & ~person("is_uc_claimant", period)
         child_ranking = (
             person.get_rank(
                 person.benunit,

--- a/policyengine_uk/variables/gov/dwp/universal_credit/child_element/uc_is_child_limit_affected.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/child_element/uc_is_child_limit_affected.py
@@ -7,10 +7,12 @@ class uc_is_child_limit_affected(Variable):
     definition_period = YEAR
     value_type = float
     unit = GBP
+    reference = "https://www.legislation.gov.uk/uksi/2013/376/regulation/24A"
 
     def formula(person, period, parameters):
         return (
             (person("uc_individual_child_element", period) == 0)
             & person("is_child_or_qualifying_young_person_for_universal_credit", period)
+            & ~person("is_uc_claimant", period)
             & (person.benunit("universal_credit", period) > 0)
         )

--- a/policyengine_uk/variables/gov/dwp/universal_credit/is_uc_claimant.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/is_uc_claimant.py
@@ -5,10 +5,14 @@ class is_uc_claimant(Variable):
     """Claimant or partner, rather than a dependent member of the benefit unit.
 
     Datasets should supply this from recorded relationships. The calculator
-    fallback includes the family head, identified parents, and adults who are
-    not UC qualifying children. A young partner in education, or a dependent
-    adult outside the UC child definition, needs an explicit input when those
-    relationships cannot be inferred. This flag does not establish eligibility.
+    fallback includes the family head, identified parents, and adults, except
+    UC qualifying young people in a benefit unit with an identified parent.
+    Education defaults to tertiary education at ages 18 and 19, so treating
+    those ages as dependants requires qualifying education and any applicable
+    entry and terminal-date inputs. A partner in qualifying education who is
+    not identified as a head or parent, or a dependent adult outside the UC
+    child definition, needs an explicit input when relationships remain
+    ambiguous. This flag does not establish eligibility.
     """
 
     value_type = bool
@@ -17,17 +21,17 @@ class is_uc_claimant(Variable):
     definition_period = YEAR
     reference = (
         "https://www.legislation.gov.uk/ukpga/2012/5/section/39",
+        "https://www.legislation.gov.uk/uksi/2013/376/regulation/3/2",
         "https://www.gov.uk/universal-credit/eligibility",
     )
 
     def formula(person, period, parameters):
+        has_parent = add(person.benunit, period, ["is_parent"]) > 0
+        qualifying_child = person(
+            "is_child_or_qualifying_young_person_for_universal_credit", period
+        )
         return (
             person("is_benunit_head", period)
             | person("is_parent", period)
-            | (
-                person("is_adult", period)
-                & ~person(
-                    "is_child_or_qualifying_young_person_for_universal_credit", period
-                )
-            )
+            | (person("is_adult", period) & ~(qualifying_child & has_parent))
         )

--- a/policyengine_uk/variables/gov/dwp/universal_credit/is_uc_claimant.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/is_uc_claimant.py
@@ -1,0 +1,33 @@
+from policyengine_uk.model_api import *
+
+
+class is_uc_claimant(Variable):
+    """Claimant or partner, rather than a dependent member of the benefit unit.
+
+    Datasets should supply this from recorded relationships. The calculator
+    fallback includes the family head, identified parents, and adults who are
+    not UC qualifying children. A young partner in education, or a dependent
+    adult outside the UC child definition, needs an explicit input when those
+    relationships cannot be inferred. This flag does not establish eligibility.
+    """
+
+    value_type = bool
+    entity = Person
+    label = "Universal Credit claimant or partner"
+    definition_period = YEAR
+    reference = (
+        "https://www.legislation.gov.uk/ukpga/2012/5/section/39",
+        "https://www.gov.uk/universal-credit/eligibility",
+    )
+
+    def formula(person, period, parameters):
+        return (
+            person("is_benunit_head", period)
+            | person("is_parent", period)
+            | (
+                person("is_adult", period)
+                & ~person(
+                    "is_child_or_qualifying_young_person_for_universal_credit", period
+                )
+            )
+        )

--- a/policyengine_uk/variables/gov/dwp/universal_credit/standard_allowance/uc_standard_allowance_claimant_type.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/standard_allowance/uc_standard_allowance_claimant_type.py
@@ -14,13 +14,18 @@ class uc_standard_allowance_claimant_type(Variable):
     default_value = UCClaimantType.SINGLE_YOUNG
     entity = BenUnit
     label = "Universal Credit claimant type"
-    documentation = "The category of the UC claimant, assuming their eligibilty to UC"
     definition_period = YEAR
+    reference = "https://www.legislation.gov.uk/uksi/2013/376/regulation/36"
 
     def formula(benunit, period, parameters):
-        is_single = benunit("is_single", period)
+        person = benunit.members
+        claimant = person("is_uc_claimant", period)
+        is_single = add(benunit, period, ["is_uc_claimant"]) <= 1
         p = parameters(period).gov.dwp.universal_credit.standard_allowance.claimant_type
-        any_over_25 = benunit("eldest_adult_age", period.this_year) >= p.age_threshold
+        eldest_claimant_age = benunit.max(
+            where(claimant, person("age", period.this_year), 0)
+        )
+        any_over_25 = eldest_claimant_age >= p.age_threshold
         return select(
             [
                 is_single & ~any_over_25,
@@ -34,4 +39,5 @@ class uc_standard_allowance_claimant_type(Variable):
                 UCClaimantType.COUPLE_YOUNG,
                 UCClaimantType.COUPLE_OLD,
             ],
+            default=UCClaimantType.SINGLE_YOUNG,
         )

--- a/policyengine_uk/variables/gov/dwp/universal_credit/work_allowance/is_uc_work_allowance_eligible.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/work_allowance/is_uc_work_allowance_eligible.py
@@ -6,9 +6,13 @@ class is_uc_work_allowance_eligible(Variable):
     entity = BenUnit
     label = "Family receives a Universal Credit Work Allowance"
     definition_period = YEAR
+    reference = "https://www.legislation.gov.uk/uksi/2013/376/regulation/22"
 
     def formula(benunit, period, parameters):
         person = benunit.members
         has_LCWRA = benunit.any(person("uc_limited_capability_for_WRA", period))
-        has_children = benunit.any(person("is_child", period))
+        has_children = benunit.any(
+            person("is_child_or_qualifying_young_person_for_universal_credit", period)
+            & ~person("is_uc_claimant", period)
+        )
         return has_LCWRA | has_children


### PR DESCRIPTION
Refs PolicyEngine/microcosm#882

An 18- or 19-year-old dependent in qualifying education can be counted as an adult when selecting a Universal Credit standard allowance, while being omitted from the work allowance's child test. A young claimant in education can also satisfy the qualifying-child predicate and receive their own child element or consume a place under the two-child limit.

This adds a person-level `is_uc_claimant` input and fallback to identify the claimant or partner separately from dependent members. The standard allowance uses claimant count and age. Work-allowance eligibility counts nonclaimant children and qualifying young people. Child-element ordering, both disability additions and the affected-child flag exclude claimants. Benefit-unit membership and generic family variables retain their existing definitions.

The fallback includes the head, identified parents and adults, excluding an adult qualifying young person only when the benefit unit contains an identified parent. This keeps a young cohabiting partner in qualifying education as a claimant when no parent or claimant-role inputs are supplied. Dataset producers should provide `is_uc_claimant` from recorded relationships. Ambiguous relationships in units with identified parents, and nonqualifying adult dependants, still need explicit role inputs.

Qualification also depends on education inputs. The generic education default treats 18–19-year-olds as being in tertiary education. The lone-parent examples therefore supply non-advanced education; the 19-year-old case also supplies the qualifying entry-age and terminal-date conditions. The claimant flag identifies roles, rather than establishing UC eligibility.

The work-allowance change also excludes 16–17-year-olds outside qualifying education or training and children looked after by a local authority from its child-based route. Disability additions remain payable for qualifying nonclaimant children, including those beyond the ordinary two-child element limit.

This work does not implement the under-18 UC eligibility exceptions or the two-child-limit exceptions machinery. Child ordering still uses the model's integer ages; it does not reconstruct exact dates of birth or resolve twin ordering by birth date.

Synthetic regressions cover lone parents with 18/19-year-old qualifying children, young cohabiting couples without role inputs, genuine couples with an older child, explicit claimant inputs, young claimants with their own children, and both disability tiers for claimants and dependants. They assert final UC awards as well as component amounts and child ordering. With the explicit parent/education inputs and zero capital and deductions used in the 2025 regressions, a lone parent earning £12,000 with an 18-year-old qualifying child receives £6,784.08 annual UC; an 18-year-old parent with one child receives one child element and £7,317.48 UC.

Companion pipeline PR: [Microcosm #883](https://github.com/PolicyEngine/microcosm/pull/883), stacked on [Microcosm #879](https://github.com/PolicyEngine/microcosm/pull/879). Its own-qualifying-child measurements exclude recorded claimant roles before aggregating within each person's benefit unit. Its statistical two-child-limit cohort deliberately differs from the model's element-denial flag; that statistical definition does not imply that the engine implements exception rules. The broader tracking issue stays open for the remaining pipeline and target-measurement work.

The changelog separates the new public claimant input (`added`) from the UC calculation corrections (`fixed`); no manual version update is included.

Local validation used the checked-out PolicyEngine-UK 2.96.1 source on the current `main` base (`5e57717f`), core 3.32.3 and Python 3.13.14:

- [x] The initial regression run reproduced three semantic failures with 25 passing controls. The focused original/updated seven-file manifest then passed all 34 cases with unchanged expected results.
- [x] `uv run --no-sync policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/universal_credit -c policyengine_uk` — 138 passed.
- [x] `uv run --no-sync policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/child_qualifying_young_person.yaml -c policyengine_uk` — 8 passed after adding the missing `is_parent: true` input to its intended parent; expected child indices stayed unchanged.
- [x] `uv run --no-sync policyengine-core test policyengine_uk/tests/policy -c policyengine_uk` — 1,164 passed on the final full-suite run.
- [x] `uv run --no-sync pytest policyengine_uk/tests/ -m 'not microsimulation' --maxfail=0 -q` — 211 passed, 15 skipped, 29 deselected.
- [x] Independent verification — all five fix-plan items checked; one additional synthetic two-benefit-unit case passed, confirming parent evidence does not cross benefit-unit boundaries.
- [x] Final formatting and Ruff — passed. Formatting changed only `is_uc_claimant.py`; the affected eight-file policy YAML check then passed 42 cases.
- [x] `uv run --no-sync towncrier build --draft` — passed, rendering both Added and Fixed sections without writing files.
- [x] [GitHub CI on the updated commit (`7b365884`)](https://github.com/PolicyEngine/policyengine-uk/actions/runs/34223514848) — all six checks passed, covering tests, docs, lint and Python 3.11–3.14 imports.

The independent Microcosm consumer check passed six synthetic cases at `9d13d1dd`, including a young claimant who also satisfies the raw qualifying-child predicate. No Microcosm source changed in this update. Dataset-dependent microsimulation tests and a population rebuild were not run; this update contains model code and synthetic tests only.
