### PR TITLE
Track the source series when building the lagged CPI and earnings

### DIFF
--- a/changelog.d/lagged-series-hardcoded-ranges.fixed.md
+++ b/changelog.d/lagged-series-hardcoded-ranges.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the lagged CPI and lagged average earnings series ending at a hardcoded 2029, which froze lagged average earnings at its 2028 growth rate and left the index around 14% low by 2039.

--- a/docs/book/validation/hbai.md
+++ b/docs/book/validation/hbai.md
@@ -77,4 +77,4 @@ Each of the variables above is either derived from other variables, or is a dire
 | `rent` | gov.obr.rent | Social rents uprated by CPI+1%, private rents uprated with outturn data by region to 2025, then with backed-out private rent level growth from OBR aggregate rent forecasts (assuming social rent grows at CPI+1%) |
 | `water_and_sewerage_charges` | gov.obr.consumer_price_index | Uprated based on CPI as proxy |
 | `mortgage_interest_repayment` | gov.obr.mortgage_interest | Uprated based on outturn Ofwat data to 2025, then Ofwat projections onwards |
-| `housing_service_charges` | gov.obr.consumer_price_index | Uprated based on CPI as proxy |
+| `housing_service_charges` | gov.economic_assumptions.indices.obr.lagged_average_earnings | Uprated based on lagged average earnings as proxy |

--- a/policyengine_uk/parameters/gov/economic_assumptions/lag_average_earnings.py
+++ b/policyengine_uk/parameters/gov/economic_assumptions/lag_average_earnings.py
@@ -1,4 +1,8 @@
-from policyengine_core.parameters import Parameter, ParameterNode
+from policyengine_core.parameters import ParameterNode
+
+from policyengine_uk.parameters.gov.economic_assumptions.lagged_series import (
+    add_lagged_parameter,
+)
 
 
 def add_lagged_earnings(
@@ -8,20 +12,8 @@ def add_lagged_earnings(
     Add lagged average earnings to the economic assumptions.
     """
     obr = parameters.gov.economic_assumptions.yoy_growth.obr
-    earnings = obr.average_earnings
-
-    lagged_earnings = Parameter(
-        "gov.economic_assumptions.yoy_growth.lagged_average_earnings",
-        data={
-            "values": {
-                f"{year}-01-01": earnings(year - 1) for year in range(2022, 2030)
-            },
-        },
-    )
-
-    obr.add_child(
-        "lagged_average_earnings",
-        lagged_earnings,
+    add_lagged_parameter(
+        obr, "average_earnings", "lagged_average_earnings", first_year=2022
     )
 
     return parameters

--- a/policyengine_uk/parameters/gov/economic_assumptions/lag_cpi.py
+++ b/policyengine_uk/parameters/gov/economic_assumptions/lag_cpi.py
@@ -1,25 +1,17 @@
-from policyengine_core.parameters import Parameter, ParameterNode
+from policyengine_core.parameters import ParameterNode
+
+from policyengine_uk.parameters.gov.economic_assumptions.lagged_series import (
+    add_lagged_parameter,
+)
 
 
 def add_lagged_cpi(
     parameters: ParameterNode,
 ) -> ParameterNode:
     """
-    Add lagged average earnings to the economic assumptions.
+    Add lagged CPI to the economic assumptions.
     """
     obr = parameters.gov.economic_assumptions.yoy_growth.obr
-    cpi = obr.consumer_price_index
-
-    lagged_cpi = Parameter(
-        "gov.economic_assumptions.yoy_growth.obr.lagged_cpi",
-        data={
-            "values": {f"{year}-01-01": cpi(year - 1) for year in range(2010, 2030)},
-        },
-    )
-
-    obr.add_child(
-        "lagged_cpi",
-        lagged_cpi,
-    )
+    add_lagged_parameter(obr, "consumer_price_index", "lagged_cpi", first_year=2010)
 
     return parameters

--- a/policyengine_uk/parameters/gov/economic_assumptions/lagged_series.py
+++ b/policyengine_uk/parameters/gov/economic_assumptions/lagged_series.py
@@ -1,0 +1,37 @@
+from policyengine_core.parameters import Parameter, ParameterNode
+
+
+def lag_source_years(source: Parameter, first_year: int) -> range:
+    """Years a one-year-lagged copy of ``source`` should be built for.
+
+    The lagged value at year Y is the source value at Y-1, so the series can
+    run to one year past the end of the source. Deriving the end this way
+    keeps the lagged series in step with the source: a hardcoded end silently
+    freezes the lagged value at the last year written, because a parameter
+    carries its final value forward rather than raising.
+    """
+    last_source_year = max(int(value.instant_str[:4]) for value in source.values_list)
+    return range(first_year, last_source_year + 2)
+
+
+def add_lagged_parameter(
+    node: ParameterNode,
+    source_name: str,
+    lagged_name: str,
+    first_year: int,
+) -> Parameter:
+    """Add a one-year-lagged copy of ``source_name`` as a child of ``node``."""
+    source = getattr(node, source_name)
+
+    lagged = Parameter(
+        f"{node.name}.{lagged_name}",
+        data={
+            "values": {
+                f"{year}-01-01": source(year - 1)
+                for year in lag_source_years(source, first_year)
+            },
+        },
+    )
+
+    node.add_child(lagged_name, lagged)
+    return lagged

--- a/policyengine_uk/tests/test_lagged_series.py
+++ b/policyengine_uk/tests/test_lagged_series.py
@@ -1,0 +1,63 @@
+"""The lagged economic series track their source rather than a fixed end year.
+
+A parameter carries its final value forward rather than raising, so a lagged
+series that stops early does not fail — it silently holds a stale growth rate.
+Average earnings are not flat, so that previously left the lagged earnings
+index well below the series it lags.
+"""
+
+from policyengine_uk import system
+
+
+def _obr(node: str):
+    return getattr(system.parameters.gov.economic_assumptions, node).obr
+
+
+def _last_year(parameter) -> int:
+    return max(int(value.instant_str[:4]) for value in parameter.values_list)
+
+
+def test_lagged_series_reach_the_end_of_their_source():
+    growth = _obr("yoy_growth")
+
+    for source_name, lagged_name in (
+        ("consumer_price_index", "lagged_cpi"),
+        ("average_earnings", "lagged_average_earnings"),
+    ):
+        source = getattr(growth, source_name)
+        lagged = getattr(growth, lagged_name)
+
+        assert _last_year(lagged) >= _last_year(source), (
+            f"{lagged_name} stops before {source_name} does"
+        )
+
+
+def test_lagged_series_hold_the_previous_year_of_their_source():
+    growth = _obr("yoy_growth")
+
+    for source_name, lagged_name in (
+        ("consumer_price_index", "lagged_cpi"),
+        ("average_earnings", "lagged_average_earnings"),
+    ):
+        source = getattr(growth, source_name)
+        lagged = getattr(growth, lagged_name)
+
+        for year in (2030, 2035, 2039):
+            assert lagged(str(year)) == source(str(year - 1)), (
+                f"{lagged_name} at {year} is not {source_name} at {year - 1}"
+            )
+
+
+def test_the_lagged_earnings_index_keeps_growing_with_earnings():
+    """Earnings growth is not flat, so a frozen lag shows up in the index."""
+    index = _obr("indices").lagged_average_earnings
+
+    assert index("2039") > index("2035") > index("2030")
+
+
+def test_lagged_parameter_names_match_their_position_in_the_tree():
+    growth = _obr("yoy_growth")
+
+    for lagged_name in ("lagged_cpi", "lagged_average_earnings"):
+        lagged = getattr(growth, lagged_name)
+        assert lagged.name.endswith(f"yoy_growth.obr.{lagged_name}")

--- a/policyengine_uk/tests/test_lagged_series.py
+++ b/policyengine_uk/tests/test_lagged_series.py
@@ -18,6 +18,12 @@ def _last_year(parameter) -> int:
 
 
 def test_lagged_series_reach_the_end_of_their_source():
+    """The lag runs exactly one year past its source, and holds its last value.
+
+    A parameter carries its terminal value forward, so an off-by-one series
+    that stopped a year early would still answer correctly at every year
+    tested above. Pinning the terminal year and value is what catches it.
+    """
     growth = _obr("yoy_growth")
 
     for source_name, lagged_name in (
@@ -26,9 +32,13 @@ def test_lagged_series_reach_the_end_of_their_source():
     ):
         source = getattr(growth, source_name)
         lagged = getattr(growth, lagged_name)
+        last_source_year = _last_year(source)
 
-        assert _last_year(lagged) >= _last_year(source), (
-            f"{lagged_name} stops before {source_name} does"
+        assert _last_year(lagged) == last_source_year + 1, (
+            f"{lagged_name} should end one year after {source_name}"
+        )
+        assert lagged(str(last_source_year + 1)) == source(str(last_source_year)), (
+            f"{lagged_name} does not end on {source_name}'s final value"
         )
 
 


### PR DESCRIPTION
`lag_cpi.py` and `lag_average_earnings.py` both built their series with a hardcoded `range(..., 2030)`, so values stopped at 2029. A parameter carries its final value forward rather than raising, so nothing failed past that point — the series just held a stale growth rate, and `create_economic_assumption_indices` compounded that stale rate into the index.

Spotted by @edward-mcpherson.

## CPI: harmless today

The OBR CPI series is flat at 2% from 2027, so the carried-forward value is exactly what the loop would have produced. Patching the old range to 2045 and diffing `yoy_growth.obr.lagged_cpi`, `indices.obr.lagged_cpi` and `gov.benefit_uprating_cpi` across 2024–2050 gives **zero** differing years. Bumping the number would have been a no-op.

## Average earnings: already wrong

Earnings growth is not flat — it ramps from 0.021 in 2028 to 0.0383 by 2036 — so the lagged series stayed at 0.021 and the index diverged from 2030:

| `indices.obr.lagged_average_earnings` | before | after |
|---|---:|---:|
| 2029 | 1.34884 | 1.34884 |
| 2030 | 1.37717 | 1.37851 |
| 2035 | 1.52798 | 1.62829 |
| 2039 | 1.66043 | 1.89190 |

About 14% low by 2039.

**No modelled outcome moves.** The only consumer is `housing_service_charges`, and nothing consumes that in turn. Running three households at 2039 and computing every year-period variable, exactly one changes — `housing_service_charges` itself — and `household_net_income` is bit-identical. This is a correctness fix to an input series, not a change in results.

## The fix

The end year is derived from the source series instead of being written down a second time. Start years are unchanged (2010 for CPI, 2022 for earnings), so historic values are untouched — deriving the start too would have pulled earnings back to 2010 and moved the index base, which is a bigger change than the bug warrants.

Two smaller things in the same area:

- The lagged earnings `Parameter` was constructed as `gov.economic_assumptions.yoy_growth.lagged_average_earnings`, missing the `.obr`, while being added as a child of `obr`. The mismatch propagated into the mirrored index node. Harmless for tree access, but `.name` is what gets exported to metadata and what a name-keyed reform would target.
- `docs/book/validation/hbai.md` still said service charges were uprated by CPI.

## Known limitation, not addressed here

`create_economic_assumption_indices` loops `range(start_year + 1, 2040)`, so every index flatlines at 2039 regardless of how far its source runs. Worth a separate look.

## Tests

`test_lagged_series.py` asserts each lagged series reaches its source's last year, equals the source lagged one year at 2030/2035/2039, that the earnings index keeps growing, and that the parameter names match their position in the tree.

Full suite: 1,140 YAML policy tests, 211 pytest, ruff clean.
